### PR TITLE
tests/prelude.sh: Remove ENABLE_WARN_DEPRECATED from required list.

### DIFF
--- a/tests/prelude.sh
+++ b/tests/prelude.sh
@@ -172,7 +172,6 @@ require-kernel-config FTRACE_SYSCALLS
 #require-kernel-config ENABLE_DEFAULT_TRACERS
 
 # Debugging options
-require-kernel-config ENABLE_WARN_DEPRECATED
 require-kernel-config ENABLE_MUST_CHECK
 
 require-kernel-config MAGIC_SYSRQ


### PR DESCRIPTION
ENABLE_WARN_DEPRECATED has been dropped from the kernel.  See kernel
commit id 771c035372a036f83353eef46dbb829780330234

Signed-off-by: Liam R. Howlett <howlett@gmail.com>