### PR TITLE
Fix debootstrap; use Buster; flag for shellcheck

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,12 @@
-[submodule "debootstrap"]
-	path = debootstrap
-	url = https://anonscm.debian.org/git/d-i/debootstrap.git
 [submodule "tests/bcachefs/bcachefs-tools"]
-	path = tests/bcachefs/bcachefs-tools
-	url = http://evilpiepirate.org/git/bcachefs-tools.git
+        path = tests/bcachefs/bcachefs-tools
+        url = https://github.com/koverstreet/bcachefs-tools.git
 [submodule "tests/xfstests"]
-	path = tests/xfstests
-	url = http://evilpiepirate.org/git/xfstests.git
+        path = tests/xfstests
+        url = https://github.com/kdave/xfstests.git
 [submodule "tests/bcachefs/linuxquota-code"]
-	path = tests/bcachefs/linuxquota-code
-	url = http://evilpiepirate.org/git/linuxquota.git
+        path = tests/bcachefs/linuxquota-code
+        url = https://github.com/leeminghao/linux-quota.git
 [submodule "tests/blktests"]
-	path = tests/blktests
-	url = https://github.com/osandov/blktests.git
+        path = tests/blktests
+        url = https://github.com/osandov/blktests.git

--- a/build-test-kernel
+++ b/build-test-kernel
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Dec 2019: requires additional validation via https://github.com/koalaman/shellcheck
+
 set -o nounset
 set -o errexit
 set -o errtrace
@@ -7,58 +9,56 @@ set -o errtrace
 ktest_dir=$(dirname "$(readlink -f "$0")")
 KTEST=$ktest_dir/ktest
 
-. "$ktest_dir/lib/libktest.sh"
+source "$ktest_dir/lib/libktest.sh"
 
 checkdep gcc
 checkdep make
 
-ktest_kernel_source="."	# dir of kernel source
-			#       set with: -k <path>
-			#       defaults: current directory
-ktest_kernel_build=""	# kernel build dir
-			# defaults to
-			# $ktest_kernel_source/.build-test-kernel-$ktest_arch
-ktest_kernel_binary=""	# kernel output dir
-			# defaults to $ktest_kernel_build/kpkg
+ktest_kernel_source="." # dir of kernel source
+#       set with: -k <path>
+#       defaults: current directory
+ktest_kernel_build=""  # kernel build dir
+# defaults to
+# $ktest_kernel_source/.build-test-kernel-$ktest_arch
+ktest_kernel_binary="" # kernel output dir
+# defaults to $ktest_kernel_build/kpkg
 
-BUILD=1			# if set to 1, kernel will build
+BUILD=1 # if set to 1, kernel will build
 DEPS=1
-COVERAGE=""		# doing code coverage?
+COVERAGE="" # doing code coverage?
 MAKEARGS=()
 ktest_njobs=$(($(grep -c '^processor' /proc/cpuinfo) * 2))
-			# number of jobs to passed to make during kernel compile
-			#       sets with: -j
-			#       defaults to 2 * number of processor
+# number of jobs to passed to make during kernel compile
+#       sets with: -j
+#       defaults to 2 * number of processor
 
-
-usage()
-{
-    echo "build-test-kernel: Run generic virtual machine tests"
-    echo "Usage: build-test-kernel cmd [options]"
-    ktest_usage_cmds
-    echo "  oldconfig   Run make oldconfig"
-    echo "  config      Run make nconfig"
-    echo
-    echo "  options:"
-    ktest_usage_opts
-    echo
-    echo " options for build-test-kernel run:"
-    ktest_usage_run_opts
-    echo "      -k <dir>    kernel source dir"
-    echo "      -b <dir>    build directory for kernel (default: kernel_source/.build-test-kernel)"
-    echo "      -o <dir>    output directory for kernel binary (default: kernel_build/kpkg"
-    echo "      -K          don't rebuild kernel"
-    echo "      -D          don't modify kernel .config"
-    echo "      -c <dir>    enable coverage for this dir (only valid without -K)"
-    echo "      -j <num>    j option to make"
-    echo "      -K          don't rebuild kernel"
-    echo
-    ktest_usage_post
+usage() {
+	echo "build-test-kernel: Run generic virtual machine tests"
+	echo "Usage: build-test-kernel cmd [options]"
+	ktest_usage_cmds
+	echo "  oldconfig   Run make oldconfig"
+	echo "  config      Run make nconfig"
+	echo
+	echo "  options:"
+	ktest_usage_opts
+	echo
+	echo " options for build-test-kernel run:"
+	ktest_usage_run_opts
+	echo "      -k <dir>    kernel source dir"
+	echo "      -b <dir>    build directory for kernel (default: kernel_source/.build-test-kernel)"
+	echo "      -o <dir>    output directory for kernel binary (default: kernel_build/kpkg"
+	echo "      -K          don't rebuild kernel"
+	echo "      -D          don't modify kernel .config"
+	echo "      -c <dir>    enable coverage for this dir (only valid without -K)"
+	echo "      -j <num>    j option to make"
+	echo "      -K          don't rebuild kernel"
+	echo
+	ktest_usage_post
 }
 
-if [[ $# = 0 ]]; then
-    usage
-    exit 1
+if [[ $# == 0 ]]; then
+	usage
+	exit 1
 fi
 
 #parse command and shift for rest of arg parsing
@@ -66,56 +66,56 @@ CMD="$1"
 shift
 
 while getopts "k:b:o:KDc:j:h${ktest_args}" arg; do
-    case $arg in
+	case $arg in
 	k)
-	    ktest_kernel_source="$OPTARG"
-	    ;;
+		ktest_kernel_source="$OPTARG"
+		;;
 	b)
-	    ktest_kernel_build="$OPTARG"
-	    ;;
+		ktest_kernel_build="$OPTARG"
+		;;
 	o)
-	    ktest_kernel_binary="$OPTARG"
-	    ;;
+		ktest_kernel_binary="$OPTARG"
+		;;
 	K)
-	    BUILD=""
-	    ;;
+		BUILD=""
+		;;
 	D)
-	    DEPS=""
-	    ;;
+		DEPS=""
+		;;
 	c)
-	    if [[ ! -d $OPTARG ]]; then
-		echo "$OPTARG must be a directory"
-		exit 1
-	    fi
+		if [[ ! -d $OPTARG ]]; then
+			echo "$OPTARG must be a directory"
+			exit 1
+		fi
 
-	    checkdep lcov
+		checkdep lcov
 
-	    # Strip trailing / from directory name, substitute _ for /
-	    OPTARG=$(echo "${OPTARG%/}"|tr / _)
-	    MAKEARGS+=("GCOV_PROFILE_$OPTARG=y")
-	    COVERAGE=1
-	    ;;
+		# Strip trailing / from directory name, substitute _ for /
+		OPTARG=$(echo "${OPTARG%/}" | tr / _)
+		MAKEARGS+=("GCOV_PROFILE_$OPTARG=y")
+		COVERAGE=1
+		;;
 	j)
-	    ktest_njobs=$OPTARG
-	    ;;
+		ktest_njobs=$OPTARG
+		;;
 
 	h)
-	    usage
-	    exit 0
-	    ;;
-    esac
-    parse_ktest_arg $arg
+		usage
+		exit 0
+		;;
+	esac
+	parse_ktest_arg "$arg"
 done
-shift $(( OPTIND - 1 ))
+shift $((OPTIND - 1))
 
 # default parameters
-[[ -z $ktest_kernel_source ]]	&& ktest_kernel_source="."
-[[ -z $ktest_kernel_build ]]	&& ktest_kernel_build="$ktest_kernel_source/.build_test_kernel-$ktest_arch"
-[[ -z $ktest_kernel_binary ]]	&& ktest_kernel_binary="$ktest_kernel_build/kpgk"
+[[ -z $ktest_kernel_source ]] && ktest_kernel_source="."
+[[ -z $ktest_kernel_build ]] && ktest_kernel_build="$ktest_kernel_source/.build_test_kernel-$ktest_arch"
+[[ -z $ktest_kernel_binary ]] && ktest_kernel_binary="$ktest_kernel_build/kpgk"
 
 if [[ ! -d $ktest_kernel_source ]]; then
-    echo "kernel source directory $ktest_kernel_source does not exist"
-    exit 1
+	echo "kernel source directory $ktest_kernel_source does not exist"
+	exit 1
 fi
 
 ktest_kernel_source=$(readlink -e "$ktest_kernel_source")
@@ -128,199 +128,189 @@ ktest_kernel_binary=$(readlink -f "$ktest_kernel_binary")
 parse_args_post
 
 if [[ -n $CROSS_COMPILE ]]; then
-    checkdep "$ARCH_TRIPLE-gcc" "gcc-$ARCH_TRIPLE"
+	checkdep "$ARCH_TRIPLE-gcc" "gcc-$ARCH_TRIPLE"
 fi
 
-run_ktest()
-{
-    arg=$1
-    shift
+run_ktest() {
+	arg=$1
+	shift
 
-    "$KTEST" "$arg" $KTESTARGS -k "$ktest_kernel_binary" "$@"
+	"$KTEST" "$arg" "$KTESTARGS" -k "$ktest_kernel_binary" "$@"
 }
 
-do_make()
-{
-    if [[ -n $CROSS_COMPILE ]]; then
-	export ARCH="$KERNEL_ARCH"
-	export CROSS_COMPILE="$ARCH_TRIPLE-"
-    fi
-
-    # work around a bug in make - maybe not needed anymore?
-#    if [[ $# = 0 || $1 != nconfig ]]; then
-#	MAKEARGS+=("--output-sync=target")
-#    fi
-
-    make --jobs="$ktest_njobs"			\
-	--directory="$ktest_kernel_source"    	\
-	O="$ktest_kernel_build"			\
-	INSTALL_MOD_PATH="$ktest_kernel_binary"	\
-	SKIP_STACK_VALIDATION=1			\
-	"${MAKEARGS[@]}"			\
-	"$@"
-}
-
-new_config()
-{
-    local kconfig="$ktest_kernel_build/.config"
-    local config_tool="$ktest_kernel_source/scripts/config"
-
-    if [[ ! -f $kconfig ]]; then
-	do_make allnoconfig
-
-	# Really undefine everything:
-	sed -i -e 's/\(CONFIG_.*\)=.*/# \1 is not set/' "$kconfig"
-    fi
-}
-
-kernel_opt()
-{
-    local cmd=$1
-    local opt=$2
-    local kconfig="$ktest_kernel_build/.config"
-    local config_tool="$ktest_kernel_source/scripts/config"
-
-    if [[ $opt =~ = ]]; then
-	local val=${opt: -1}
-	opt="${opt%=?}"
-    else
-	local val=y
-    fi
-
-    case $cmd in
-	set)
-	    "$config_tool" --file "$kconfig" --set-val "$opt" "$val"
-	    ;;
-	check)
-	    local c=$("$config_tool" --file "$kconfig" -s "$opt")
-
-	    if [[ $c != $val ]]; then
-		echo "Kernel config option $opt is $c; should be $val"
-		exit 1
-	    fi
-	    ;;
-    esac
-}
-
-build_kernel()
-{
-    local magic=$ktest_kernel_binary/ktest-kernel-binary-dir
-
-    if [[ -e $ktest_kernel_binary ]] && [[ ! -d $ktest_kernel_binary ]]; then
-	echo "$ktest_kernel_binary already exists and is not a directory"
-	exit 1
-    fi
-
-    if [[ -d $ktest_kernel_binary ]] && [[ -n $(ls -A $ktest_kernel_binary) ]]; then
-	if [[ ! -f $magic ]]; then
-	    echo "$ktest_kernel_binary already exists and has non ktest kernel contents"
-	    exit 1
+do_make() {
+	if [[ -n $CROSS_COMPILE ]]; then
+		export ARCH="$KERNEL_ARCH"
+		export CROSS_COMPILE="$ARCH_TRIPLE-"
 	fi
 
-	rm -rf "$ktest_kernel_binary"
-    fi
+	# work around a bug in make - maybe not needed anymore?
+	#    if [[ $# = 0 || $1 != nconfig ]]; then
+	#	MAKEARGS+=("--output-sync=target")
+	#    fi
 
-    mkdir -p "$ktest_kernel_binary"
-    touch "$magic"
+	make --jobs="$ktest_njobs" \
+		--directory="$ktest_kernel_source" \
+		O="$ktest_kernel_build" \
+		INSTALL_MOD_PATH="$ktest_kernel_binary" \
+		SKIP_STACK_VALIDATION=1 \
+		"${MAKEARGS[@]}" \
+		"$@"
+}
 
-    if [[ -n $DEPS ]]; then
-	new_config
+new_config() {
+	local kconfig="$ktest_kernel_build/.config"
+	local config_tool="$ktest_kernel_source/scripts/config"
 
-	for opt in "${ktest_kernel_config_require[@]}"; do
-	    [[ -n $opt ]] && kernel_opt set "$opt"
-	done
+	if [[ ! -f $kconfig ]]; then
+		do_make allnoconfig
 
-	do_make olddefconfig
+		# Really undefine everything:
+		sed -i -e 's/\(CONFIG_.*\)=.*/# \1 is not set/' "$kconfig"
+	fi
+}
 
-	for opt in "${ktest_kernel_config_require[@]}"; do
-	    [[ -n $opt ]] && kernel_opt check "$opt"
-	done
-    fi
+kernel_opt() {
+	local cmd=$1
+	local opt=$2
+	local kconfig="$ktest_kernel_build/.config"
+	local config_tool="$ktest_kernel_source/scripts/config"
 
-    case $KERNEL_ARCH in
+	if [[ $opt =~ = ]]; then
+		local val=${opt: -1}
+		opt="${opt%=?}"
+	else
+		local val=y
+	fi
+
+	case $cmd in
+	set)
+		"$config_tool" --file "$kconfig" --set-val "$opt" "$val"
+		;;
+	check)
+		local c=$("$config_tool" --file "$kconfig" -s "$opt")
+
+		if [[ $c != "$val" ]]; then
+			echo "Kernel config option $opt is $c; should be $val"
+			exit 1
+		fi
+		;;
+	esac
+}
+
+build_kernel() {
+	local magic=$ktest_kernel_binary/ktest-kernel-binary-dir
+
+	if [[ -e $ktest_kernel_binary ]] && [[ ! -d $ktest_kernel_binary ]]; then
+		echo "$ktest_kernel_binary already exists and is not a directory"
+		exit 1
+	fi
+
+	if [[ -d $ktest_kernel_binary ]] && [[ -n $(ls -A "$ktest_kernel_binary") ]]; then
+		if [[ ! -f $magic ]]; then
+			echo "$ktest_kernel_binary already exists and has non ktest kernel contents"
+			exit 1
+		fi
+
+		rm -rf "$ktest_kernel_binary"
+	fi
+
+	mkdir -p "$ktest_kernel_binary"
+	touch "$magic"
+
+	if [[ -n $DEPS ]]; then
+		new_config
+
+		for opt in "${ktest_kernel_config_require[@]}"; do
+			[[ -n $opt ]] && kernel_opt set "$opt"
+		done
+
+		do_make olddefconfig
+
+		for opt in "${ktest_kernel_config_require[@]}"; do
+			[[ -n $opt ]] && kernel_opt check "$opt"
+		done
+	fi
+
+	case $KERNEL_ARCH in
 	mips)
-	    do_make vmlinuz
-	    ;;
+		do_make vmlinuz
+		;;
 	*)
-	    do_make
-	    ;;
-    esac
+		do_make
+		;;
+	esac
 
-    local BOOT=$ktest_kernel_build/arch/$KERNEL_ARCH/boot
+	local BOOT=$ktest_kernel_build/arch/$KERNEL_ARCH/boot
 
-    if   [[ -f "$BOOT/bzImage" ]]; then
-	install -m0644 "$BOOT/bzImage"		"$ktest_kernel_binary/vmlinuz"
-    elif [[ -f "$BOOT/vmlinux.strip" ]]; then
-	install -m0644 "$BOOT/vmlinux.strip"	"$ktest_kernel_binary/vmlinuz"
-    else
-	install -m0644 "$ktest_kernel_build/vmlinux"	"$ktest_kernel_binary/vmlinuz"
-    fi
+	if [[ -f "$BOOT/bzImage" ]]; then
+		install -m0644 "$BOOT/bzImage" "$ktest_kernel_binary/vmlinuz"
+	elif [[ -f "$BOOT/vmlinux.strip" ]]; then
+		install -m0644 "$BOOT/vmlinux.strip" "$ktest_kernel_binary/vmlinuz"
+	else
+		install -m0644 "$ktest_kernel_build/vmlinux" "$ktest_kernel_binary/vmlinuz"
+	fi
 
-    install -m0644 "$ktest_kernel_build/vmlinux" "$ktest_kernel_binary/vmlinux"
-    install -m0644 "$ktest_kernel_build/.config" "$ktest_kernel_binary/config"
+	install -m0644 "$ktest_kernel_build/vmlinux" "$ktest_kernel_binary/vmlinux"
+	install -m0644 "$ktest_kernel_build/.config" "$ktest_kernel_binary/config"
 
-    # if there weren't actually any modules selected, make modules_install gets
-    # confused:
-    touch "$ktest_kernel_build/modules.order"
-    touch "$ktest_kernel_build/modules.builtin"
+	# if there weren't actually any modules selected, make modules_install gets
+	# confused:
+	touch "$ktest_kernel_build/modules.order"
+	touch "$ktest_kernel_build/modules.builtin"
 
-    do_make modules_install
+	do_make modules_install
 }
 
-cmd_run()
-{
-    if [[ $# = 0 ]]; then
-	echo "build-test-kernel: missing test"
+cmd_run() {
+	if [[ $# == 0 ]]; then
+		echo "build-test-kernel: missing test"
+		usage
+		exit 1
+	fi
+
+	ktest_test=$1
+	shift
+	ktest_testargs=("$@")
+
+	parse_test_deps "$ktest_test"
+
+	if [[ -n $COVERAGE ]]; then
+		ktest_kernel_config_require+=(GCOV_KERNEL)
+	fi
+
+	if [[ -n $BUILD ]]; then
+		run_quiet "building kernel" build_kernel
+	fi
+
+	start_vm
+}
+
+cmd_boot() {
+	cmd_run "$ktest_dir/boot.ktest"
+}
+
+cmd_oldconfig() {
+	new_config
+	do_make oldconfig
+}
+
+cmd_config() {
+	new_config
+	do_make nconfig
+}
+
+cmd_help() {
 	usage
-	exit 1
-    fi
-
-    ktest_test=$1
-    shift
-    ktest_testargs="$@"
-
-    parse_test_deps "$ktest_test"
-
-    if [[ -n $COVERAGE ]]; then
-	ktest_kernel_config_require+=(GCOV_KERNEL)
-    fi
-
-    if [[ -n $BUILD ]]; then
-	run_quiet "building kernel" build_kernel
-    fi
-
-    start_vm
-}
-
-cmd_boot()
-{
-    cmd_run "$ktest_dir/boot.ktest"
-}
-
-cmd_oldconfig()
-{
-    new_config
-    do_make oldconfig
-}
-
-cmd_config()
-{
-    new_config
-    do_make nconfig
-}
-
-cmd_help()
-{
-    usage
 }
 
 if [[ $(type -t "cmd_$CMD") == function ]]; then
-    CMD="cmd_$CMD"
+	CMD="cmd_$CMD"
 elif [[ $(type -t "ktest_$CMD") == function ]]; then
-    CMD="ktest_$CMD"
+	CMD="ktest_$CMD"
 else
-    usage
-    exit 1
+	usage
+	exit 1
 fi
 
 $CMD "$@"

--- a/ktest
+++ b/ktest
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Dec 2019: requires additional validation via https://github.com/koalaman/shellcheck
+
 set -o nounset
 set -o errexit
 set -o errtrace
@@ -11,14 +13,13 @@ export PS4='+${LINENO}+ '
 
 ktest_dir=$(dirname "$(readlink -f "$0")")
 
-ktest_kernel_binary=""	# dir that has the kernel to run
-                        #       set with: -k <path>
+ktest_kernel_binary="" # dir that has the kernel to run
+#       set with: -k <path>
 
-. "$ktest_dir/lib/util.sh"
-. "$ktest_dir/lib/libktest.sh"
+source "$ktest_dir/lib/util.sh" || exit 1
+source "$ktest_dir/lib/libktest.sh" || exit 1
 
-usage()
-{
+usage() {
     echo "ktest: Run generic virtual machine tests"
     echo "Usage: ktest cmd [options]"
     ktest_usage_cmds
@@ -33,21 +34,20 @@ usage()
     ktest_usage_post
 }
 
-if [[ $# = 0 ]]; then
+if [[ $# == 0 ]]; then
     usage
     exit 1
 fi
 
-cmd_run()
-{
-    if [[ $# = 0 ]]; then
-	echo "ktest: missing test"
-	exit 1
+cmd_run() {
+    if [[ $# == 0 ]]; then
+        echo "ktest: missing test"
+        exit 1
     fi
 
     ktest_test=$1
     shift
-    ktest_testargs="$@"
+    ktest_testargs=("$@")
 
     parse_test_deps "$ktest_test"
 
@@ -70,15 +70,15 @@ fi
 
 while getopts "k:h${ktest_args}" arg; do
     case $arg in
-	k)
-	    ktest_kernel_binary=$OPTARG
-	    ;;
-	h)
-	    usage
-	    exit 0
-	    ;;
+    k)
+        ktest_kernel_binary=$OPTARG
+        ;;
+    h)
+        usage
+        exit 0
+        ;;
     esac
-    parse_ktest_arg $arg
+    parse_ktest_arg "$arg"
 done
 shift $((OPTIND - 1))
 

--- a/lib/libktest.sh
+++ b/lib/libktest.sh
@@ -1,3 +1,4 @@
+# Dec 2019: requires additional validation via https://github.com/koalaman/shellcheck
 
 . "$ktest_dir/lib/util.sh"
 . "$ktest_dir/lib/parse-test.sh"

--- a/lib/parse-test.sh
+++ b/lib/parse-test.sh
@@ -1,3 +1,4 @@
+# Dec 2019: requires additional validation via https://github.com/koalaman/shellcheck
 
 parse_test_deps()
 {

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -1,3 +1,4 @@
+# Dec 2019: requires additional validation via https://github.com/koalaman/shellcheck
 
 ktest_no_cleanup_tmpdir=""
 ktest_tmp=""

--- a/root_image
+++ b/root_image
@@ -3,6 +3,8 @@
 # Create a VM image suitable for running automated tests
 # Output: vm_image
 
+# Dec 2019: requires additional validation via https://github.com/koalaman/shellcheck
+
 set -o nounset
 set -o errexit
 set -o errtrace
@@ -10,9 +12,9 @@ set -o errtrace
 ktest_dir=$(dirname "$(readlink -f "$0")")
 debootstrap=$ktest_dir/debootstrap/debootstrap
 
-. "$ktest_dir/lib/util.sh"
+source "$ktest_dir/lib/util.sh" || exit 1
 
-if [[ $(id -u) != 0 ]] ; then
+if [[ $(id -u) != 0 ]]; then
     echo this script must be run as root
     exit 1
 fi
@@ -21,10 +23,9 @@ checkdep fallocate util-linux
 checkdep mkfs.ext4 e2fsprogs
 
 IMAGE_SIZE="4G"
-MIRROR=http://ftp.us.debian.org/debian/
+MIRROR=http://cdn-fastly.deb.debian.org/debian
 
-usage()
-{
+usage() {
     echo "root_image: create/update virtual machine root images for ktest"
     echo "Usage: root_image cmd [options]"
     echo "  create		Create a new image"
@@ -34,10 +35,10 @@ usage()
     echo "  -h			Display this help and exit"
     echo "  -a <arch>		Architecture for vm image"
     echo "  -m <mirror>		Debian mirror"
-    echo '  -i <image>		Image to create/update, defaults to /var/lib/ktest/root.$arch'
+    echo "  -i <image>		Image to create/update, defaults to /var/lib/ktest/root.arch"
 }
 
-if [[ $# = 0 ]]; then
+if [[ $# == 0 ]]; then
     usage
     exit 1
 fi
@@ -48,22 +49,22 @@ shift
 
 while getopts "ha:m:i:" arg; do
     case $arg in
-	h)
-	    usage
-	    exit 0
-	    ;;
-	a)
-	    ktest_arch=$OPTARG
-	    ;;
-	m)
-	    MIRROR=$OPTARG
-	    ;;
-	i)
-	    ktest_image=$OPTARG
-	    ;;
+    h)
+        usage
+        exit 0
+        ;;
+    a)
+        ktest_arch=$OPTARG
+        ;;
+    m)
+        MIRROR=$OPTARG
+        ;;
+    i)
+        ktest_image=$OPTARG
+        ;;
     esac
 done
-shift $(( OPTIND - 1 ))
+shift $((OPTIND - 1))
 
 parse_arch "$ktest_arch"
 
@@ -71,20 +72,24 @@ parse_arch "$ktest_arch"
 
 mkdir -p "$(dirname "$ktest_image")"
 
-PACKAGES=(kexec-tools less psmisc openssh-server	\
-    build-essential make gcc g++			\
-    autoconf automake pkg-config libtool-bin		\
-    gdb strace ltrace linux-perf blktrace sysstat	\
-    hdparm btrfs-progs mdadm lvm2 aoetools vblade	\
+PACKAGES=(kexec-tools less psmisc openssh-server
+    build-essential make gcc g++
+    autoconf automake pkg-config libtool-bin
+    gdb strace ltrace linux-perf blktrace sysstat
+    hdparm btrfs-progs mdadm lvm2 aoetools vblade
     bc attr gawk acl rsync)
 
 # stress testing:
 PACKAGES+=(fio dbench bonnie++ fsmark)
 
+# FUSE:
+PACKAGES+=(libfuse3-3 libfuse3-dev libpcre2-32-0 libpcre2-dev libpcre2-posix0)
+PACKAGES+=(libselinux1-dev libsepol1-dev fuse3)
+
 # bcachefs-tools build dependencies:
 PACKAGES+=(libblkid-dev uuid-dev libscrypt-dev libsodium-dev)
 PACKAGES+=(libkeyutils-dev liburcu-dev zlib1g-dev libattr1-dev)
-PACKAGES+=(libaio-dev libzstd-dev liblz4-dev libfuse3-dev valgrind)
+PACKAGES+=(libaio-dev libzstd-dev liblz4-dev valgrind)
 
 # xfstests:
 PACKAGES+=(xfsprogs xfslibs-dev quota libcap2-bin)
@@ -101,31 +106,31 @@ PACKAGES+=(cryptsetup)
 PACKAGES+=(multipath-tools sg3-utils srptools)
 
 # suspend testing:
-[[ $KERNEL_ARCH = x86 ]] && PACKAGES+=(uswsusp)
+[[ $KERNEL_ARCH == x86 ]] && PACKAGES+=(uswsusp)
 
-EXCLUDE=(dmidecode nano rsyslog logrotate cron		\
-    iptables nfacct					\
+EXCLUDE=(dmidecode nano rsyslog logrotate cron
+    iptables nfacct
     debconf-i18n info gnupg libpam-systemd)
 
-SYSTEMD_MASK=(dev-hvc0.device				\
-    getty.target					\
-    getty-static.service				\
-    avahi-daemon.service				\
-    crond.service					\
-    kdump.service					\
-    hdparm.service					\
-    cdrom.mount						\
-    mdadm-raid.service					\
-    lvm2-activation-early.service			\
-    aoetools.service					\
-    sysstat.service					\
-    kexec-load.service					\
-    kexec.service					\
-    systemd-ask-password-console.path			\
-    systemd-ask-password-wall.path			\
-    systemd-update-utmp-runlevel.service		\
-    systemd-update-utmp.service				\
-    time-sync.target					\
+SYSTEMD_MASK=(dev-hvc0.device
+    getty.target
+    getty-static.service
+    avahi-daemon.service
+    crond.service
+    kdump.service
+    hdparm.service
+    cdrom.mount
+    mdadm-raid.service
+    lvm2-activation-early.service
+    aoetools.service
+    sysstat.service
+    kexec-load.service
+    kexec.service
+    systemd-ask-password-console.path
+    systemd-ask-password-wall.path
+    systemd-update-utmp-runlevel.service
+    systemd-update-utmp.service
+    time-sync.target
     multipathd.service)
 
 export DEBIAN_FRONTEND=noninteractive
@@ -134,13 +139,11 @@ export LC_ALL=C
 export LANGUAGE=C
 export LANG=C
 
-_chroot()
-{
+_chroot() {
     PATH=/usr/sbin:/usr/bin:/sbin:/bin chroot "$@"
 }
 
-update_files()
-{
+update_files() {
     install -m0644 "$ktest_dir/lib/fstab" "$MNT/etc/fstab"
     install -m0755 "$ktest_dir/lib/rc.local" "$MNT/etc/rc.local"
 
@@ -162,16 +165,19 @@ update_files()
     #_chroot "$MNT" systemctl mask "${SYSTEMD_MASK[@]}"
 
     for i in "${SYSTEMD_MASK[@]}"; do
-	(cd "$MNT/etc/systemd/system"; ln -sf /dev/null "$i")
+        (
+            cd "$MNT/etc/systemd/system"
+            ln -sf /dev/null "$i"
+        )
     done
 
-    cat > "$MNT/etc/systemd/journald.conf" <<-ZZ
+    cat >"$MNT/etc/systemd/journald.conf" <<-ZZ
 [Journal]
 Storage=none
 ZZ
 
     mkdir -p "$MNT/etc/network"
-    cat > "$MNT/etc/network/interfaces" <<-ZZ
+    cat >"$MNT/etc/network/interfaces" <<-ZZ
 auto lo
 iface lo inet loopback
 
@@ -190,44 +196,40 @@ ZZ
     rm -f "$MNT/lib/udev/rules.d/*btrfs*"
     rm -f "$MNT/lib/udev/rules.d/*hdparm*"
 
-    echo $(hostname)-kvm >"$MNT/etc/hostname"
+    echo "$(hostname)"-kvm >"$MNT/etc/hostname"
 }
 
-update_packages()
-{
+update_packages() {
     _chroot "$MNT" apt update
     _chroot "$MNT" apt upgrade -y
     _chroot "$MNT" apt install -y "${PACKAGES[@]}"
     rm -f "$MNT/var/cache/apt/archives/*.deb"
 }
 
-trim_image()
-{
+trim_image() {
     e2fsck -f "$ktest_image"
-    resize2fs -M "$ktest_image"			# shrinks the file
-    resize2fs "$ktest_image" "$IMAGE_SIZE"	# re-grows as sparse
+    resize2fs -M "$ktest_image"            # shrinks the file
+    resize2fs "$ktest_image" "$IMAGE_SIZE" # re-grows as sparse
 }
 
-umount_image()
-{
+umount_image() {
     # Unmount everything under $MNT
-    awk '{print $2}' /proc/mounts|
-	grep "^$MNT"|
-	sort -r|
-	xargs umount
+    awk '{print $2}' /proc/mounts |
+        grep "^$MNT" |
+        sort -r |
+        xargs umount
 
     rmdir "$MNT"
     trap '' EXIT
 }
 
-cmd_update()
-{
+cmd_update() {
     if [[ ! -e $ktest_image ]]; then
-	echo "$ktest_image does not exist"
-	exit 1
+        echo "$ktest_image does not exist"
+        exit 1
     fi
 
-    MNT=$(mktemp --tmpdir -d $(basename "$0")-XXXXXXXXXX)
+    MNT=$(mktemp --tmpdir -d "$(basename "$0")"-XXXXXXXXXX)
     trap 'umount_image' EXIT
 
     mount "$ktest_image" "$MNT"
@@ -239,29 +241,32 @@ cmd_update()
     trim_image
 }
 
-cmd_create()
-{
+cmd_create() {
     if [[ -e $ktest_image ]]; then
-	echo "$ktest_image already exists"
-	exit 1
+        echo "$ktest_image already exists"
+        exit 1
     fi
 
-    (cd "$ktest_dir"; git submodule update --init debootstrap)
+    (
+        cd "$ktest_dir"
+        rm -fr debootstrap
+        git clone https://salsa.debian.org/installer-team/debootstrap.git
+    )
 
-    MNT=$(mktemp --tmpdir -d $(basename "$0")-XXXXXXXXXX)
+    MNT=$(mktemp --tmpdir -d "$(basename "$0")"-XXXXXXXXXX)
     trap 'umount_image; rm "$ktest_image"' EXIT
 
     fallocate -l "$IMAGE_SIZE" "$ktest_image"
     mkfs.ext4 -F "$ktest_image"
     mount "$ktest_image" "$MNT"
 
-    DEBOOTSTRAP_DIR=$ktest_dir/debootstrap $debootstrap	\
-	--no-check-gpg					\
-	--arch="$DEBIAN_ARCH"				\
-	--include=$(join_by , "${PACKAGES[@]}")		\
-	--exclude=$(join_by , "${EXCLUDE[@]}")		\
-	--foreign					\
-	sid "$MNT" "$MIRROR"
+    DEBOOTSTRAP_DIR=$ktest_dir/debootstrap $debootstrap \
+        --no-check-gpg \
+        --arch="$DEBIAN_ARCH" \
+        --include="$(join_by , "${PACKAGES[@]}")" \
+        --exclude="$(join_by , "${EXCLUDE[@]}")" \
+        --foreign \
+        buster "$MNT" "$MIRROR"
 
     update_files
 

--- a/tests/bcache/bcache-test-libs.sh
+++ b/tests/bcache/bcache-test-libs.sh
@@ -1,3 +1,5 @@
+# Dec 2019: requires additional validation via https://github.com/koalaman/shellcheck
+
 #
 # Library with some functions for writing bcache tests using the
 # ktest framework.

--- a/tests/bcachefs/bcachefs-test-libs.sh
+++ b/tests/bcachefs/bcachefs-test-libs.sh
@@ -1,3 +1,5 @@
+# Dec 2019: requires additional validation via https://github.com/koalaman/shellcheck
+
 #
 # Library with some functions for writing bcachefs tests using the
 # ktest framework.

--- a/tests/prelude.sh
+++ b/tests/prelude.sh
@@ -1,4 +1,4 @@
-
+# Dec 2019: requires additional validation via https://github.com/koalaman/shellcheck
 
 have_kvmguest=0
 have_virtio=0

--- a/tests/test-libs.sh
+++ b/tests/test-libs.sh
@@ -1,3 +1,5 @@
+# Dec 2019: requires additional validation via https://github.com/koalaman/shellcheck
+
 #
 # Library with some functions for writing block layer tests using the
 # ktest framework.

--- a/tests/xfstests.sh
+++ b/tests/xfstests.sh
@@ -1,3 +1,5 @@
+# Dec 2019: requires additional validation via https://github.com/koalaman/shellcheck
+
 # xfstests wrapper:
 
 require-lib test-libs.sh


### PR DESCRIPTION
* Fixed the Debootstrap usage, so it'd work correctly.
* Set to use Debian Buster, instead of Sid; to avoid dependency failures.
* Completed most https://github.com/koalaman/shellcheck work on ktest & root_image scripts.
* Flagged remaining shell scripts for follow-up ShellCheck cleanup.
