### PR TITLE
lib/testrunner: skip configure for linuxquota

### DIFF
--- a/lib/testrunner
+++ b/lib/testrunner
@@ -90,8 +90,10 @@ j=$(($(grep -c '^processor' /proc/cpuinfo) * 2))
 for i in "${ktest_make_install[@]}"; do
     if [ "$(basename $i)" = "linuxquota-code" ]; then
 	pushd "/host/$i"
-	./autogen.sh
-	./configure
+	if [ ! -e .configured ]; then
+		./autogen.sh
+		./configure && touch .configured
+	fi
 	popd
     fi
 


### PR DESCRIPTION
Running configure for linuxquota unconditionally makes ktest runs that
depend on it a fair amount slower. Only run autogen.sh and configure
when the source has not been configured yet.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>