### PR TITLE
Fix build-test-kernel boot command

### DIFF
--- a/boot.ktest
+++ b/boot.ktest
@@ -7,7 +7,9 @@ config-scratch-devs 4G
 config-pmem-devs 4G
 config-timeout 600000
 
-main()
+list_tests()
 {
-    exit 0
+    echo boot
 }
+
+main "$@"


### PR DESCRIPTION
Error:
```
$ build-test-kernel boot -I
Running test boot.ktest
/home/holmanb/workspace/ktest/lib/parse-test.sh: line 5: /home/holmanb/workspace/ktest/boot.ktest: Permission denied
Error 126 from: "$ktest_test" deps, exiting
/home/holmanb/workspace/ktest/lib/parse-test.sh: line 9: ktest_mem: unbound variable
```


Ktest requirements changed initially in https://github.com/koverstreet/ktest/commit/6129a076d6e8140fb3ba396945c64961d40aace4 and again in https://github.com/koverstreet/ktest/commit/f0f07641db06cc9e864db6aa7c2c5ae5b87195a8.

