### PR TITLE
ktest: support ZFS

### DIFF
--- a/root_image
+++ b/root_image
@@ -296,6 +296,7 @@ cmd_create()
 	--arch="$DEBIAN_ARCH"				\
 	--exclude=$(join_by , "${EXCLUDE[@]}")		\
 	--foreign					\
+	--components='main,contrib,non-free,bullseye-backports' \
 	bullseye "$MNT" "$MIRROR"
 
     _chroot "$MNT" /debootstrap/debootstrap --second-stage

--- a/root_image
+++ b/root_image
@@ -117,6 +117,9 @@ PACKAGES+=(cryptsetup)
 # weird block layer crap
 PACKAGES+=(multipath-tools sg3-utils srptools)
 
+# ZFS support
+PACKAGES+=("linux-headers-$DEBIAN_ARCH" dkms zfsutils-linux zfs-dkms)
+
 # suspend testing:
 # [[ $KERNEL_ARCH = x86 ]] && PACKAGES+=(uswsusp)
 

--- a/root_image
+++ b/root_image
@@ -151,10 +151,14 @@ export DEBCONF_NONINTERACTIVE_SEEN=true
 export LC_ALL=C
 export LANGUAGE=C
 export LANG=C
+# We compute it here to avoid on hosts systems (e.g. NixOS)
+# that does not possess `chroot` in the isolated `PATH`
+# to fail miserably.
+export CHROOT=$(which chroot)
 
 _chroot()
 {
-    PATH=/usr/sbin:/usr/bin:/sbin:/bin /usr/bin/env chroot "$@"
+    PATH=/usr/sbin:/usr/bin:/sbin:/bin "$CHROOT" "$@"
 }
 
 update_files()


### PR DESCRIPTION
This should enable support for ZFS, untested yet for me because I cannot run `ktest` properly on NixOS yet.