### PR TITLE
restore xxhash testing + allow running ktest on emulated architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cscope*
 tags
 ktest-out
 *.tags
+cross.conf
 
 lib/lwip-connect
 lib/supervisor

--- a/build-test-kernel
+++ b/build-test-kernel
@@ -121,10 +121,8 @@ run_ktest()
 
 do_make()
 {
-    if [[ -n $CROSS_COMPILE ]]; then
-	export ARCH="$KERNEL_ARCH"
-	export CROSS_COMPILE="$ARCH_TRIPLE-"
-    fi
+	local ARCH="$KERNEL_ARCH"
+	local CROSS_COMPILE="$ARCH_TRIPLE-"
 
     make --jobs="$ktest_njobs"			\
 	--directory="$ktest_kernel_source"    	\
@@ -192,7 +190,7 @@ build_kernel()
 
     log_verbose "kernel_config_require: ${ktest_kernel_config_require[@]}"
 
-    MAKEARGS+=("LOCALVERSION=-ktest")
+    MAKEARGS+=("LOCALVERSION=-ktest" ARCH="$KERNEL_ARCH" CROSS_COMPILE="$ARCH_TRIPLE-")
 
     for opt in "${ktest_kernel_config_require[@]}"; do
 	[[ -n $opt ]] && kernel_opt set "$opt"

--- a/build-test-kernel
+++ b/build-test-kernel
@@ -107,7 +107,7 @@ ktest_kernel_source=$(readlink -e "$ktest_kernel_source")
 ktest_kernel_build="$ktest_out/kernel_build.$ktest_arch"
 mkdir -p "$ktest_kernel_build"
 
-if [[ -n $CROSS_COMPILE ]]; then
+if [[ -z ${CROSS_COMPILE:+x} ]]; then
     checkdep "$ARCH_TRIPLE-gcc" "gcc-$ARCH_TRIPLE"
 fi
 

--- a/build-test-kernel
+++ b/build-test-kernel
@@ -139,7 +139,7 @@ new_config()
     local config_tool="$ktest_kernel_source/scripts/config"
 
     if [[ ! -f $kconfig ]]; then
-	do_make allnoconfig
+	do_make ARCH="$KERNEL_ARCH" CROSS_COMPILE="$ARCH_TRIPLE-" allnoconfig
 
 	# Really undefine everything:
 	sed -i -e 's/\(CONFIG_.*\)=.*/# \1 is not set/' "$kconfig"
@@ -186,17 +186,17 @@ build_kernel()
 	mv "$kconfig" "$kconfig".bak
     fi
 
+    MAKEARGS+=("LOCALVERSION=-ktest" ARCH="$KERNEL_ARCH" CROSS_COMPILE="$ARCH_TRIPLE-")
+
     new_config
 
     log_verbose "kernel_config_require: ${ktest_kernel_config_require[@]}"
-
-    MAKEARGS+=("LOCALVERSION=-ktest" ARCH="$KERNEL_ARCH" CROSS_COMPILE="$ARCH_TRIPLE-")
 
     for opt in "${ktest_kernel_config_require[@]}"; do
 	[[ -n $opt ]] && kernel_opt set "$opt"
     done
 
-    do_make olddefconfig
+    do_make ARCH="$KERNEL_ARCH" CROSS_COMPILE="$ARCH_TRIPLE-" olddefconfig
 
     for opt in "${ktest_kernel_config_require[@]}"; do
 	[[ -n $opt ]] && kernel_opt check "$opt"
@@ -209,10 +209,10 @@ build_kernel()
 
     case $KERNEL_ARCH in
 	mips)
-	    do_make -k vmlinuz
+	    do_make $MAKEARGS -k vmlinuz
 	    ;;
 	*)
-	    do_make -k
+	    do_make $MAKEARGS -k
 	    ;;
     esac
 
@@ -221,6 +221,9 @@ build_kernel()
     case $ktest_arch in
 	x86*)
 	    install -m0644 "$BOOT/bzImage"	"$ktest_kernel_binary/vmlinuz"
+	    ;;
+	arm)
+	    install -m0644 "$BOOT/zImage"	"$ktest_kernel_binary/vmlinuz"
 	    ;;
 	aarch64)
 	    install -m0644 "$BOOT/Image"	"$ktest_kernel_binary/vmlinuz"
@@ -281,13 +284,13 @@ cmd_boot()
 cmd_oldconfig()
 {
     new_config
-    do_make oldconfig
+    do_make ARCH="$KERNEL_ARCH" CROSS_COMPILE="$ARCH_TRIPLE-" oldconfig
 }
 
 cmd_config()
 {
     new_config
-    do_make nconfig
+    do_make ARCH="$KERNEL_ARCH" CROSS_COMPILE="$ARCH_TRIPLE-" nconfig
 }
 
 cmd_faddr2line()

--- a/build-test-kernel
+++ b/build-test-kernel
@@ -224,6 +224,9 @@ build_kernel()
 	ppc64)
 	    install -m0644 "$BOOT/zImage"	"$ktest_kernel_binary/vmlinuz"
 	    ;;
+	sparc64)
+	    install -m0644 "$BOOT/image"	"$ktest_kernel_binary/vmlinuz"
+	    ;;
 	*)
 	    if [ -f "$BOOT/Image" ]; then
 		 install -m0644 "$BOOT/Image"	"$ktest_kernel_binary/vmlinuz"

--- a/build-test-kernel
+++ b/build-test-kernel
@@ -230,11 +230,14 @@ build_kernel()
 	    ;;
 	mips)
 	    install -m0644 "$BOOT/vmlinux.strip"	"$ktest_kernel_binary/vmlinuz"
-	    #install -m0644 "$ktest_kernel_build/vmlinux"	"$ktest_kernel_binary/vmlinuz"
 	    ;;
 	default)
-	    echo "Don't know how to install kernel"
-	    exit 1
+	    if [ -f "$BOOT/Image" ]; then
+		 install -m0644 "$BOOT/Image"	"$ktest_kernel_binary/vmlinuz"
+	    else
+		echo "Don't know how to install kernel"
+	    	exit 1
+	    fi
 	    ;;
     esac
 

--- a/build-test-kernel
+++ b/build-test-kernel
@@ -207,14 +207,7 @@ build_kernel()
 	mv "$kconfig".bak "$kconfig"
     fi
 
-    case $KERNEL_ARCH in
-	mips)
-	    do_make $MAKEARGS -k vmlinuz
-	    ;;
-	*)
-	    do_make $MAKEARGS -k
-	    ;;
-    esac
+    do_make $MAKEARGS -k
 
     local BOOT=$ktest_kernel_build/arch/$KERNEL_ARCH/boot
 
@@ -228,12 +221,16 @@ build_kernel()
 	aarch64)
 	    install -m0644 "$BOOT/Image"	"$ktest_kernel_binary/vmlinuz"
 	    ;;
-	mips)
-	    install -m0644 "$BOOT/vmlinux.strip"	"$ktest_kernel_binary/vmlinuz"
+	ppc64)
+	    install -m0644 "$BOOT/zImage"	"$ktest_kernel_binary/vmlinuz"
 	    ;;
-	default)
+	*)
 	    if [ -f "$BOOT/Image" ]; then
 		 install -m0644 "$BOOT/Image"	"$ktest_kernel_binary/vmlinuz"
+	    elif [ -f "$BOOT/zImage" ]; then
+		 install -m0644 "$BOOT/zImage"	"$ktest_kernel_binary/vmlinuz"
+	    elif [ -f "$BOOT/bzImage" ]; then
+		 install -m0644 "$BOOT/bzImage"	"$ktest_kernel_binary/vmlinuz"
 	    else
 		echo "Don't know how to install kernel"
 	    	exit 1

--- a/cross.conf
+++ b/cross.conf
@@ -6,3 +6,6 @@ ARCH_TRIPLE_X86=x86-linux-gnu
 ARCH_TRIPLE_X86_64=x86_64-linux-gnu
 ARCH_TRIPLE_ARM64=aarch64-linux-gnu
 ARCH_TRIPLE_ARMV7=arm-linux-gnueabihf
+ARCH_TRIPLE_PPC64=powerpc64-linux-gnu
+ARCH_TRIPLE_SPARC64=sparc64-linux-gnu
+ARCH_TRIPLE_RISCV64=riscv64-linux-gnu

--- a/cross.conf
+++ b/cross.conf
@@ -5,4 +5,4 @@
 ARCH_TRIPLE_X86=x86-linux-gnu
 ARCH_TRIPLE_X86_64=x86_64-linux-gnu
 ARCH_TRIPLE_ARM64=aarch64-linux-gnu
-
+ARCH_TRIPLE_ARMV7=arm-linux-gnueabihf

--- a/cross.conf
+++ b/cross.conf
@@ -1,0 +1,8 @@
+# this file specifies target triplets for cross-compiling
+# whenever these need to be changed (some distributions prefer ARCHITECTURE-VENDOR-OS-LIBC), 
+# change the triplet here
+
+ARCH_TRIPLE_X86=x86-linux-gnu
+ARCH_TRIPLE_X86_64=x86_64-linux-gnu
+ARCH_TRIPLE_ARM64=aarch64-linux-gnu
+

--- a/cross.conf
+++ b/cross.conf
@@ -2,10 +2,23 @@
 # whenever these need to be changed (some distributions prefer ARCHITECTURE-VENDOR-OS-LIBC), 
 # change the triplet here
 
+#32 bit architectures
 ARCH_TRIPLE_X86=x86-linux-gnu
+ARCH_TRIPLE_ARMV7=arm-linux-gnueabihf
+
+#64 bit architectures
 ARCH_TRIPLE_X86_64=x86_64-linux-gnu
 ARCH_TRIPLE_ARM64=aarch64-linux-gnu
-ARCH_TRIPLE_ARMV7=arm-linux-gnueabihf
-ARCH_TRIPLE_PPC64=powerpc64-linux-gnu
+ARCH_TRIPLE_S390X=s390x-linux-gnu
+
+#currently unsupported (but maintained) debian architectures
+ARCH_TRIPLE_PPC64=powerpc-linux-gnu
 ARCH_TRIPLE_SPARC64=sparc64-linux-gnu
 ARCH_TRIPLE_RISCV64=riscv64-linux-gnu
+
+#here you can specify up snapshots which are used to fix sid dependencies:
+#debian SID is updated frequently, having a lot of broken packages due to dependencies
+#view https://snapshot.debian.org/archive/debian-ports/ for a list
+#as always: the older, the more dangerous ...
+
+SID_SNAPSHOTS=("20220501T101242Z")

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -87,6 +87,7 @@ parse_arch()
 	    ktest_arch=x86
 	    DEBIAN_ARCH=i386
 	    ARCH_TRIPLE=${ARCH_TRIPLE_X86}
+	    RUST_TRIPLE=i686-unknown-linux-gnu
 
 	    KERNEL_ARCH=x86
 	    BITS=32
@@ -98,6 +99,7 @@ parse_arch()
 	    ktest_arch=x86_64
 	    DEBIAN_ARCH=amd64
 	    ARCH_TRIPLE=${ARCH_TRIPLE_X86_64}
+	    RUST_TRIPLE=x86_64-unknown-linux-gnu
 
 	    KERNEL_ARCH=x86
 	    BITS=64
@@ -109,6 +111,7 @@ parse_arch()
 	    ktest_arch=aarch64
 	    DEBIAN_ARCH=arm64
 	    ARCH_TRIPLE=${ARCH_TRIPLE_ARM64}
+	    RUST_TRIPLE=aarch64-unknown-linux-gnu
 
 	    KERNEL_ARCH=arm64
 	    BITS=64
@@ -120,6 +123,7 @@ parse_arch()
 	    ktest_arch=arm
 	    DEBIAN_ARCH=armhf
 	    ARCH_TRIPLE=${ARCH_TRIPLE_ARMV7}
+	    RUST_TRIPLE=armv7-unknown-linux-gnueabihf
 
 	    KERNEL_ARCH=arm
 	    BITS=32

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -3,6 +3,10 @@ set -o nounset
 set -o errtrace
 set -o pipefail
 
+[[ -v ktest_dir ]] || ktest_dir=$(dirname ${BASH_SOURCE})/..
+
+. "$ktest_dir/cross.conf"
+
 trap 'echo "Error $? at $BASH_SOURCE $LINENO from: $BASH_COMMAND, exiting"' ERR
 
 ktest_tmp=${ktest_tmp:-""}
@@ -85,7 +89,7 @@ parse_arch()
 	x86|i386)
 	    ktest_arch=x86
 	    DEBIAN_ARCH=i386
-	    ARCH_TRIPLE=x86-linux-gnu
+	    ARCH_TRIPLE=${ARCH_TRIPLE_X86}
 
 	    KERNEL_ARCH=x86
 	    BITS=32
@@ -96,7 +100,7 @@ parse_arch()
 	x86_64|amd64)
 	    ktest_arch=x86_64
 	    DEBIAN_ARCH=amd64
-	    ARCH_TRIPLE=x86_64-linux-gnu
+	    ARCH_TRIPLE=${ARCH_TRIPLE_X86_64}
 
 	    KERNEL_ARCH=x86
 	    BITS=64
@@ -107,7 +111,7 @@ parse_arch()
 	aarch64|arm64)
 	    ktest_arch=aarch64
 	    DEBIAN_ARCH=arm64
-	    ARCH_TRIPLE=aarch64-linux-gnu
+	    ARCH_TRIPLE=${ARCH_TRIPLE_ARM64}
 
 	    KERNEL_ARCH=arm64
 	    BITS=64

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -116,6 +116,17 @@ parse_arch()
 	    QEMU_PACKAGE=qemu-system-arm
 	    QEMU_BIN=qemu-system-aarch64
 	    ;;
+	armhf|armv7|armv7l|arm)
+	    ktest_arch=arm
+	    DEBIAN_ARCH=armhf
+	    ARCH_TRIPLE=${ARCH_TRIPLE_ARMV7}
+
+	    KERNEL_ARCH=arm
+	    BITS=32
+
+	    QEMU_PACKAGE=qemu-system-arm
+	    QEMU_BIN=qemu-system-arm
+	    ;;
 	mips)
 	    DEBIAN_ARCH=mips
 	    ARCH_TRIPLE=mips-linux-gnu

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -131,6 +131,17 @@ parse_arch()
 	    QEMU_PACKAGE=qemu-system-arm
 	    QEMU_BIN=qemu-system-arm
 	    ;;
+	s390x)
+	    DEBIAN_ARCH=s390x
+	    ARCH_TRIPLE=${ARCH_TRIPLE_S390X}
+	    RUST_TRIPLE=s390x-unknown-linux-gnu
+
+	    KERNEL_ARCH=s390
+	    BITS=64
+
+	    QEMU_PACKAGE=qemu-system-s390x
+	    QEMU_BIN=qemu-system-s390x
+	    ;;
 	riscv64)
 	    DEBIAN_ARCH=riscv64
 	    ARCH_TRIPLE=${ARCH_TRIPLE_RISCV64}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -80,9 +80,6 @@ join_by()
     echo "$*"
 }
 
-ktest_arch=$(uname -m)
-CROSS_COMPILE=""
-
 parse_arch()
 {
     case $1 in
@@ -191,6 +188,14 @@ parse_arch()
     if [[ $ktest_arch != $(uname -m) ]]; then
 	CROSS_COMPILE=1
     fi
+
+    export DEBIAN_ARCH
+    export MIRROR
+    export ARCH_TRIPLE
+    export KERNEL_ARCH
+    export QEMU_PACKAGE
+    export QEMU_BIN
+    export ktest_arch
 }
 
 find_command() {

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -131,39 +131,23 @@ parse_arch()
 	    QEMU_PACKAGE=qemu-system-arm
 	    QEMU_BIN=qemu-system-arm
 	    ;;
-	mips)
-	    DEBIAN_ARCH=mips
-	    ARCH_TRIPLE=mips-linux-gnu
+	riscv64)
+	    DEBIAN_ARCH=riscv64
+	    ARCH_TRIPLE=${ARCH_TRIPLE_RISCV64}
+	    MIRROR=http://deb.debian.org/debian-ports
+	    RUST_TRIPLE=riscv64gc-unknown-linux-gnu
 
-	    KERNEL_ARCH=mips
-	    BITS=32
-
-	    QEMU_PACKAGE=qemu-system-mips
-	    QEMU_BIN=qemu-system-mips
-	    ;;
-	mips64)
-	    DEBIAN_ARCH=mips
-	    ARCH_TRIPLE=mips-linux-gnu
-
-	    KERNEL_ARCH=mips
+	    KERNEL_ARCH=riscv
 	    BITS=64
 
-	    QEMU_PACKAGE=qemu-system-mips
-	    QEMU_BIN=qemu-system-mips64
-	    ;;
-	sparc)
-	    DEBIAN_ARCH=sparc
-	    ARCH_TRIPLE=sparc64-linux-gnu
-
-	    KERNEL_ARCH=sparc
-	    BITS=32
-
-	    QEMU_PACKAGE=qemu-system-sparc
-	    QEMU_BIN=qemu-system-sparc
+	    QEMU_PACKAGE=qemu-system-riscv
+	    QEMU_BIN=qemu-system-riscv64
 	    ;;
 	sparc64)
-	    DEBIAN_ARCH=sparc
-	    ARCH_TRIPLE=sparc64-linux-gnu
+	    DEBIAN_ARCH=sparc64
+	    ARCH_TRIPLE=${ARCH_TRIPLE_SPARC64}
+	    MIRROR=http://deb.debian.org/debian-ports
+	    RUST_TRIPLE=sparc64-unknown-linux-gnu
 
 	    KERNEL_ARCH=sparc
 	    BITS=64
@@ -171,23 +155,13 @@ parse_arch()
 	    QEMU_PACKAGE=qemu-system-sparc
 	    QEMU_BIN=qemu-system-sparc64
 	    ;;
-	ppc|powerpc)
-	    DEBIAN_ARCH=powerpc
-	    MIRROR=http://deb.debian.org/debian-ports
-
-	    ARCH_TRIPLE=powerpc-linux-gnu
-
-	    KERNEL_ARCH=powerpc
-	    BITS=32
-
-	    QEMU_PACKAGE=qemu-system-ppc
-	    QEMU_BIN=qemu-system-ppc
-	    ;;
-	ppc64)
+	ppc64|powerpc)
+	    ktest_arch=ppc64
 	    DEBIAN_ARCH=ppc64
 	    MIRROR=http://deb.debian.org/debian-ports
 
-	    ARCH_TRIPLE=powerpc-linux-gnu
+	    ARCH_TRIPLE=${ARCH_TRIPLE_PPC64}
+	    RUST_TRIPLE=powerpc64-unknown-linux-gnu
 
 	    KERNEL_ARCH=powerpc
 	    BITS=64
@@ -213,6 +187,7 @@ parse_arch()
     export QEMU_BIN
     export ktest_arch
     export BITS
+    export RUST_TRIPLE
 }
 
 find_command() {

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -83,7 +83,7 @@ join_by()
 parse_arch()
 {
     case $1 in
-	x86|i386)
+	x86|i386|i686)
 	    ktest_arch=x86
 	    DEBIAN_ARCH=i386
 	    ARCH_TRIPLE=${ARCH_TRIPLE_X86}
@@ -92,7 +92,7 @@ parse_arch()
 	    BITS=32
 
 	    QEMU_PACKAGE=qemu-system-x86
-	    QEMU_BIN=qemu-system-x86_64
+	    QEMU_BIN=qemu-system-i386
 	    ;;
 	x86_64|amd64)
 	    ktest_arch=x86_64
@@ -188,7 +188,8 @@ parse_arch()
     if [[ $ktest_arch != $(uname -m) ]]; then
 	CROSS_COMPILE=1
     fi
-
+    #special case: x86_64 is able to run i386 code.  this isn't always the case for armv8 -> armv7 (cortex A35)
+    [[ $DEBIAN_ARCH == "i386" ]] && [[ "$(uname -m)" == "x86_64" ]] && CROSS_COMPILE=0
     export DEBIAN_ARCH
     export MIRROR
     export ARCH_TRIPLE
@@ -196,6 +197,7 @@ parse_arch()
     export QEMU_PACKAGE
     export QEMU_BIN
     export ktest_arch
+    export BITS
 }
 
 find_command() {

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -88,6 +88,7 @@ parse_arch()
 	    DEBIAN_ARCH=i386
 	    ARCH_TRIPLE=${ARCH_TRIPLE_X86}
 	    RUST_TRIPLE=i686-unknown-linux-gnu
+	    DEBIAN_INCLUDE_HEADERS=i386-linux-gnu
 
 	    KERNEL_ARCH=x86
 	    BITS=32
@@ -100,6 +101,7 @@ parse_arch()
 	    DEBIAN_ARCH=amd64
 	    ARCH_TRIPLE=${ARCH_TRIPLE_X86_64}
 	    RUST_TRIPLE=x86_64-unknown-linux-gnu
+	    DEBIAN_INCLUDE_HEADERS=x86_64-linux-gnu
 
 	    KERNEL_ARCH=x86
 	    BITS=64
@@ -112,6 +114,7 @@ parse_arch()
 	    DEBIAN_ARCH=arm64
 	    ARCH_TRIPLE=${ARCH_TRIPLE_ARM64}
 	    RUST_TRIPLE=aarch64-unknown-linux-gnu
+	    DEBIAN_INCLUDE_HEADERS=aarch64-linux-gnu
 
 	    KERNEL_ARCH=arm64
 	    BITS=64
@@ -124,6 +127,7 @@ parse_arch()
 	    DEBIAN_ARCH=armhf
 	    ARCH_TRIPLE=${ARCH_TRIPLE_ARMV7}
 	    RUST_TRIPLE=armv7-unknown-linux-gnueabihf
+	    DEBIAN_INCLUDE_HEADERS=arm-linux-gnueabihf
 
 	    KERNEL_ARCH=arm
 	    BITS=32
@@ -135,6 +139,7 @@ parse_arch()
 	    DEBIAN_ARCH=s390x
 	    ARCH_TRIPLE=${ARCH_TRIPLE_S390X}
 	    RUST_TRIPLE=s390x-unknown-linux-gnu
+	    DEBIAN_INCLUDE_HEADERS=s390x-linux-gnu
 
 	    KERNEL_ARCH=s390
 	    BITS=64
@@ -143,10 +148,15 @@ parse_arch()
 	    QEMU_BIN=qemu-system-s390x
 	    ;;
 	riscv64)
+	    ktest_arch=riscv64
 	    DEBIAN_ARCH=riscv64
 	    ARCH_TRIPLE=${ARCH_TRIPLE_RISCV64}
+#TODO: risc-v is being promoted out of "unsupported backports and moved into main debian architectures.
+#it is currently not yet supported in trixie, but it might still be - or might not - we don't know.
+#it IS impossible to use the current mirror, but maybe another solution comes up when riscv64's support status is clear.
 	    MIRROR=http://deb.debian.org/debian-ports
 	    RUST_TRIPLE=riscv64gc-unknown-linux-gnu
+	    DEBIAN_INCLUDE_HEADERS=riscv64gc-linux-gnu
 
 	    KERNEL_ARCH=riscv
 	    BITS=64
@@ -155,10 +165,12 @@ parse_arch()
 	    QEMU_BIN=qemu-system-riscv64
 	    ;;
 	sparc64)
+            ktest_arch=sparc64
 	    DEBIAN_ARCH=sparc64
 	    ARCH_TRIPLE=${ARCH_TRIPLE_SPARC64}
 	    MIRROR=http://deb.debian.org/debian-ports
 	    RUST_TRIPLE=sparc64-unknown-linux-gnu
+	    DEBIAN_INCLUDE_HEADERS=sparc64-linux-gnu
 
 	    KERNEL_ARCH=sparc
 	    BITS=64
@@ -170,9 +182,9 @@ parse_arch()
 	    ktest_arch=ppc64
 	    DEBIAN_ARCH=ppc64
 	    MIRROR=http://deb.debian.org/debian-ports
-
 	    ARCH_TRIPLE=${ARCH_TRIPLE_PPC64}
 	    RUST_TRIPLE=powerpc64-unknown-linux-gnu
+	    DEBIAN_INCLUDE_HEADERS=powerpc64-linux-gnu
 
 	    KERNEL_ARCH=powerpc
 	    BITS=64

--- a/lib/libktest.sh
+++ b/lib/libktest.sh
@@ -438,7 +438,7 @@ start_vm()
 	qemu_pmem mem-path="$file",size=$size
     done
 
-    ulimit -n 65535
+    [ "$(ulimit)" == "unlimited" ] || ulimit -n 65535
     qemu_cmd+=("${ktest_qemu_append[@]}")
 
     set +o errexit

--- a/lib/libktest.sh
+++ b/lib/libktest.sh
@@ -85,6 +85,7 @@ parse_ktest_arg()
 
 parse_args_post()
 {
+    [ -z ${ktest_arch:+x} ] && ktest_arch=$(uname -m)
     parse_arch "$ktest_arch"
 
     ktest_out=$(readlink -f "$ktest_out")
@@ -306,12 +307,15 @@ start_vm()
     kernelargs+=("${ktest_kernel_append[@]}")
 
     local qemu_cmd=("$QEMU_BIN" -nodefaults -nographic)
+    local accel=kvm
+    local cputype=host
+    [[ $(uname -m) == $ktest_arch ]] || accel=tcg && cputype=max
     case $ktest_arch in
 	x86|x86_64)
-	    qemu_cmd+=(-cpu host -machine type=q35,accel=kvm,nvdimm=on)
+	    qemu_cmd+=(-cpu $cputype -machine type=q35,accel=$accel,nvdimm=on)
 	    ;;
 	aarch64)
-	    qemu_cmd+=(-cpu host -machine type=virt,gic-version=max,accel=kvm)
+	    qemu_cmd+=(-cpu $cputype -machine type=virt,gic-version=max,accel=$accel)
 	    ;;
 	mips)
 	    qemu_cmd+=(-cpu 24Kf -machine malta)

--- a/lib/libktest.sh
+++ b/lib/libktest.sh
@@ -309,7 +309,7 @@ start_vm()
     local qemu_cmd=("$QEMU_BIN" -nodefaults -nographic)
     local accel=kvm
     local cputype=host
-    [[ $(uname -m) == $ktest_arch ]] || accel=tcg && cputype=max
+    [[ "${CROSS_COMPILE:-0}" == "1" ]] && accel=tcg && cputype=max
     case $ktest_arch in
 	x86|x86_64)
 	    qemu_cmd+=(-cpu $cputype -machine type=q35,accel=$accel,nvdimm=on)

--- a/lib/libktest.sh
+++ b/lib/libktest.sh
@@ -317,12 +317,14 @@ start_vm()
 	aarch64|arm)
 	    qemu_cmd+=(-cpu $cputype -machine type=virt,gic-version=max,accel=$accel)
 	    ;;
-	mips)
-	    qemu_cmd+=(-cpu 24Kf -machine malta)
-	    ktest_cpus=1
+	ppc64)
+	    qemu_cmd+=(-cpu power9)
 	    ;;
-	mips64)
-	    qemu_cmd+=(-cpu MIPS64R2-generic -machine malta)
+	sparc64)
+	    qemu_cmd+=(-cpu default)
+	    ;;
+	riscv64)
+	    qemu_cmd+=(-cpu any)
 	    ;;
     esac
 

--- a/lib/libktest.sh
+++ b/lib/libktest.sh
@@ -269,7 +269,7 @@ try_construct_cross_bcachefs()
 (
      cd ${ktest_dir}/tests/bcachefs/bcachefs-tools/
      make clean
-     rm -rf rust-src/target/release
+     cargo clean --manifest-path=rust-src/Cargo.toml || true
      rootpath=${ktest_out}/vm/cross-user
      make CC=${ARCH_TRIPLE}-gcc EXTRA_CFLAGS="-I/${rootpath}/usr/include/ -I/${rootpath}/usr/include/${DEBIAN_INCLUDE_HEADERS}/ -ffile-prefix-map=${rootpath}=/" -j $ktest_cpus libbcachefs.a && echo ${ktest_arch} > .crossarch
      find -name "*.d" -exec sed -i "s/${rootpath//\//\\\/}/\//g" {} \;
@@ -318,7 +318,6 @@ start_vm()
     ln -s "$ktest_tmp" "$ktest_out/vm"
 
     local kernelargs=()
-
     case $ktest_storage_bus in
 	virtio-blk)
 	    ktest_root_dev="/dev/vda"
@@ -328,7 +327,7 @@ start_vm()
 	    ;;
     esac
 
-    kernelargs+=(root=$ktest_root_dev rw log_buf_len=8M)
+    kernelargs+=(root=$ktest_root_dev rw log_buf_len=8M rootwait)
     kernelargs+=(mitigations=off)
     kernelargs+=("ktest.dir=$ktest_dir")
     kernelargs+=(ktest.env=$(readlink -f "$ktest_out/vm/env"))

--- a/lib/libktest.sh
+++ b/lib/libktest.sh
@@ -318,13 +318,17 @@ start_vm()
 	    qemu_cmd+=(-cpu $cputype -machine type=virt,gic-version=max,accel=$accel)
 	    ;;
 	ppc64)
-	    qemu_cmd+=(-cpu power9)
+	    qemu_cmd+=(-machine ppce500 -cpu e6500 -accel tcg)
+	    ;;
+	s390x)
+	    qemu_cmd+=(-cpu max -machine s390-ccw-virtio -accel tcg)
 	    ;;
 	sparc64)
-	    qemu_cmd+=(-cpu default)
+	    qemu_cmd+=(-machine sun4u -accel tcg)
+	    ktest_cpus=1; #sparc64 currently supports only 1 cpu
 	    ;;
 	riscv64)
-	    qemu_cmd+=(-cpu any)
+	    qemu_cmd+=(-machine virt -cpu rv64 -accel tcg)
 	    ;;
     esac
 

--- a/lib/testrunner
+++ b/lib/testrunner
@@ -97,9 +97,10 @@ for i in "${ktest_make_install[@]}"; do
 	run_quiet "configure $(basename $i)" ./configure
     fi
     #bcachefs tools sometimes seems to use compiled files from previous runs, even if other architecture, so clean out:
-    [ "bcachefs-tools" == "$(basename $i)" ] && [ "$(objdump -f bcachefs.o | grep architecture | cut -d' ' -f 2)" == "$(objdump -f /bin/bash | grep architecture | cut -d' ' -f 2)" ] || make clean & rm -rf "rust-src/targets/*"
+    [ "bcachefs-tools" == "$(basename $i)" ] && [ "$(objdump -f libbcachefs.a | grep architecture | cut -d' ' -f 2)" == "$(objdump -f /bin/bash | grep architecture | cut -d' ' -f 2)" ] || make clean & rm -rf "rust-src/targets/*"
     run_quiet "building $(basename $i)" make -j $ktest_cpus
     run_quiet "installing $(basename $i)" make -j $ktest_cpus install
+    [ "bcachefs-tools" == "$(basename $i)" ] && echo $ktest_arch > .precompiled
     popd > /dev/null
 done
 

--- a/lib/testrunner
+++ b/lib/testrunner
@@ -89,6 +89,7 @@ if compgen -G "$ktest_tmp/*.deb" > /dev/null; then
 fi
 
 for i in "${ktest_make_install[@]}"; do
+    set -o xtrace
     pushd "/host/$i" > /dev/null
     if [[ -f autogen.sh && ! -f configure ]]; then
 	run_quiet "autogen $(basename $i)" ./autogen.sh
@@ -97,7 +98,7 @@ for i in "${ktest_make_install[@]}"; do
 	run_quiet "configure $(basename $i)" ./configure
     fi
     #bcachefs tools sometimes seems to use compiled files from previous runs, even if other architecture, so clean out:
-    [ "bcachefs-tools" == "$(basename $i)" ] && [ "$(objdump -f libbcachefs.a | grep architecture | cut -d' ' -f 2)" == "$(objdump -f /bin/bash | grep architecture | cut -d' ' -f 2)" ] || make clean & rm -rf "rust-src/targets/*"
+    [ "bcachefs-tools" == "$(basename $i)" ] && [ "$(objdump -f libbcachefs.o | grep architecture | cut -d' ' -f 2)" == "$(objdump -f /bin/bash | grep architecture | cut -d' ' -f 2)" ] || make clean & rm -rf "rust-src/targets/*"
     run_quiet "building $(basename $i)" make -j $ktest_cpus
     run_quiet "installing $(basename $i)" make -j $ktest_cpus install
     [ "bcachefs-tools" == "$(basename $i)" ] && echo $ktest_arch > .precompiled

--- a/lib/testrunner
+++ b/lib/testrunner
@@ -20,6 +20,10 @@ ktest_out="/host/$ktest_out"
 ln -sf $ktest_dir /ktest
 ln -sf $ktest_out /ktest-out
 
+. /ktest/lib/common.sh
+
+parse_arch $(uname -m)
+
 # Some home directories are in weird places:
 mkdir -p $(dirname $home)
 ln -sf /host/$home $home
@@ -92,7 +96,11 @@ for i in "${ktest_make_install[@]}"; do
     if [[ -f configure && ! -f Makefile ]]; then
 	run_quiet "configure $(basename $i)" ./configure
     fi
-    run_quiet "building $(basename $i)" make -j $ktest_cpus
+    #this won't make me popular - compiling bcachefs tools with rust support on a emulated machine is too heavy to be useful, so omit it:
+    rustcompile="" && [[ "$(systemd-detect-virt)" == "qemu" ]] && rustcompile="NO_RUST=1"
+    #bcachefs tools sometimes seems to use compiled files from previous runs, even if other architecture, so clean out:
+    [ "bcachefs-tools" == "$(basename $i)" ] && [ "$(objdump -f bcachefs.o | grep architecture | cut -d' ' -f 2)" == "$(objdump -f /bin/bash | grep architecture | cut -d' ' -f 2)" ] || make clean
+    run_quiet "building $(basename $i)" make $rustcompile -j $ktest_cpus
     run_quiet "installing $(basename $i)" make -j $ktest_cpus install
     popd > /dev/null
 done

--- a/lib/testrunner
+++ b/lib/testrunner
@@ -96,11 +96,9 @@ for i in "${ktest_make_install[@]}"; do
     if [[ -f configure && ! -f Makefile ]]; then
 	run_quiet "configure $(basename $i)" ./configure
     fi
-    #this won't make me popular - compiling bcachefs tools with rust support on a emulated machine is too heavy to be useful, so omit it:
-    rustcompile="" && [[ "$(systemd-detect-virt)" == "qemu" ]] && rustcompile="NO_RUST=1"
     #bcachefs tools sometimes seems to use compiled files from previous runs, even if other architecture, so clean out:
-    [ "bcachefs-tools" == "$(basename $i)" ] && [ "$(objdump -f bcachefs.o | grep architecture | cut -d' ' -f 2)" == "$(objdump -f /bin/bash | grep architecture | cut -d' ' -f 2)" ] || make clean
-    run_quiet "building $(basename $i)" make $rustcompile -j $ktest_cpus
+    [ "bcachefs-tools" == "$(basename $i)" ] && [ "$(objdump -f bcachefs.o | grep architecture | cut -d' ' -f 2)" == "$(objdump -f /bin/bash | grep architecture | cut -d' ' -f 2)" ] || make clean & rm -rf "rust-src/targets/*"
+    run_quiet "building $(basename $i)" make -j $ktest_cpus
     run_quiet "installing $(basename $i)" make -j $ktest_cpus install
     popd > /dev/null
 done

--- a/root_image
+++ b/root_image
@@ -34,7 +34,7 @@ usage()
     echo
     echo "options:"
     echo "  -h			Display this help and exit"
-    echo "  -a <arch>		Architecture for vm image"
+    echo "  -a <arch>		Architecture for vm image (x86_64,armhf,i386,aarch64,sparc64,ppc64,riscv64)"
     echo "  -m <mirror>		Debian mirror"
     echo '  -i <image>		Image to create/update, defaults to /var/lib/ktest/root.$arch'
 }
@@ -124,7 +124,7 @@ PACKAGES+=("linux-headers-generic")
 # DKMS needs to cross-compile the module,
 # against a different kernel on a different CPUarchitecture.
 # this has to cause errors
-[ -z ${CROSS_COMPILE:-0} ] || PACKAGES+=(dkms zfsutils-linux zfs-dkms)
+#[ -z ${CROSS_COMPILE:-0} ] || PACKAGES+=(dkms zfsutils-linux zfs-dkms)
 
 
 
@@ -232,9 +232,11 @@ update_packages()
     mkdir -p "$MNT"/run/user/0
     cp /etc/resolv.conf "$MNT/etc/resolv.conf"
     _chroot "$MNT" mount -t proc none /proc
-    _chroot "$MNT" apt-get -qq update
-    _chroot "$MNT" apt-get -qq upgrade
-    _chroot "$MNT" apt-get -qq install --no-install-recommends "${PACKAGES[@]}"
+    [[ $MIRROR == *"debian-ports"* ]] && _chroot "$MNT" apt-get -qq install debian-ports-archive-keyring
+    _chroot "$MNT" apt-get -qq --allow-unauthenticated --allow-insecure-repositories update --fix-missing
+    _chroot "$MNT" apt-get -qq --allow-unauthenticated upgrade
+    _chroot "$MNT" apt-get -qq install -f
+    _chroot "$MNT" apt-get -qq install -m --allow-unauthenticated --no-install-recommends "${PACKAGES[@]}"
     rm -f "$MNT/var/cache/apt/archives/*.deb"
 
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > "$MNT"/tmp/rustup.sh
@@ -300,18 +302,37 @@ cmd_create()
     mkfs.ext4 -F "$ktest_image"
     mount "$ktest_image" "$MNT"
 
+   local debian_release="trixie" #general release
+   local keyring=""
+
+    if [[ $MIRROR == *"debian-ports"* ]]; then
+	debian_release="sid" #unofficial ports don't have named releases
+        wget https://www.ports.debian.org/archive_$(date +%Y).key
+	gpg --import archive_$(date +%Y).key
+	rm archive_$(date +%Y).key
+	echo "WARNING: $ktest_arch is unsupported, using SID release for packages"
+	echo "*******************************************************************"
+	echo "PLEASE NOTE: this often has dependency problems between packages, "
+	echo "and can prevent the install due to a dependency conflict "
+	echo "If so, contact the debian maintainer for this architecture to fix it:"
+	echo "${ktest_arch} : ${DEBIAN_ARCH}@buildd.debian.org"
+	echo "*******************************************************************"
+	echo ""
+    fi
+
     DEBOOTSTRAP_DIR=$ktest_dir/debootstrap $debootstrap	\
 	--no-check-gpg					\
 	--arch="$DEBIAN_ARCH"				\
 	--exclude=$(join_by , "${EXCLUDE[@]}")		\
+	$keyring					\
 	--foreign					\
 	--components='main,contrib,non-free' \
-	trixie "$MNT" "$MIRROR"
+	$debian_release "$MNT" "$MIRROR"
 
-    [ ${CROSS_COMPILE:-0} == 1 ] && cp $(which qemu-${ktest_arch}) ${MNT}$(which qemu-${ktest_arch})
+    statichelper=$(which qemu-${ktest_arch}) || statichelper=$(which qemu-${ktest_arch}-static)
+    [ ${CROSS_COMPILE:-0} == 1 ] && cp $statichelper ${MNT}$statichelper
     _chroot "$MNT" /debootstrap/debootstrap --second-stage
     _chroot "$MNT" dpkg --configure -a
-
     update_packages
     update_files
 

--- a/root_image
+++ b/root_image
@@ -240,7 +240,7 @@ update_packages()
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > "$MNT"/tmp/rustup.sh
     chmod 755 "$MNT"/tmp/rustup.sh
 
-    _chroot "$MNT" /tmp/rustup.sh -y
+    _chroot "$MNT" /tmp/rustup.sh --default-host $RUST_TRIPLE -y
     echo 'export PATH="$HOME/.cargo/bin:$PATH"' > $MNT/etc/profile.d/rustup.sh
 }
 

--- a/root_image
+++ b/root_image
@@ -45,6 +45,7 @@ if [[ $# = 0 ]]; then
 fi
 
 ktest_image=""
+ktest_arch="$(uname -m)"
 CMD="cmd_$1"
 shift
 
@@ -100,7 +101,7 @@ PACKAGES+=(libudev-dev libldap2-dev)
 PACKAGES+=(acct bsdextrautils xfsprogs xfslibs-dev quota libcap2-bin)
 PACKAGES+=(libattr1-dev libaio-dev libgdbm-dev libacl1-dev gettext)
 PACKAGES+=(libssl-dev libgdbm-dev libgdbm-compat-dev liburing-dev)
-PACKAGES+=(duperemove thin-provisioning-tools fsverity)
+PACKAGES+=(duperemove fsverity)
 
 # xfsprogs:
 PACKAGES+=(libinih-dev)
@@ -123,10 +124,9 @@ PACKAGES+=("linux-headers-generic")
 # DKMS needs to cross-compile the module,
 # against a different kernel on a different CPUarchitecture.
 # this has to cause errors
-[ $CROSS_COMPILE == 1 ] || PACKAGES+=(dkms zfsutils-linux zfs-dkms)
+[ -z ${CROSS_COMPILE:-0} ] || PACKAGES+=(dkms zfsutils-linux zfs-dkms)
 
-# suspend testing:
-# [[ $KERNEL_ARCH = x86 ]] && PACKAGES+=(uswsusp)
+
 
 EXCLUDE=(dmidecode nano rsyslog logrotate cron		\
     iptables nfacct					\
@@ -241,6 +241,7 @@ update_packages()
     chmod 755 "$MNT"/tmp/rustup.sh
 
     _chroot "$MNT" /tmp/rustup.sh -y
+    echo 'export PATH="$HOME/.cargo/bin:$PATH"' > $MNT/etc/profile.d/rustup.sh
 }
 
 trim_image()
@@ -304,10 +305,10 @@ cmd_create()
 	--arch="$DEBIAN_ARCH"				\
 	--exclude=$(join_by , "${EXCLUDE[@]}")		\
 	--foreign					\
-	--components='main,contrib,non-free,bullseye-backports' \
-	bullseye "$MNT" "$MIRROR"
+	--components='main,contrib,non-free' \
+	trixie "$MNT" "$MIRROR"
 
-    [ ${CROSS_COMPILE} == 1 ] && cp $(which qemu-${ktest_arch}) ${MNT}$(which qemu-${ktest_arch})
+    [ ${CROSS_COMPILE:-0} == 1 ] && cp $(which qemu-${ktest_arch}) ${MNT}$(which qemu-${ktest_arch})
     _chroot "$MNT" /debootstrap/debootstrap --second-stage
     _chroot "$MNT" dpkg --configure -a
 

--- a/root_image
+++ b/root_image
@@ -34,9 +34,66 @@ usage()
     echo
     echo "options:"
     echo "  -h			Display this help and exit"
-    echo "  -a <arch>		Architecture for vm image (x86_64,armhf,i386,aarch64,sparc64,ppc64,riscv64)"
+    echo "  -a <arch>		Architecture for vm (x86_64,armhf,i386,aarch64,sparc64,s390x,ppc64,riscv64)"
     echo "  -m <mirror>		Debian mirror"
     echo '  -i <image>		Image to create/update, defaults to /var/lib/ktest/root.$arch'
+}
+
+intervene()
+{
+	local yn="N";
+	echo "Installing $2 failed: both binary install and $1";
+	echo "You can start a shell to check whether any dependency issues can be fixed"
+	echo "if you do, and exit the shell, it is assumed to be fixed and installing will continue"
+	read -p "Do you wish to start a shell to investigate? (y/N)" yn
+	case $yn in
+		[Yy]* )
+			_chroot "$MNT" /tmpbuild/executer.sh /bin/bash;
+		;;
+		* ) return 1;;
+	esac
+}
+
+install_fix_deps()
+{
+	trap 'echo "Could not install packages! please revert to the included torrent file to download a working root image"; umount $MNT/tmpbuild; umount_image; rm "$ktest_image"' EXIT
+	#get necessary certificates / pgp keyrings to work with unofficial and outdated snapshots
+	_chroot "$MNT" apt-get -qq install debian-ports-archive-keyring ca-certificates
+	#disable unwanted checks - we know the snapshots are not valid
+	echo "Acquire::Check-Valid-Until false;" > $MNT/etc/apt/apt.conf.d/10-nocheckvalid
+	#create a sources.list with more options to work around missing packages
+	echo 'deb [trusted=yes] http://deb.debian.org/debian-ports unstable main non-free' > $MNT/etc/apt/sources.list
+	echo 'deb-src [trusted=yes] http://deb.debian.org/debian-ports unstable main non-free' >> $MNT/etc/apt/sources.list
+	echo 'deb [trusted=yes] http://deb.debian.org/debian-ports unreleased main non-free' >> $MNT/etc/apt/sources.list
+	echo 'deb-src [trusted=yes] http://deb.debian.org/debian-ports unreleased main non-free' >> $MNT/etc/apt/sources.list
+	for i in "${SID_SNAPSHOTS[@]}"; do
+	echo "deb [trusted=yes] https://snapshot.debian.org/archive/debian-ports/$i sid main" >> $MNT/etc/apt/sources.list
+	echo "deb-src [trusted=yes] https://snapshot.debian.org/archive/debian-ports/$i sid main" >> $MNT/etc/apt/sources.list
+	done
+	echo "deb-src http://deb.debian.org/debian unstable main contrib non-free" >> $MNT/etc/apt/sources.list
+	touch $MNT/etc/passwd
+	touch $MNT/etc/shadow
+	_chroot "$MNT" apt-get -qq --allow-unauthenticated --allow-insecure-repositories update --fix-missing
+	_chroot "$MNT" apt-get -qq --allow-unauthenticated upgrade
+	_chroot "$MNT" apt-get -qq install -f
+	_chroot "$MNT" apt-get -qq install build-essential
+	#if we can install them all at once, do so, otherwise, try one by one
+	_chroot "$MNT" apt-get -qq install -m --allow-unauthenticated --no-install-recommends "${PACKAGES[@]}" || for i in "${PACKAGES[@]}"; do
+		if [[ ! $(_chroot "$MNT" apt-cache show $i | grep Version) == "" ]]; then
+		_chroot "$MNT" apt-get -qq install --allow-unauthenticated --no-install-recommends $i && continue;
+		fi
+		#installing binary failed.  Try to install from source.  Do it in a tmpfs folder so the image doesn't get overwhelmed:
+		mkdir ${MNT}/tmpbuild;
+		mount -t tmpfs none ${MNT}/tmpbuild;
+		echo '#!/bin/bash' > "$MNT"/tmpbuild/executer.sh
+		echo 'cd /tmpbuild/; $@' >> "$MNT"/tmpbuild/executer.sh
+		chmod ago+x "$MNT"/tmpbuild/executer.sh
+		_chroot "$MNT" /tmpbuild/executer.sh apt-get -qq build-dep --allow-unauthenticated --no-install-recommends $i || intervene install-deps $i;
+		_chroot "$MNT" /tmpbuild/executer.sh apt-get -qq -b source --allow-unauthenticated $i || intervene build $i;
+		[ -f "${MNT}/tmpbuild/${i}*.deb" ] && _chroot "$MNT" apt-get -qq install /tmpbuild/${i}*.deb;
+		umount ${MNT}/tmpbuild;
+		rmdir ${MNT}/tmpbuild;
+	done
 }
 
 if [[ $# = 0 ]]; then
@@ -124,12 +181,12 @@ PACKAGES+=("linux-headers-generic")
 # DKMS needs to cross-compile the module,
 # against a different kernel on a different CPUarchitecture.
 # this has to cause errors
-#[ -z ${CROSS_COMPILE:-0} ] || PACKAGES+=(dkms zfsutils-linux zfs-dkms)
+[ -z ${CROSS_COMPILE:-0} ] || PACKAGES+=(dkms zfsutils-linux zfs-dkms)
 
 
 
 EXCLUDE=(dmidecode nano rsyslog logrotate cron		\
-    iptables nfacct					\
+    iptables nfacct vim-tiny				\
     debconf-i18n info gnupg libpam-systemd)
 
 SYSTEMD_MASK=(dev-hvc0.device				\
@@ -232,11 +289,14 @@ update_packages()
     mkdir -p "$MNT"/run/user/0
     cp /etc/resolv.conf "$MNT/etc/resolv.conf"
     _chroot "$MNT" mount -t proc none /proc
-    [[ $MIRROR == *"debian-ports"* ]] && _chroot "$MNT" apt-get -qq install debian-ports-archive-keyring
+    if [[ $MIRROR == *"debian-ports"* ]]; then
+	install_fix_deps
+    else
     _chroot "$MNT" apt-get -qq --allow-unauthenticated --allow-insecure-repositories update --fix-missing
     _chroot "$MNT" apt-get -qq --allow-unauthenticated upgrade
     _chroot "$MNT" apt-get -qq install -f
     _chroot "$MNT" apt-get -qq install -m --allow-unauthenticated --no-install-recommends "${PACKAGES[@]}"
+    fi
     rm -f "$MNT/var/cache/apt/archives/*.deb"
 
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > "$MNT"/tmp/rustup.sh
@@ -292,11 +352,11 @@ cmd_create()
 	echo "$ktest_image already exists"
 	exit 1
     fi
-
+    set -o xtrace
     (cd "$ktest_dir"; git submodule update --init debootstrap)
 
     MNT=$(mktemp --tmpdir -d $(basename "$0")-XXXXXXXXXX)
-    trap 'umount_image; rm "$ktest_image"' EXIT
+    trap '/bin/bash; umount_image; rm "$ktest_image"' EXIT
 
     fallocate -l "$IMAGE_SIZE" "$ktest_image"
     mkfs.ext4 -F "$ktest_image"
@@ -307,9 +367,7 @@ cmd_create()
 
     if [[ $MIRROR == *"debian-ports"* ]]; then
 	debian_release="sid" #unofficial ports don't have named releases
-        wget https://www.ports.debian.org/archive_$(date +%Y).key
-	gpg --import archive_$(date +%Y).key
-	rm archive_$(date +%Y).key
+	echo ""
 	echo "WARNING: $ktest_arch is unsupported, using SID release for packages"
 	echo "*******************************************************************"
 	echo "PLEASE NOTE: this often has dependency problems between packages, "

--- a/root_image
+++ b/root_image
@@ -292,9 +292,8 @@ update_packages()
     # systemd... !?
     mkdir -p "$MNT"/run/user/0
     cp /etc/resolv.conf "$MNT/etc/resolv.conf"
-
-    [[ $(curl -qq -I "https://static.rust-lang.org/rustup/${RUST_TRIPLE}/rustup-init" 2>/dev/null | grep "HTTP/2 200") == "" ]] && NO_RUSTUP=1
-    [ $NO_RUSTUP ] && PACKAGES+=(rustc rustc-dbgsym rustfmt rustfmt-dbgsym) #don't do rustup on unsupported architectures, just try from debian repositories
+    [[ $(curl -qq -I "https://static.rust-lang.org/rustup/dist/${RUST_TRIPLE}/rustup-init" 2>/dev/null | grep "HTTP/2 200") == "" ]] && NO_RUSTUP=1
+    [ $NO_RUSTUP == "1" ] && PACKAGES+=(rustc rustc-dbgsym rustfmt rustfmt-dbgsym) #don't do rustup on unsupported architectures, just try from debian repositories
 
     _chroot "$MNT" mount -t proc none /proc
     if [[ $MIRROR == *"debian-ports"* ]]; then
@@ -307,12 +306,12 @@ update_packages()
     fi
     rm -f "$MNT/var/cache/apt/archives/*.deb"
 
-    if [ ! $NO_RUSTUP ]; then
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > "$MNT"/tmp/rustup.sh
-    chmod 755 "$MNT"/tmp/rustup.sh
+    if [ $NO_RUSTUP == "0" ]; then
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > "$MNT"/tmp/rustup.sh
+	chmod 755 "$MNT"/tmp/rustup.sh
 
-    _chroot "$MNT" /tmp/rustup.sh --default-host $RUST_TRIPLE -y
-    echo 'export PATH="$HOME/.cargo/bin:$PATH"' > $MNT/etc/profile.d/rustup.sh
+	_chroot "$MNT" /tmp/rustup.sh --default-host ${RUST_TRIPLE} -y
+	echo 'export PATH="$HOME/.cargo/bin:$PATH"' > $MNT/etc/profile.d/rustup.sh
     fi;
 }
 

--- a/root_image
+++ b/root_image
@@ -89,8 +89,11 @@ install_fix_deps()
 		echo 'cd /tmpbuild/; $@' >> "$MNT"/tmpbuild/executer.sh
 		chmod ago+x "$MNT"/tmpbuild/executer.sh
 		_chroot "$MNT" /tmpbuild/executer.sh apt-get -qq build-dep --allow-unauthenticated --no-install-recommends $i || intervene install-deps $i;
-		_chroot "$MNT" /tmpbuild/executer.sh apt-get -qq -b source --allow-unauthenticated $i || intervene build $i;
-		[ -f "${MNT}/tmpbuild/${i}*.deb" ] && _chroot "$MNT" apt-get -qq install /tmpbuild/${i}*.deb;
+		#in case the intervention also installed it, continue:
+		if [[ $(_chroot "$MNT" dpkg -l | grep "^ii  $i") == "" ]]; then
+			_chroot "$MNT" /tmpbuild/executer.sh apt-get -qq -b source --allow-unauthenticated $i || intervene build $i;
+			[ -f "${MNT}/tmpbuild/${i}*.deb" ] && _chroot "$MNT" apt-get -qq install /tmpbuild/${i}*.deb;
+		fi
 		umount ${MNT}/tmpbuild;
 		rmdir ${MNT}/tmpbuild;
 	done
@@ -285,25 +288,32 @@ ZZ
 
 update_packages()
 {
+    NO_RUSTUP=0
     # systemd... !?
     mkdir -p "$MNT"/run/user/0
     cp /etc/resolv.conf "$MNT/etc/resolv.conf"
+
+    [[ $(curl -qq -I "https://static.rust-lang.org/rustup/${RUST_TRIPLE}/rustup-init" 2>/dev/null | grep "HTTP/2 200") == "" ]] && NO_RUSTUP=1
+    [ $NO_RUSTUP ] && PACKAGES+=(rustc rustc-dbgsym rustfmt rustfmt-dbgsym) #don't do rustup on unsupported architectures, just try from debian repositories
+
     _chroot "$MNT" mount -t proc none /proc
     if [[ $MIRROR == *"debian-ports"* ]]; then
 	install_fix_deps
     else
-    _chroot "$MNT" apt-get -qq --allow-unauthenticated --allow-insecure-repositories update --fix-missing
-    _chroot "$MNT" apt-get -qq --allow-unauthenticated upgrade
-    _chroot "$MNT" apt-get -qq install -f
-    _chroot "$MNT" apt-get -qq install -m --allow-unauthenticated --no-install-recommends "${PACKAGES[@]}"
+	_chroot "$MNT" apt-get -qq --allow-unauthenticated --allow-insecure-repositories update --fix-missing
+    	_chroot "$MNT" apt-get -qq --allow-unauthenticated upgrade
+    	_chroot "$MNT" apt-get -qq install -f
+    	_chroot "$MNT" apt-get -qq install -m --allow-unauthenticated --no-install-recommends "${PACKAGES[@]}"
     fi
     rm -f "$MNT/var/cache/apt/archives/*.deb"
 
+    if [ ! $NO_RUSTUP ]; then
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > "$MNT"/tmp/rustup.sh
     chmod 755 "$MNT"/tmp/rustup.sh
 
     _chroot "$MNT" /tmp/rustup.sh --default-host $RUST_TRIPLE -y
     echo 'export PATH="$HOME/.cargo/bin:$PATH"' > $MNT/etc/profile.d/rustup.sh
+    fi;
 }
 
 trim_image()
@@ -352,7 +362,6 @@ cmd_create()
 	echo "$ktest_image already exists"
 	exit 1
     fi
-    set -o xtrace
     (cd "$ktest_dir"; git submodule update --init debootstrap)
 
     MNT=$(mktemp --tmpdir -d $(basename "$0")-XXXXXXXXXX)

--- a/root_image
+++ b/root_image
@@ -118,7 +118,7 @@ PACKAGES+=(cryptsetup)
 PACKAGES+=(multipath-tools sg3-utils srptools)
 
 # ZFS support
-PACKAGES+=("linux-headers-$DEBIAN_ARCH" dkms zfsutils-linux zfs-dkms)
+PACKAGES+=("linux-headers-generic" dkms zfsutils-linux zfs-dkms)
 
 # suspend testing:
 # [[ $KERNEL_ARCH = x86 ]] && PACKAGES+=(uswsusp)

--- a/root_image
+++ b/root_image
@@ -118,7 +118,12 @@ PACKAGES+=(cryptsetup)
 PACKAGES+=(multipath-tools sg3-utils srptools)
 
 # ZFS support
-PACKAGES+=("linux-headers-generic" dkms zfsutils-linux zfs-dkms)
+PACKAGES+=("linux-headers-generic")
+# unless no other option when cross-compiling, ignore ZFS
+# DKMS needs to cross-compile the module,
+# against a different kernel on a different CPUarchitecture.
+# this has to cause errors
+[ $CROSS_COMPILE == 1 ] || PACKAGES+=(dkms zfsutils-linux zfs-dkms)
 
 # suspend testing:
 # [[ $KERNEL_ARCH = x86 ]] && PACKAGES+=(uswsusp)
@@ -302,6 +307,7 @@ cmd_create()
 	--components='main,contrib,non-free,bullseye-backports' \
 	bullseye "$MNT" "$MIRROR"
 
+    [ ${CROSS_COMPILE} == 1 ] && cp $(which qemu-${ktest_arch}) ${MNT}$(which qemu-${ktest_arch})
     _chroot "$MNT" /debootstrap/debootstrap --second-stage
     _chroot "$MNT" dpkg --configure -a
 

--- a/tests/bcachefs/bcachefs-test-libs.sh
+++ b/tests/bcachefs/bcachefs-test-libs.sh
@@ -15,7 +15,11 @@ if [[ ! -v NO_BCACHEFS_DEBUG ]]; then
     require-kernel-config BCACHEFS_DEBUG
 fi
 
+if [[ ! $ktest_arch == ppc64 ]]; then
+
 require-kernel-config TRANSPARENT_HUGEPAGE
+
+fi
 
 if [[ $ktest_arch = x86_64 ]]; then
     require-kernel-config CRYPTO_CRC32C_INTEL

--- a/tests/bcachefs/gcov-base.sh
+++ b/tests/bcachefs/gcov-base.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
+
+require-gcov fs/bcachefs
+
+call_base_test gcov "$@"

--- a/tests/bcachefs/gcov-ec.ktest
+++ b/tests/bcachefs/gcov-ec.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ec.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-quota.ktest
+++ b/tests/bcachefs/gcov-quota.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/quota.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-replication.ktest
+++ b/tests/bcachefs/gcov-replication.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/replication.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-single_device.ktest
+++ b/tests/bcachefs/gcov-single_device.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/single_device.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-subvol.ktest
+++ b/tests/bcachefs/gcov-subvol.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/subvol.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-tier.ktest
+++ b/tests/bcachefs/gcov-tier.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/tier.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-units.ktest
+++ b/tests/bcachefs/gcov-units.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/units.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-xfstests-nocow.ktest
+++ b/tests/bcachefs/gcov-xfstests-nocow.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests-nocow.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/gcov-xfstests.ktest
+++ b/tests/bcachefs/gcov-xfstests.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-gcov fs/bcachefs
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/gcov-base.sh

--- a/tests/bcachefs/lockdep-kasan-base.sh
+++ b/tests/bcachefs/lockdep-kasan-base.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
+
+config-timeout-multiplier 3
+
+require-kernel-config PROVE_LOCKING
+require-kernel-config LOCKDEP_BITS=20
+require-kernel-config LOCKDEP_CHAINS_BITS=20
+
+require-kernel-config DEBUG_ATOMIC_SLEEP
+require-kernel-config PREEMPT
+require-kernel-config DEBUG_PREEMPT
+
+require-kernel-config KASAN
+require-kernel-config KASAN_VMALLOC
+
+call_base_test lockdep-kasan "$@"

--- a/tests/bcachefs/lockdep-kasan-ec.ktest
+++ b/tests/bcachefs/lockdep-kasan-ec.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ec.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-quota.ktest
+++ b/tests/bcachefs/lockdep-kasan-quota.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/quota.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-replication.ktest
+++ b/tests/bcachefs/lockdep-kasan-replication.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/replication.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-single_device.ktest
+++ b/tests/bcachefs/lockdep-kasan-single_device.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/single_device.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-subvol.ktest
+++ b/tests/bcachefs/lockdep-kasan-subvol.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/subvol.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-tier.ktest
+++ b/tests/bcachefs/lockdep-kasan-tier.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/tier.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-units.ktest
+++ b/tests/bcachefs/lockdep-kasan-units.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/units.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-xfstests-nocow.ktest
+++ b/tests/bcachefs/lockdep-kasan-xfstests-nocow.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests-nocow.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/lockdep-kasan-xfstests.ktest
+++ b/tests/bcachefs/lockdep-kasan-xfstests.ktest
@@ -1,15 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-config-timeout-multiplier 3
-
-require-kernel-config PROVE_LOCKING
-require-kernel-config LOCKDEP_BITS=20
-require-kernel-config LOCKDEP_CHAINS_BITS=20
-require-kernel-config DEBUG_ATOMIC_SLEEP
-require-kernel-config KASAN
-require-kernel-config PREEMPT
-require-kernel-config DEBUG_PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/lockdep-kasan-base.sh

--- a/tests/bcachefs/nodebug-base.sh
+++ b/tests/bcachefs/nodebug-base.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
+
+require-kernel-config PREEMPT
+export NO_BCACHEFS_DEBUG=1
+
+call_base_test nodebug "$@"

--- a/tests/bcachefs/nodebug-ec.ktest
+++ b/tests/bcachefs/nodebug-ec.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ec.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-quota.ktest
+++ b/tests/bcachefs/nodebug-quota.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/quota.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-replication.ktest
+++ b/tests/bcachefs/nodebug-replication.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/replication.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-single_device.ktest
+++ b/tests/bcachefs/nodebug-single_device.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/single_device.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-subvol.ktest
+++ b/tests/bcachefs/nodebug-subvol.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/subvol.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-tier.ktest
+++ b/tests/bcachefs/nodebug-tier.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/tier.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-units.ktest
+++ b/tests/bcachefs/nodebug-units.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/units.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-xfstests-nocow.ktest
+++ b/tests/bcachefs/nodebug-xfstests-nocow.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests-nocow.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/nodebug-xfstests.ktest
+++ b/tests/bcachefs/nodebug-xfstests.ktest
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-export NO_BCACHEFS_DEBUG=1
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/nodebug-base.sh

--- a/tests/bcachefs/preempt-base.sh
+++ b/tests/bcachefs/preempt-base.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
+
+require-kernel-config PREEMPT
+
+call_base_test preempt "$@"

--- a/tests/bcachefs/preempt-ec.ktest
+++ b/tests/bcachefs/preempt-ec.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ec.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-quota.ktest
+++ b/tests/bcachefs/preempt-quota.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/quota.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-replication.ktest
+++ b/tests/bcachefs/preempt-replication.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/replication.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-single_device.ktest
+++ b/tests/bcachefs/preempt-single_device.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/single_device.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-subvol.ktest
+++ b/tests/bcachefs/preempt-subvol.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/subvol.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-tier.ktest
+++ b/tests/bcachefs/preempt-tier.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/tier.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-units.ktest
+++ b/tests/bcachefs/preempt-units.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/units.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-xfstests-nocow.ktest
+++ b/tests/bcachefs/preempt-xfstests-nocow.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests-nocow.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/preempt-xfstests.ktest
+++ b/tests/bcachefs/preempt-xfstests.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config PREEMPT
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/preempt-base.sh

--- a/tests/bcachefs/single_device.ktest
+++ b/tests/bcachefs/single_device.ktest
@@ -679,6 +679,15 @@ test_crc64()
 	${ktest_scratch_dev[0]}
 }
 
+test_xxhash()
+{
+    run_basic_fio_test                         \
+       --metadata_checksum=xxhash              \
+       --data_checksum=xxhash                  \
+       ${ktest_scratch_dev[0]}
+}
+
+
 test_crypto_locked_mnt()
 {
     echo foo|bcachefs format --encrypted ${ktest_scratch_dev[0]}

--- a/tests/bcachefs/ubsan-base.sh
+++ b/tests/bcachefs/ubsan-base.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
+
+require-kernel-config UBSAN
+
+call_base_test ubsan "$@"

--- a/tests/bcachefs/ubsan-ec.ktest
+++ b/tests/bcachefs/ubsan-ec.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ec.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-quota.ktest
+++ b/tests/bcachefs/ubsan-quota.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/quota.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-replication.ktest
+++ b/tests/bcachefs/ubsan-replication.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/replication.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-single_device.ktest
+++ b/tests/bcachefs/ubsan-single_device.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/single_device.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-subvol.ktest
+++ b/tests/bcachefs/ubsan-subvol.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/subvol.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-tier.ktest
+++ b/tests/bcachefs/ubsan-tier.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/tier.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-units.ktest
+++ b/tests/bcachefs/ubsan-units.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/units.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-xfstests-nocow.ktest
+++ b/tests/bcachefs/ubsan-xfstests-nocow.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests-nocow.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/bcachefs/ubsan-xfstests.ktest
+++ b/tests/bcachefs/ubsan-xfstests.ktest
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/../test-libs.sh
-
-require-kernel-config UBSAN
-
-. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/xfstests.ktest
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/ubsan-base.sh

--- a/tests/kconfig.sh
+++ b/tests/kconfig.sh
@@ -4,6 +4,8 @@ have_kvmguest=0
 have_virtio=0
 have_suspend=0
 
+[ -z ${ktest_arch:+x} ] && ktest_arch=$(uname -m)
+
 case $ktest_arch in
     x86)
 	require-kernel-config SMP

--- a/tests/kconfig.sh
+++ b/tests/kconfig.sh
@@ -68,24 +68,29 @@ case $ktest_arch in
 
 	require-kernel-append console=hvc0
 	;;
-    powerpc)
-	require-kernel-config ADVANCED_OPTIONS
+    ppc64)
+	require-kernel-config PPC64
 
-	have_kvmguest=1
 	have_virtio=1
-	have_suspend=1
 
 	require-kernel-append console=hvc0
 	;;
-    mips)
-	require-kernel-config MIPS_MALTA
-	require-kernel-config CPU_MIPS${BITS}_R2
-	require-kernel-config CPU_BIG_ENDIAN=y
-	require-kernel-config CPU_LITTLE_ENDIAN=n
-	require-kernel-config 32BIT
+    sparc64)
+	require-kernel-config 64BIT
+	require-kernel-config SMP
+	require-kernel-config VIRTIO_MENU
+	require-kernel-config PCI
 
 	have_virtio=1
-	ktest_storage_bus=piix4-ide
+
+	require-kernel-append console=hvc0
+	;;
+    riscv64)
+	require-kernel-config SOC_VIRT
+	require-kernel-config VIRTIO_MENU
+	require-kernel-config PCI
+
+	have_virtio=1
 
 	require-kernel-append console=hvc0
 	;;

--- a/tests/kconfig.sh
+++ b/tests/kconfig.sh
@@ -68,8 +68,14 @@ case $ktest_arch in
 
 	require-kernel-append console=hvc0
 	;;
+
     ppc64)
 	require-kernel-config PPC64
+	require-kernel-config PPC_BOOK3E_64
+	require-kernel-config PPC_QEMU_E500
+	require-kernel-config E6500_CPU
+	require-kernel-config SMP
+	require-kernel-config KVM_GUEST
 
 	have_virtio=1
 
@@ -78,7 +84,6 @@ case $ktest_arch in
     sparc64)
 	require-kernel-config 64BIT
 	require-kernel-config SMP
-	require-kernel-config VIRTIO_MENU
 	require-kernel-config PCI
 
 	have_virtio=1
@@ -89,6 +94,17 @@ case $ktest_arch in
 	require-kernel-config SOC_VIRT
 	require-kernel-config VIRTIO_MENU
 	require-kernel-config PCI
+
+	have_virtio=1
+
+	require-kernel-append console=hvc0
+	;;
+    s390x)
+	require-kernel-config S390_GUEST
+	require-kernel-config MARCH_Z13
+	require-kernel-config CMM
+	require-kernel-config PCI
+	require-kernel-config DCSSBLK
 
 	have_virtio=1
 
@@ -182,13 +198,15 @@ require-kernel-config PCI
 require-kernel-config HW_RANDOM
 
 # Clock:
+if [[ ! $ktest_arch == *"s390"* ]]; then
 require-kernel-config RTC_CLASS
 require-kernel-config RTC_HCTOSYS
-
+fi
 # Console:
+if [[ ! $ktest_arch == *"s390"* ]]; then
 require-kernel-config SERIAL_8250	# XXX can probably drop
 require-kernel-config SERIAL_8250_CONSOLE
-
+fi
 # Block devices:
 require-kernel-config SCSI
 require-kernel-config SCSI_LOWLEVEL	# what's this for?
@@ -229,8 +247,10 @@ require-kernel-config 9P_FS
 #fi
 
 # KGDB:
+if [[ ! $ktest_arch == *"s390"* ]]; then
 require-kernel-config KGDB
 require-kernel-config KGDB_SERIAL_CONSOLE
+fi
 require-kernel-config VMAP_STACK=n
 require-kernel-config RANDOMIZE_BASE=n
 require-kernel-config RANDOMIZE_MEMORY=n
@@ -253,7 +273,9 @@ require-kernel-config FUNCTION_TRACER
 #require-kernel-config ENABLE_DEFAULT_TRACERS
 
 require-kernel-config PANIC_ON_OOPS
+if [[ ! $ktest_arch == *"s390"* ]]; then
 require-kernel-config SOFTLOCKUP_DETECTOR
+fi
 require-kernel-config DETECT_HUNG_TASK
 #require-kernel-config DEFAULT_HUNG_TASK_TIMEOUT=30
 require-kernel-config WQ_WATCHDOG

--- a/tests/kconfig.sh
+++ b/tests/kconfig.sh
@@ -55,7 +55,6 @@ case $ktest_arch in
 	require-kernel-config RTC_DRV_PL031
 
 	have_virtio=1
-	have_kvmguest=1
 
 	require-kernel-append console=hvc0
 	;;
@@ -63,9 +62,9 @@ case $ktest_arch in
 	require-kernel-config PCI_HOST_GENERIC
 	require-kernel-config RTC_DRV_PL031
 	require-kernel-config COMPAT_32BIT_TIME
+	require-kernel-config IOMMU_SUPPORT
 
 	have_virtio=1
-	have_kvmguest=1
 
 	require-kernel-append console=hvc0
 	;;

--- a/tests/kconfig.sh
+++ b/tests/kconfig.sh
@@ -12,6 +12,7 @@ case $ktest_arch in
 	require-kernel-config MCORE2	# optimize for core2
 	require-kernel-config IO_DELAY_0XED
 	require-kernel-config 64BIT=n
+	require-kernel-config COMPAT_32BIT_TIME
 	require-kernel-config ACPI	# way slower without it, do not know why
 	require-kernel-config UNWINDER_FRAME_POINTER
 	require-kernel-config HARDLOCKUP_DETECTOR
@@ -40,11 +41,31 @@ case $ktest_arch in
 
 	require-kernel-append console=hvc0
 	;;
-    aarch64)
+    arm)
+	require-kernel-config ARCH_VIRT
+	require-kernel-config SMP
+	require-kernel-config VFP
+	require-kernel-config NEON
+	require-kernel-config ARM_LPAE
+	require-kernel-config MMU
+	require-kernel-config HAVE_PCI
 	require-kernel-config PCI_HOST_GENERIC
+	require-kernel-config ARM_AMBA
+	require-kernel-config COMPAT_32BIT_TIME
 	require-kernel-config RTC_DRV_PL031
 
 	have_virtio=1
+	have_kvmguest=1
+
+	require-kernel-append console=hvc0
+	;;
+    aarch64)
+	require-kernel-config PCI_HOST_GENERIC
+	require-kernel-config RTC_DRV_PL031
+	require-kernel-config COMPAT_32BIT_TIME
+
+	have_virtio=1
+	have_kvmguest=1
 
 	require-kernel-append console=hvc0
 	;;
@@ -70,7 +91,7 @@ case $ktest_arch in
 	require-kernel-append console=hvc0
 	;;
     *)
-	echo "Kernel architecture not supported by kconfig.sh"
+	echo "Kernel architecture $ktest_arch not supported by kconfig.sh"
 	exit 1
 	;;
 esac
@@ -94,8 +115,6 @@ require-kernel-config BINFMT_ELF
 require-kernel-config BINFMT_SCRIPT
 
 require-kernel-config COMPACTION	# virtfs doesn't do well without it
-
-require-kernel-config PROC_KCORE	# XXX Needed?
 
 require-kernel-config TTY
 require-kernel-config VT

--- a/tests/prelude.sh
+++ b/tests/prelude.sh
@@ -273,7 +273,7 @@ list_tests()
 
 main()
 {
-    if [[ $BASH_ARGC = 0 ]]; then
+    if [[ $# = 0 ]]; then
 	exit 0
     fi
 

--- a/tests/prelude.sh
+++ b/tests/prelude.sh
@@ -14,9 +14,9 @@ if [[ ! -v ktest_verbose ]]; then
     ktest_kernel_make_append=()
 
     # virtio-scsi-pci semes to be buggy: reading the superblock on the root
-    # filesystem randomly returns zeroes
-    #ktest_storage_bus=virtio-scsi-pci
-    ktest_storage_bus=virtio-blk
+    # filesystem randomly returns zeroes.  nonetherless, it's the most supported architecture (for now)
+    ktest_storage_bus=virtio-scsi-pci
+    #ktest_storage_bus=virtio-blk
     ktest_images=()
 
     ktest_scratch_dev=()

--- a/tests/test-libs.sh
+++ b/tests/test-libs.sh
@@ -95,3 +95,12 @@ stress_timeout()
 {
     echo $((($ktest_priority + 3) * 600))
 }
+
+call_base_test()
+{
+    fname=$(basename ${BASH_SOURCE[2]})
+    fname=${fname#$1-}
+    shift
+
+    . $(dirname $(readlink -e ${BASH_SOURCE[2]}))/$fname
+}

--- a/tests/test-libs.sh
+++ b/tests/test-libs.sh
@@ -7,9 +7,9 @@
 . $(dirname $(readlink -e ${BASH_SOURCE[0]}))/prelude.sh
 . $(dirname $(readlink -e ${BASH_SOURCE[0]}))/kconfig.sh
 
-config-mem 4G
+config-mem 8G
 
-(($ktest_cpus > 16)) && ktest_cpus=16
+(($ktest_cpus > 8)) && ktest_cpus=8
 
 # Usage:
 # setup_tracing tracepoint_glob


### PR DESCRIPTION
this allows to run bcachefs tests on a non-native CPU (which has to be emulated using tcg).
Currently, only 3 architectures (aarch64,x86 and x86_64) are supported,
but more should be following soon