### PR TITLE
Initial Lustre support

### DIFF
--- a/build-test-kernel
+++ b/build-test-kernel
@@ -176,7 +176,12 @@ kernel_opt()
 
 	    if [[ $c != $val ]]; then
 		echo "Kernel config option $opt is $c; should be $val"
-		ret=1
+
+		# If the current kernel doesn't have the option available,
+		# don't fail
+		if [[ $(cd $ktest_kernel_source; git grep "CONFIG_$opt") ]]; then
+		    ret=1
+		fi
 	    fi
 	    ;;
     esac

--- a/lib/testrunner
+++ b/lib/testrunner
@@ -132,7 +132,7 @@ check_taint()
 {
     read taint < /proc/sys/kernel/tainted
 
-    if [[ $taint != 0 ]]; then
+    if [[ $taint != 0 && ! $ktest_allow_taint ]]; then
 	echo "Failure because kernel tainted - check log for warnings"
 	echo "TEST FAILED"
 	exit 0

--- a/lib/testrunner
+++ b/lib/testrunner
@@ -98,6 +98,10 @@ for i in "${ktest_make_install[@]}"; do
     popd > /dev/null
 done
 
+# Update hosts file
+local_ip=$(ip address show eth0 | awk -F' ' '$1 == "inet" { print $2 }' | awk -F'/' '{ print $1 }')
+echo "$local_ip" "$(hostname)" >> /etc/hosts
+
 get_stratch_devs()
 {
     echo

--- a/root_image
+++ b/root_image
@@ -136,6 +136,9 @@ PACKAGES+=(capnproto jq)
 # ZFS support
 #PACKAGES+=("linux-headers-generic" dkms zfsutils-linux zfs-dkms)
 
+# Lustre support
+PACKAGES+=(libyaml-0-2 libyaml-dev)
+
 # suspend testing:
 # [[ $KERNEL_ARCH = x86 ]] && PACKAGES+=(uswsusp)
 

--- a/root_image
+++ b/root_image
@@ -31,6 +31,7 @@ usage()
     echo "Usage: root_image cmd [options]"
     echo "  create		Create a new image"
     echo "  update		Update an existing image"
+    echo "  sync		Copy directory to an existing image"
     echo
     echo "options:"
     echo "  -h			Display this help and exit"
@@ -291,6 +292,31 @@ cmd_update()
 
     update_packages
     update_files
+
+    umount_image
+    trim_image "$ktest_image".new
+    mv "$ktest_image".new "$ktest_image"
+}
+
+cmd_sync()
+{
+    local source="${1:-$(pwd)/}"
+    local source_dir="$(basename "$source")"
+
+    if [[ ! -e "$ktest_image" ]]; then
+	echo "$ktest_image does not exist"
+	exit 1
+    fi
+
+    MNT="$(mktemp --tmpdir -d $(basename "$0")-XXXXXXXXXX)"
+    trap 'umount_image' EXIT
+
+    cp "$ktest_image" "$ktest_image".new
+    mount "$ktest_image".new "$MNT"
+
+    rm -rf "$MNT/workspace/$source_dir"
+    mkdir -p "$MNT/workspace/$source_dir"
+    rsync --archive -r "$source" "$MNT/workspace/$source_dir"
 
     umount_image
     trim_image "$ktest_image".new

--- a/tests/fs/lustre/llmount.ktest
+++ b/tests/fs/lustre/llmount.ktest
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0
+
+#
+# Copyright (c) 2024, Amazon and/or its affiliates. All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Run a simple mount test (client and server). This currently
+# only works with ZFS.
+#
+# Author: Timothy Day <timday@amazon.com>
+#
+
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/lustre-libs.sh"
+
+require-kernel-config QUOTA
+require-kernel-config KEYS
+require-kernel-config NETWORK_FILESYSTEMS
+require-kernel-config MULTIUSER
+require-kernel-config NFS_FS
+require-kernel-config BITREVERSE
+require-kernel-config CRYPTO_DEFLATE
+require-kernel-config ZLIB_DEFLATE
+require-kernel-config KASAN
+require-kernel-config KASAN_VMALLOC
+
+config-mem 10G
+config-timeout 60
+
+test_llmount()
+{
+    load_zfs_modules
+
+    "$lustre_pkg_path/lustre/tests/llmount.sh"
+}
+
+main "$@"

--- a/tests/fs/lustre/lustre-libs.sh
+++ b/tests/fs/lustre/lustre-libs.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0
+
+#
+# Copyright (c) 2024, Amazon and/or its affiliates. All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Library for writing Lustre tests in the ktest format.
+#
+# Author: Timothy Day <timday@amazon.com>
+#
+
+. "$(dirname "$(dirname "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")")")/test-libs.sh"
+
+# Currently, other packages must be in the same directory
+# as the kernel source and ktest
+export workspace_path="/workspace"
+export lustre_pkg_path="$workspace_path/lustre-release"
+export zfs_pkg_path="$workspace_path/zfs"
+
+function load_zfs_modules()
+{
+    insmod "$zfs_pkg_path/module/spl/spl.ko"
+    insmod "$zfs_pkg_path/module/zstd/zzstd.ko"
+    insmod "$zfs_pkg_path/module/unicode/zunicode.ko"
+    insmod "$zfs_pkg_path/module/avl/zavl.ko"
+    insmod "$zfs_pkg_path/module/lua/zlua.ko"
+    insmod "$zfs_pkg_path/module/nvpair/znvpair.ko"
+    insmod "$zfs_pkg_path/module/zcommon/zcommon.ko"
+    insmod "$zfs_pkg_path/module/icp/icp.ko"
+    insmod "$zfs_pkg_path/module/zfs/zfs.ko"
+}
+
+# Set Lustre test-framework.sh environment
+export ZFS="$zfs_pkg_path/cmd/zfs/zfs"
+export ZPOOL="$zfs_pkg_path/cmd/zpool/zpool"
+export FSTYPE="zfs"
+
+# Update paths
+set +u
+export PATH="$zfs_pkg_path/cmd/zpool:$zfs_pkg_path/cmd/zfs:$PATH"
+export LD_LIBRARY_PATH="$zfs_pkg_path/lib/libzfs/.libs:$zfs_pkg_path/lib/libzfs_core/.libs:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$zfs_pkg_path/lib/libuutil/.libs:$zfs_pkg_path/lib/libnvpair/.libs:$LD_LIBRARY_PATH"
+set -u
+
+# Lustre/ZFS will always taint kernel
+allow_taint

--- a/tests/prelude.sh
+++ b/tests/prelude.sh
@@ -28,6 +28,7 @@ if [[ ! -v ktest_verbose ]]; then
     ktest_kernel_config_require=()
     ktest_qemu_append=()
     ktest_compiler=gcc
+    ktest_allow_taint=false
 
     BUILD_ON_HOST=""
 fi
@@ -203,6 +204,11 @@ config-compiler()
     ktest_compiler=$1
 }
 
+allow_taint()
+{
+    ktest_allow_taint=true
+}
+
 set_watchdog()
 {
     ktest_timeout=$(($ktest_timeout_multiplier * $1))
@@ -314,6 +320,7 @@ main()
 	    echo "ktest_make_install=(${ktest_make_install[@]})"
 	    echo "ktest_kernel_config_require=(${ktest_kernel_config_require[@]})"
 	    echo "ktest_qemu_append=(${ktest_qemu_append[@]})"
+	    echo "ktest_allow_taint=$ktest_allow_taint"
 	    ;;
 	list-tests)
 	    list_tests


### PR DESCRIPTION
I've tried to write this in a way that isn't super Lustre specific. So far I've added only a simple test to run `llmount.sh` script from the Lustre tree - this sets up a toy Lustre filesystem and client. Right now, this only supports ZFS - I need to find a way to pass arguments to a ktest to make it configurable.

The current workflow looks something like:
```
cd ~/zfs/; ./autogen.sh && ./configure && make
sudo root_image sync ~/zfs

cd ~/lustre-release/; ./autogen.sh && ./configure && make
sudo root_image sync ~/lustre-release

cd ~/linux/
build_test_kernel run ~/ktest/tests/lustre/llmount.ktest
```
I prefer copying over directly read/writing from host filesystem to avoid the risk of corrupting the Lustre/ZFS git repositories. I'm open to other ideas.