### PR TITLE
Minor updates

### DIFF
--- a/root_image
+++ b/root_image
@@ -110,9 +110,6 @@ PACKAGES+=(duperemove fsverity)
 # xfsprogs:
 PACKAGES+=(libinih-dev)
 
-# bcachefs:
-PACKAGES+=(bcachefs-tools)
-
 # nfs testing:
 PACKAGES+=(nfs-kernel-server)
 

--- a/tests/fs/lustre/boot.ktest
+++ b/tests/fs/lustre/boot.ktest
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0
+
+#
+# Copyright (c) 2024, Amazon and/or its affiliates. All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Just boot using the Lustre kernel config
+#
+# Author: Timothy Day <timday@amazon.com>
+#
+
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/lustre-libs.sh"
+
+require-lustre-kernel-config
+require-lustre-debug-kernel-config
+
+config-mem 10G
+config-timeout 60
+
+test_llmount()
+{
+    echo boot
+}
+
+main "$@"


### PR DESCRIPTION
I noticed that bcachefs-tools got dropped from Debian - it caused an install failure when setting up ktest on my laptop. I saw you had a patch to build it when running interactively. I imagine we'd need to unconditionally build it from git, even in non-interactive mode. Curious your thoughts.

Also, added a small Lustre convenience ktest. Still trying to find cycles for my OSD ktests. 