### PR TITLE
Basic OSD tests

### DIFF
--- a/tests/fs/lustre/boot.ktest
+++ b/tests/fs/lustre/boot.ktest
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0
+
+#
+# Copyright (c) 2024, Amazon and/or its affiliates. All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Just boot using the Lustre kernel config
+#
+# Author: Timothy Day <timday@amazon.com>
+#
+
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/lustre-libs.sh"
+
+require-lustre-kernel-config
+require-lustre-debug-kernel-config
+
+config-mem 10G
+config-timeout 60
+
+test_llmount()
+{
+    echo boot
+}
+
+main "$@"

--- a/tests/fs/lustre/llmount.ktest
+++ b/tests/fs/lustre/llmount.ktest
@@ -7,8 +7,8 @@
 #
 
 #
-# Run a simple mount test (client and server). This currently
-# only works with ZFS.
+# Run a simple mount test (client and server). The backing OSD is
+# specified with FSTYPE.
 #
 # Author: Timothy Day <timday@amazon.com>
 #

--- a/tests/fs/lustre/llog-unit.ktest
+++ b/tests/fs/lustre/llog-unit.ktest
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0
+
+#
+# Copyright (c) 2024, Amazon and/or its affiliates. All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Run the llog unit tests with a stand-alone MGT.
+#
+# Author: Timothy Day <timday@amazon.com>
+#
+
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/lustre-libs.sh"
+
+require-lustre-kernel-config
+require-lustre-debug-kernel-config
+
+config-mem 10G
+config-timeout 60
+
+config-scratch-devs 512M
+
+test_llmount()
+{
+    load_lustre_modules
+    setup_lustre_mgs
+
+    run_llog
+
+    cleanup_lustre_mgs
+}
+
+main "$@"

--- a/tests/fs/lustre/lustre-libs.sh
+++ b/tests/fs/lustre/lustre-libs.sh
@@ -64,6 +64,25 @@ function require-lustre-debug-kernel-config()
     require-kernel-config KASAN_VMALLOC
 }
 
+function load_lustre_modules()
+{
+    load_zfs_modules
+
+    "$lustre_pkg_path/lustre/tests/llmount.sh" --load-modules
+}
+
+function setup_lustre_mgs()
+{
+    zpool create lustre-mgs "${ktest_scratch_dev[0]}"
+    "$lustre_pkg_path/lustre/utils/mkfs.lustre" --mgs --fsname=lustre lustre-mgs/mgs
+    mkdir -p /mnt/lustre-mgs
+    mount -t lustre lustre-mgs/mgs /mnt/lustre-mgs
+
+    sleep 5
+
+    umount -t lustre /mnt/lustre-mgs
+}
+
 function setup_lustrefs()
 {
     load_zfs_modules

--- a/tests/fs/lustre/lustre-libs.sh
+++ b/tests/fs/lustre/lustre-libs.sh
@@ -21,15 +21,21 @@ export lustre_pkg_path="$workspace_path/lustre-release"
 export zfs_pkg_path="$workspace_path/zfs"
 
 # Set Lustre test-framework.sh environment
-export ZFS="$zfs_pkg_path/cmd/zfs/zfs"
-export ZPOOL="$zfs_pkg_path/cmd/zpool/zpool"
+if [[ -f "$zfs_pkg_path/zfs" ]]; then
+    export ZFS="$zfs_pkg_path/zfs"
+    export ZPOOL="$zfs_pkg_path/zpool"
+else
+    export ZFS="$zfs_pkg_path/cmd/zfs/zfs"
+    export ZPOOL="$zfs_pkg_path/cmd/zpool/zpool"
+fi
+
 export LUSTRE="$lustre_pkg_path/lustre"
 export LCTL="$LUSTRE/utils/lctl"
 export RUNAS_ID="1000"
 
 # Update paths
 set +u
-export PATH="$zfs_pkg_path/cmd/zpool:$zfs_pkg_path/cmd/zfs:$PATH"
+export PATH="$zfs_pkg_path:$zfs_pkg_path/cmd/zpool:$zfs_pkg_path/cmd/zfs:$PATH"
 export LD_LIBRARY_PATH="$zfs_pkg_path/lib/libzfs/.libs:$zfs_pkg_path/lib/libzfs_core/.libs:$LD_LIBRARY_PATH"
 export LD_LIBRARY_PATH="$zfs_pkg_path/lib/libuutil/.libs:$zfs_pkg_path/lib/libnvpair/.libs:$LD_LIBRARY_PATH"
 set -u
@@ -85,15 +91,20 @@ set -u
 
 function load_zfs_modules()
 {
-    insmod "$zfs_pkg_path/module/spl/spl.ko"
-    insmod "$zfs_pkg_path/module/zstd/zzstd.ko"
-    insmod "$zfs_pkg_path/module/unicode/zunicode.ko"
-    insmod "$zfs_pkg_path/module/avl/zavl.ko"
-    insmod "$zfs_pkg_path/module/lua/zlua.ko"
-    insmod "$zfs_pkg_path/module/nvpair/znvpair.ko"
-    insmod "$zfs_pkg_path/module/zcommon/zcommon.ko"
-    insmod "$zfs_pkg_path/module/icp/icp.ko"
-    insmod "$zfs_pkg_path/module/zfs/zfs.ko"
+    # ZFS pre-2.3.0
+    insmod "$zfs_pkg_path/module/spl/spl.ko" || true
+    insmod "$zfs_pkg_path/module/zstd/zzstd.ko" || true
+    insmod "$zfs_pkg_path/module/unicode/zunicode.ko" || true
+    insmod "$zfs_pkg_path/module/avl/zavl.ko" || true
+    insmod "$zfs_pkg_path/module/lua/zlua.ko" || true
+    insmod "$zfs_pkg_path/module/nvpair/znvpair.ko" || true
+    insmod "$zfs_pkg_path/module/zcommon/zcommon.ko" || true
+    insmod "$zfs_pkg_path/module/icp/icp.ko" || true
+    insmod "$zfs_pkg_path/module/zfs/zfs.ko" || true
+
+    # ZFS post-2.3.0
+    insmod "$zfs_pkg_path/module/spl.ko" || true
+    insmod "$zfs_pkg_path/module/zfs.ko" || true
 }
 
 function require-lustre-kernel-config()

--- a/tests/fs/lustre/lustre-libs.sh
+++ b/tests/fs/lustre/lustre-libs.sh
@@ -158,6 +158,10 @@ function setup_lustrefs()
     load_lustre_modules
 
     FSTYPE="$FSTYPE" "$lustre_pkg_path/lustre/tests/llmount.sh"
+
+    # Disable identity upcall (for OSD mem)
+    "$LCTL" set_param mdt.*.identity_upcall=NONE
+
     mount -t lustre
 }
 

--- a/tests/fs/lustre/mgs-setup.ktest
+++ b/tests/fs/lustre/mgs-setup.ktest
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0
+
+#
+# Copyright (c) 2024, Amazon and/or its affiliates. All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Run a simple mount test (client and server). This currently
+# only works with ZFS.
+#
+# Author: Timothy Day <timday@amazon.com>
+#
+
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/lustre-libs.sh"
+
+require-lustre-kernel-config
+require-lustre-debug-kernel-config
+
+config-mem 10G
+config-timeout 60
+
+config-scratch-devs 512M
+
+test_llmount()
+{
+    load_lustre_modules
+    setup_lustre_mgs
+}
+
+main "$@"

--- a/tests/fs/lustre/mgs-setup.ktest
+++ b/tests/fs/lustre/mgs-setup.ktest
@@ -7,8 +7,8 @@
 #
 
 #
-# Run a simple mount test (client and server). This currently
-# only works with ZFS.
+# Setup/cleanup a Lustre MGT. The backing OSD is specified
+# with FSTYPE.
 #
 # Author: Timothy Day <timday@amazon.com>
 #
@@ -27,6 +27,10 @@ test_llmount()
 {
     load_lustre_modules
     setup_lustre_mgs
+
+    sleep 5
+
+    cleanup_lustre_mgs
 }
 
 main "$@"

--- a/tests/fs/lustre/sanity-quick.ktest
+++ b/tests/fs/lustre/sanity-quick.ktest
@@ -22,7 +22,7 @@ test_sanity-quick()
 {
     setup_lustrefs
 
-    "$lustre_pkg_path/lustre/tests/auster" -v sanity --stop-at 16
+    FSTYPE="$FSTYPE" "$lustre_pkg_path/lustre/tests/auster" -v sanity --stop-at 16
 
     cleanup_lustrefs
 }


### PR DESCRIPTION
Added a couple tests that were useful for debugging OSDs. I included the boot test from the other PR. Updated some of the infrastructure to support non-ZFS OSDs. The FSTYPE is passed via a temporary file. This isn't ideal, but I want to a) grab the value from the local environment similar to the other Lustre scripts and b) not pollute the rest of ktest with tons of Lustre arguments.

More tests to come in the future.