### PR TITLE
root_image: install systemd-dev

### DIFF
--- a/root_image
+++ b/root_image
@@ -94,7 +94,7 @@ PACKAGES+=(fio dbench bonnie++ fsmark)
 
 # bcachefs-tools build dependencies:
 PACKAGES+=(libblkid-dev uuid-dev libscrypt-dev libsodium-dev)
-PACKAGES+=(libkeyutils-dev liburcu-dev libudev-dev zlib1g-dev libattr1-dev)
+PACKAGES+=(libkeyutils-dev liburcu-dev libudev-dev zlib1g-dev libattr1-dev systemd-dev)
 PACKAGES+=(libaio-dev libzstd-dev liblz4-dev libfuse3-dev valgrind)
 PACKAGES+=(llvm libclang-dev)
 


### PR DESCRIPTION
Commit aaa7ca9faf11 ("root_image: add separate init cmd for debootstrap") changed the Debian version used in the ktest VM from bullseye to sid. The current version of the udev package in sid does not contain the udev.pc pkg-config file anymore, which causes bcachefs-tools build to fail:

hook init_build_bcachefs_tools
Makefile:95: *** pkg-config error, command: pkg-config --variable=udevdir udev.  Stop.

Fix this by adding systemd-dev to the packages installed in the VM image.