### PR TITLE
syzbot-get: fix panic from conflict in argument definitions

### DIFF
--- a/src/bin/syzbot-get.rs
+++ b/src/bin/syzbot-get.rs
@@ -5,9 +5,9 @@ use serde_derive::Deserialize;
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    #[arg(short, long)]
+    #[arg(long)]
     id:         String,
-    #[arg(short, long)]
+    #[arg(long)]
     idx:        Option<usize>,
     #[arg(short, long)]
     output:     PathBuf,


### PR DESCRIPTION
Remove the short variant of --id and --idx since they conflict and cause syzbot-get to panic at runtime.

```
thread 'main' panicked at /home/bharadwaj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.20/src/builder/debug_asserts.rs:112:17:
Command ci_cgi: Short option names must be unique for each argument, but '-i' is in use by both 'id' and 'idx'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

In this repo we only use the long variants anyway, and I don't think it's used anywhere outside.