### PR TITLE
Improve LLVM support (and some Lustre updates)

### DIFF
--- a/build-test-kernel
+++ b/build-test-kernel
@@ -18,7 +18,7 @@ checkdep bc
 
 ktest_njobs=$(nproc)
 ktest_precise=false
-ktest_compiler=gcc
+ktest_compiler="${CC:-gcc}"
 ktest_skip_kernel_config=false
 
 COVERAGE=""		# doing code coverage?
@@ -122,6 +122,14 @@ run_ktest()
     "$KTEST" "$arg" $KTESTARGS "$@"
 }
 
+map_clang_version() {
+    case "$ktest_compiler" in
+        clang) echo "1" ;;
+        clang-[0-9]*) echo "-${ktest_compiler#clang-}" ;;
+        *) echo "" ;;
+    esac
+}
+
 do_make()
 {
     if [[ -n $CROSS_COMPILE ]]; then
@@ -132,6 +140,7 @@ do_make()
     make --jobs="$ktest_njobs"			\
 	--directory="$ktest_kernel_source"    	\
 	CC="$ktest_compiler"			\
+	LLVM="$(map_clang_version)"		\
 	O="$ktest_kernel_build"			\
 	INSTALL_MOD_PATH="$ktest_kernel_binary"	\
 	"${ktest_kernel_make_append[@]}"	\

--- a/tests/fs/lustre/lustre-libs.sh
+++ b/tests/fs/lustre/lustre-libs.sh
@@ -91,7 +91,7 @@ else
     if [[ -f /host/tmp/ktest-lustre.env ]]; then
 	eval $(cat /host/tmp/ktest-lustre.env)
     else
-	FSTYPE="mem"
+	FSTYPE="wbcfs"
     fi
 fi
 set -u
@@ -173,11 +173,12 @@ function setup_lustre_mgs()
 	    "$lustre_pkg_path/lustre/utils/mkfs.lustre" --mgs --fsname=lustre lustre-mgs/mgs
 	    mount -t lustre lustre-mgs/mgs /mnt/lustre-mgs
 	    ;;
-	mem)
-	    export OSD_MEM_TGT_TYPE="MGT"
-	    export OSD_MEM_INDEX="0"
-	    export OSD_MEM_MGS_NID="$(hostname -i)@tcp"
-	    run_tf "$lustre_pkg_path/lustre/utils/mount.lustre" -v /mnt/lustre-mgs
+	wbcfs)
+	    export OSD_WBC_TGT_TYPE="MGT"
+	    export OSD_WBC_INDEX="0"
+	    export OSD_WBC_MGS_NID="$(hostname -i)@tcp"
+	    export OSD_WBC_FSNAME="lustre"
+	    run_tf "$lustre_pkg_path/lustre/utils/mount.lustre" -v lustre-wbcfs /mnt/lustre-mgs
 	    ;;
 	*)
 	    echo "Unsupported OSD!"
@@ -198,7 +199,7 @@ function setup_lustrefs()
 
     FSTYPE="$FSTYPE" "$lustre_pkg_path/lustre/tests/llmount.sh"
 
-    # Disable identity upcall (for OSD mem)
+    # Disable identity upcall (for OSD wbcfs)
     "$LCTL" set_param mdt.*.identity_upcall=NONE
 
     mount -t lustre

--- a/tests/prelude.sh
+++ b/tests/prelude.sh
@@ -34,7 +34,7 @@ if [[ ! -v ktest_cpus ]]; then
     ktest_kernel_config_require=()
     ktest_kernel_config_require_soft=()
     ktest_qemu_append=()
-    ktest_compiler=gcc
+    ktest_compiler="${CC:-gcc}"
     ktest_allow_taint=false
 
     ktest_tests_unknown=false


### PR DESCRIPTION
We ought to set the `LLVM` variable as part of the kernel build when we're using Clang. Also, I have some minor updates to the Lustre test setup to match the latest OSD code. I'll also have some more tests and PCIe pass-through support ready soon(ish). But I'll open another PR for that - I have a backlog of testing improvements I need to work through.