### PR TITLE
tests/fs/bcachefs: add rereplicate2 test

### DIFF
--- a/tests/fs/bcachefs/replication.ktest
+++ b/tests/fs/bcachefs/replication.ktest
@@ -837,6 +837,69 @@ test_rereplicate()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_rereplicate2()
+{
+    echo ":: format with replicas=1 (default)"
+    run_quiet "" bcachefs format -f		\
+        ${ktest_scratch_dev[0]}			\
+        ${ktest_scratch_dev[1]}
+
+    mount -t bcachefs ${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]} /mnt
+
+    echo ":: write to fs, while replicas=1"
+    touch /mnt/empty-file
+
+    echo ":: we should have some durability=1 data now"
+    bcachefs fs usage -h /mnt
+
+    echo ":: set replicas=2 and run rereplicate"
+    echo 2 > /sys/fs/bcachefs/*/options/data_replicas
+    echo 2 > /sys/fs/bcachefs/*/options/metadata_replicas
+    bcachefs data rereplicate /mnt
+
+    # echo ":: running rereplicate a second time seems to guarantee all data has durability=2"
+    # bcachefs data rereplicate /mnt
+
+    echo ":: all data should be replicated to both devices now, verifying..."
+    local fs_usage_out=$(bcachefs fs usage -h /mnt)
+    echo "$fs_usage_out"
+    local residual_durability_1_data=$(grep -E '^(btree|user):' <<<"$fs_usage_out" | awk '$3 == "1"')
+
+    umount /mnt
+
+    local dev_remove=
+    if ! [[ -n "$residual_durability_1_data" ]]; then
+	echo ":: no residual durability=1 data found"
+	dev_remove="vdb"
+        echo ":: we will simulate loss of device '$dev_remove' to verify proper replication"
+    else
+        echo ":: found residual durability=1 data:"
+        echo "$residual_durability_1_data"
+
+        local first_spof_dev=$(head -n1 <<<"$residual_durability_1_data" | grep -oP '\[\K[^\]]+' | awk '{print $1}')
+	dev_remove="$first_spof_dev"
+        echo ":: we will simulate loss of device '$dev_remove', which we suspect of being a single-point-of-failure"
+    fi
+
+    # we want to keep the other device
+    local dev_keep=
+    if [[ "$dev_remove" == "vdb" ]]; then
+        dev_keep="vdc"
+    elif [[ "$dev_remove" == "vdc" ]]; then
+        dev_keep="vdb"
+    else
+        exit 1
+    fi
+
+    echo ":: wipe the super-block on device '$dev_remove' to prevent auto-discovery durring mount"
+    dd if=/dev/zero of=/dev/$dev_remove bs=1M count=1 oflag=direct
+
+    echo ":: attempt degraded mount with only device '$dev_keep'"
+    mount -t bcachefs -o degraded,fsck,fix_errors /dev/$dev_keep /mnt
+
+    umount /mnt
+}
+
 disabled_test_device_add_faults()
 {
     setup_tracing 'bcachefs:*'


### PR DESCRIPTION
Add replication test where we wipe the superblock on a device before attempting a degraded mount to prevent it from being auto-discovered on mount.

ktest log:
```
Running test replication.ktest on pc at /home/shug/shared/git/git.kernel.org/torvalds/linux/_wt/ktest
building kernel... done
[!p]104[?7hKernel version: 6.16.0-rc5-ktest-00092-gc8bf0a2d2e65
hook init_build_bcachefs_tools
install -m0755 -D fsck/bcachefsck_fail fsck/bcachefsck_all -t /usr/libexec
install -m0644 -D fsck/bcachefsck_fail@.service fsck/bcachefsck@.service fsck/system-bcachefsck.slice fsck/bcachefsck_all_fail.service fsck/bcachefsck_all.service fsck/bcachefsck_all.timer -t /usr/lib/systemd/system
install -m0755 -D target/release/bcachefs  -t /sbin
install -m0644 -D bcachefs.8    -t /usr/share/man/man8/
install -m0755 -D initramfs/script /usr/share/initramfs-tools/scripts/local-premount/bcachefs
install -m0755 -D initramfs/hook   /usr/share/initramfs-tools/hooks/bcachefs
install -m0644 -D udev/64-bcachefs.rules -t /usr/lib/udev/rules.d/
ln -sfr /sbin/bcachefs /sbin/mkfs.bcachefs
ln -sfr /sbin/bcachefs /sbin/fsck.bcachefs
ln -sfr /sbin/bcachefs /sbin/mount.bcachefs
ln -sfr /sbin/bcachefs /sbin/mkfs.fuse.bcachefs
ln -sfr /sbin/bcachefs /sbin/fsck.fuse.bcachefs
ln -sfr /sbin/bcachefs /sbin/mount.fuse.bcachefs
sed -i '/^# Note: make install replaces/,$d' /usr/share/initramfs-tools/hooks/bcachefs
echo "copy_exec /sbin/bcachefs /sbin/bcachefs" >> /usr/share/initramfs-tools/hooks/bcachefs
echo "copy_exec /sbin/mount.bcachefs /sbin/mount.bcachefs" >> /usr/share/initramfs-tools/hooks/bcachefs
hook init_noop

Running tests rereplicate2

========= TEST   rereplicate2

:: format with replicas=1 (default)
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): starting version 1.28: inode_has_case_insensitive
  features: new_siphash,new_extent_overwrite,btree_ptr_v2,extents_above_btree_updates,btree_updates_journalled,new_varint,journal_no_flush,alloc_v2,extents_across_btree_nodes,incompat_version_field
  with devices vdb vdc
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): Using encoding defined by superblock: utf8-12.1.0
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): initializing new filesystem
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): marking superblocks
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): going read-write
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): initializing freespace
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): done initializing freespace
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): reading snapshots table
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): reading snapshots done
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): done starting filesystem
mount.bcachefs (579) used greatest stack depth: 9712 bytes left
:: write to fs, while replicas=1
:: we should have some durability=1 data now
Filesystem: ffdd9fe3-12ec-49ee-a17e-1c1212600af0
Size:                       7.36 GiB
Used:                       2.50 MiB
Online reserved:                 0 B

Data type       Required/total  Durability    Devices
btree:          1/1             1             [vdb]               1.00 MiB
btree:          1/1             1             [vdc]               1.50 MiB

Btree usage:
inodes:              256 KiB
dirents:             256 KiB
alloc:               256 KiB
subvolumes:          256 KiB
snapshots:           256 KiB
freespace:           256 KiB
backpointers:        256 KiB
snapshot_trees:      256 KiB
logged_ops:          256 KiB
accounting:          256 KiB

(no label) (device 0):           vdb              rw
                                data         buckets    fragmented
  free:                     3.96 GiB           16239
  sb:                       3.00 MiB              13       252 KiB
  journal:                  32.0 MiB             128
  btree:                    1.00 MiB               4
  user:                          0 B               0
  cached:                        0 B               0
  parity:                        0 B               0
  stripe:                        0 B               0
  need_gc_gens:                  0 B               0
  need_discard:                  0 B               0
  unstriped:                     0 B               0
  capacity:                 4.00 GiB           16384

(no label) (device 1):           vdc              rw
                                data         buckets    fragmented
  free:                     3.96 GiB           16237
  sb:                       3.00 MiB              13       252 KiB
  journal:                  32.0 MiB             128
  btree:                    1.50 MiB               6
  user:                          0 B               0
  cached:                        0 B               0
  parity:                        0 B               0
  stripe:                        0 B               0
  need_gc_gens:                  0 B               0
  need_discard:                  0 B               0
  unstriped:                     0 B               0
  capacity:                 4.00 GiB           16384
:: set replicas=2 and run rereplicate
[2K
0% complete: current position free
Done
:: all data should be replicated to both devices now, verifying...
Filesystem: ffdd9fe3-12ec-49ee-a17e-1c1212600af0
Size:                       7.36 GiB
Used:                       5.00 MiB
Online reserved:                 0 B

Data type       Required/total  Durability    Devices
btree:          1/1             1             [vdb]                512 KiB
btree:          1/1             1             [vdc]                512 KiB
btree:          1/2             2             [vdb vdc]           4.00 MiB

Btree usage:
inodes:              256 KiB
dirents:             256 KiB
alloc:               512 KiB
subvolumes:          512 KiB
snapshots:           512 KiB
freespace:           512 KiB
need_discard:        256 KiB
backpointers:        512 KiB
bucket_gens:         256 KiB
snapshot_trees:      512 KiB
logged_ops:          512 KiB
accounting:          512 KiB

(no label) (device 0):           vdb              rw
                                data         buckets    fragmented
  free:                     3.96 GiB           16229
  sb:                       3.00 MiB              13       252 KiB
  journal:                  32.0 MiB             128
  btree:                    2.50 MiB              10
  user:                          0 B               0
  cached:                        0 B               0
  parity:                        0 B               0
  stripe:                        0 B               0
  need_gc_gens:                  0 B               0
  need_discard:             1.00 MiB               4
  unstriped:                     0 B               0
  capacity:                 4.00 GiB           16384

(no label) (device 1):           vdc              rw
                                data         buckets    fragmented
  free:                     3.96 GiB           16227
  sb:                       3.00 MiB              13       252 KiB
  journal:                  32.0 MiB             128
  btree:                    2.50 MiB              10
  user:                          0 B               0
  cached:                        0 B               0
  parity:                        0 B               0
  stripe:                        0 B               0
  need_gc_gens:                  0 B               0
  need_discard:             1.50 MiB               6
  unstriped:                     0 B               0
  capacity:                 4.00 GiB           16384
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): shutting down
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): going read-only
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): finished waiting for writes to stop
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): flushing journal and stopping allocators, journal seq 10
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): flushing journal and stopping allocators complete, journal seq 10
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): clean shutdown complete, journal seq 11
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): marking filesystem clean
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): shutdown complete
:: found residual durability=1 data:
btree:          1/1             1             [vdb]                512 KiB
btree:          1/1             1             [vdc]                512 KiB
:: we will simulate loss of device 'vdb', which we suspect of being a single-point-of-failure
:: wipe the super-block on device 'vdb' to prevent auto-discovery durring mount
1+0 records in
1+0 records out
1048576 bytes (1.0 MB, 1.0 MiB) copied, 0.00316743 s, 331 MB/s
:: attempt degraded mount with only device 'vdc'
bcachefs (/dev/vdb): error reading default superblock: Not a bcachefs superblock (got magic 00000000-0000-0000-0000-000000000000)
bcachefs (/dev/vdb): error reading superblock: Not a bcachefs superblock layout
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): starting version 1.28: inode_has_case_insensitive opts=metadata_replicas=2,data_replicas=2,degraded=yes,fsck,fix_errors=yes
  features: new_siphash,new_extent_overwrite,btree_ptr_v2,new_varint,journal_no_flush,alloc_v2,extents_across_btree_nodes,incompat_version_field
  with devices vdc
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): Using encoding defined by superblock: utf8-12.1.0
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): insufficient devices online (0) for replicas entry btree: 1/1 [0]
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): shutting down
bcachefs (ffdd9fe3-12ec-49ee-a17e-1c1212600af0): shutdown complete
bcachefs: bch2_fs_get_tree() error: insufficient_devices_to_start
mount: /dev/vdc: Invalid argument
[[31;1mERROR[0m src/commands/mount.rs:412] Mount failed: Invalid argument
Error 1 at /host//mnt/datastore/shug-shared/git/github.com/koverstreet/ktest/tests/fs/bcachefs/replication.ktest 898 from: mount -t bcachefs -o degraded,fsck,fix_errors /dev/$dev_keep /mnt, exiting
Error 1 at /host/mnt/datastore/shug-shared/git/github.com/koverstreet/ktest/tests/prelude.sh 304 from: ( set -e; run_test $i ), exiting

========= FAILED rereplicate2 in 3s

Passed: 
Failed: rereplicate2
Error 1 at /host/mnt/datastore/shug-shared/git/github.com/koverstreet/ktest/tests/prelude.sh 400 from: return ${#tests_failed[@]}, exiting
Error 1 at /host//mnt/datastore/shug-shared/git/github.com/koverstreet/ktest/tests/fs/bcachefs/replication.ktest 1182 from: return ${#tests_failed[@]}, exiting
Kernel version: 6.16.0-rc5-ktest-00092-gc8bf0a2d2e65
TEST FAILED

```