### PR TITLE
tests/bcachefs: cover allocator and device remove edge cases

### DIFF
--- a/tests/fs/bcachefs/quota.ktest
+++ b/tests/fs/bcachefs/quota.ktest
@@ -147,4 +147,29 @@ test_prjquota_multidevices()
     umount /mnt
 }
 
+test_prjquota_after_primary_device_remove()
+{
+    set_watchdog 180
+
+    run_quiet "" bcachefs format -f				\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}		\
+	--label=hdd.hdd1 ${ktest_scratch_dev[1]}		\
+	--metadata_target=hdd					\
+	--foreground_target=hdd					\
+	--promote_target=hdd					\
+	--background_target=hdd
+
+    mount -t bcachefs -o usrquota,grpquota,prjquota		\
+	${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]} /mnt
+
+    repquota -P -s /mnt
+    bcachefs device remove ${ktest_scratch_dev[0]} /mnt
+    repquota -P -s /mnt
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[1]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[1]}
+}
+
 main "$@"

--- a/tests/fs/bcachefs/quota.ktest
+++ b/tests/fs/bcachefs/quota.ktest
@@ -157,4 +157,29 @@ test_prjquota_multidevices()
     umount /mnt
 }
 
+test_prjquota_after_primary_device_remove()
+{
+    set_watchdog 180
+
+    run_quiet "" bcachefs format -f				\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}		\
+	--label=hdd.hdd1 ${ktest_scratch_dev[1]}		\
+	--metadata_target=hdd					\
+	--foreground_target=hdd					\
+	--promote_target=hdd					\
+	--background_target=hdd
+
+    mount -t bcachefs -o usrquota,grpquota,prjquota		\
+	${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]} /mnt
+
+    repquota -P -s /mnt
+    bcachefs device remove ${ktest_scratch_dev[0]} /mnt
+    repquota -P -s /mnt
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[1]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[1]}
+}
+
 main "$@"

--- a/tests/fs/bcachefs/single_device.ktest
+++ b/tests/fs/bcachefs/single_device.ktest
@@ -79,6 +79,28 @@ test_remount_ro_rw()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_directory_stat_size_nonzero()
+{
+    set_watchdog 10
+
+    run_quiet "" bcachefs format -f ${ktest_scratch_dev[0]}
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    mkdir /mnt/dir
+    dir_size="$(stat -c '%s' /mnt/dir)"
+    root_size="$(stat -c '%s' /mnt)"
+
+    echo "bcachefs directory size: $dir_size"
+    echo "bcachefs root size: $root_size"
+
+    test "$dir_size" -gt 0
+    test "$root_size" -gt 0
+
+    umount /mnt
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_mount_again_after_ebusy()
 {
     set_watchdog 10

--- a/tests/fs/bcachefs/tier.ktest
+++ b/tests/fs/bcachefs/tier.ktest
@@ -79,6 +79,42 @@ test_tiering_misaligned()
 	--background_target=hdd
 }
 
+test_foreground_target_durability_counts()
+{
+    set_watchdog 180
+
+    run_quiet "" bcachefs format -f			\
+	--block_size=4k					\
+	--bucket_size=256k				\
+	--data_replicas=2				\
+	--metadata_replicas=2				\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}	\
+	--label=ssd.ssd2 ${ktest_scratch_dev[1]}	\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}	\
+	--label=hdd.hdd2 ${ktest_scratch_dev[3]}	\
+	--foreground_target=ssd				\
+	--background_target=hdd
+
+    mount -t bcachefs "$(join_by : "${ktest_scratch_dev[@]}")" /mnt
+
+    dd if=/dev/zero of=/mnt/foreground-durable bs=4M count=1 oflag=direct status=progress
+    sync
+
+    timeout 30s bcachefs reconcile wait -t target /mnt || true
+
+    local fs_usage_out=$(bcachefs fs usage -h --all /mnt)
+    echo "$fs_usage_out"
+
+    if grep -q '^cached:' <<<"$fs_usage_out"; then
+	echo "durable foreground target copy became cached"
+	return 1
+    fi
+
+    umount /mnt
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_tiering_drop_alloc()
 {
     run_basic_tiering_test

--- a/tests/fs/bcachefs/tier.ktest
+++ b/tests/fs/bcachefs/tier.ktest
@@ -120,6 +120,35 @@ test_tiering_buffered()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_foreground_target_full_fallback()
+{
+    set_watchdog 180
+
+    run_quiet "" bcachefs format -f			\
+	--block_size=4k					\
+	--bucket_size=256k				\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}	\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}	\
+	--foreground_target=ssd				\
+	--promote_target=ssd				\
+	--background_target=hdd
+
+    mount -t bcachefs ${ktest_scratch_dev[0]}:${ktest_scratch_dev[2]} /mnt
+
+    # The foreground target is only a preference.  This write is larger than
+    # the SSD scratch device, so it must complete by falling back to HDD space
+    # instead of waiting forever on SSD/copygc progress.
+    dd if=/dev/zero of=/mnt/foreground-target-fallback bs=16M count=96	\
+	oflag=direct status=progress
+    sync
+    bcachefs fs usage -h /mnt
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]} ${ktest_scratch_dev[2]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_writethrough()
 {
     run_basic_fio_test "$@"								\
@@ -299,6 +328,76 @@ test_device_remove_background()
     bcachefs reset-counters --counters=data_update_fail ${ktest_scratch_dev[0]}
     bcachefs reset-counters --counters=bucket_alloc_fail ${ktest_scratch_dev[0]}
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+test_failed_device_remove_restores_rw()
+{
+    set_watchdog 180
+
+    run_quiet "" bcachefs format -f			\
+	--block_size=4k					\
+	--bucket_size=256k				\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}	\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}	\
+	--foreground_target=hdd				\
+	--promote_target=ssd				\
+	--background_target=hdd
+
+    mount -t bcachefs ${ktest_scratch_dev[0]}:${ktest_scratch_dev[2]} /mnt
+
+    # Make the HDD member uniquely necessary.  Removing it should fail because
+    # the SSD member is too small, but the failed remove must not leave the
+    # member stuck evacuating/readonly.
+    dd if=/dev/zero of=/mnt/hdd-only bs=16M count=96 oflag=direct status=progress
+    sync
+    bcachefs fs usage -h /mnt
+
+    if bcachefs device remove ${ktest_scratch_dev[2]} /mnt; then
+	echo "device remove unexpectedly succeeded"
+	return 1
+    fi
+
+    bcachefs fs usage -h /mnt
+    grep -q '\[rw\]' /sys/fs/bcachefs/*/dev-1/state
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]} ${ktest_scratch_dev[2]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+test_device_remove_rewrites_metadata()
+{
+    set_watchdog 240
+
+    run_quiet "" bcachefs format -f			\
+	--block_size=4k					\
+	--bucket_size=256k				\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}	\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}	\
+	--metadata_target=ssd				\
+	--foreground_target=hdd				\
+	--promote_target=ssd				\
+	--background_target=hdd
+
+    mount -t bcachefs ${ktest_scratch_dev[0]}:${ktest_scratch_dev[2]} /mnt
+
+    # Populate enough small-file metadata that the SSD metadata target owns
+    # btree nodes.  Device removal has to rewrite those nodes elsewhere before
+    # dropping the SSD member's metadata pointers.
+    for i in $(seq 0 100000); do
+	echo $i > /mnt/file-$i
+    done
+    sync
+    bcachefs fs usage -h --all /mnt
+
+    bcachefs device remove ${ktest_scratch_dev[0]} /mnt
+    bcachefs fs usage -h /mnt
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[2]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[2]}
 }
 
 test_mount_umount_torture()

--- a/tests/fs/bcachefs/tier.ktest
+++ b/tests/fs/bcachefs/tier.ktest
@@ -68,6 +68,42 @@ test_tiering_misaligned()
 	--background_target=hdd
 }
 
+test_foreground_target_durability_counts()
+{
+    set_watchdog 180
+
+    run_quiet "" bcachefs format -f			\
+	--block_size=4k					\
+	--bucket_size=256k				\
+	--data_replicas=2				\
+	--metadata_replicas=2				\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}	\
+	--label=ssd.ssd2 ${ktest_scratch_dev[1]}	\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}	\
+	--label=hdd.hdd2 ${ktest_scratch_dev[3]}	\
+	--foreground_target=ssd				\
+	--background_target=hdd
+
+    mount -t bcachefs "$(join_by : "${ktest_scratch_dev[@]}")" /mnt
+
+    dd if=/dev/zero of=/mnt/foreground-durable bs=4M count=1 oflag=direct status=progress
+    sync
+
+    timeout 30s bcachefs reconcile wait -t target /mnt || true
+
+    local fs_usage_out=$(bcachefs fs usage -h --all /mnt)
+    echo "$fs_usage_out"
+
+    if grep -q '^cached:' <<<"$fs_usage_out"; then
+	echo "durable foreground target copy became cached"
+	return 1
+    fi
+
+    umount /mnt
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_tiering_drop_alloc()
 {
     run_basic_tiering_test

--- a/tests/fs/bcachefs/tier.ktest
+++ b/tests/fs/bcachefs/tier.ktest
@@ -131,6 +131,35 @@ test_tiering_buffered()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_foreground_target_full_fallback()
+{
+    set_watchdog 180
+
+    run_quiet "" bcachefs format -f			\
+	--block_size=4k					\
+	--bucket_size=256k				\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}	\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}	\
+	--foreground_target=ssd				\
+	--promote_target=ssd				\
+	--background_target=hdd
+
+    mount -t bcachefs ${ktest_scratch_dev[0]}:${ktest_scratch_dev[2]} /mnt
+
+    # The foreground target is only a preference.  This write is larger than
+    # the SSD scratch device, so it must complete by falling back to HDD space
+    # instead of waiting forever on SSD/copygc progress.
+    dd if=/dev/zero of=/mnt/foreground-target-fallback bs=16M count=96	\
+	oflag=direct status=progress
+    sync
+    bcachefs fs usage -h /mnt
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]} ${ktest_scratch_dev[2]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_writethrough()
 {
     run_basic_fio_test "$@"								\
@@ -310,6 +339,76 @@ test_device_remove_background()
     bcachefs reset-counters --counters=data_update_fail ${ktest_scratch_dev[0]}
     bcachefs reset-counters --counters=bucket_alloc_fail ${ktest_scratch_dev[0]}
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+test_failed_device_remove_restores_rw()
+{
+    set_watchdog 180
+
+    run_quiet "" bcachefs format -f			\
+	--block_size=4k					\
+	--bucket_size=256k				\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}	\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}	\
+	--foreground_target=hdd				\
+	--promote_target=ssd				\
+	--background_target=hdd
+
+    mount -t bcachefs ${ktest_scratch_dev[0]}:${ktest_scratch_dev[2]} /mnt
+
+    # Make the HDD member uniquely necessary.  Removing it should fail because
+    # the SSD member is too small, but the failed remove must not leave the
+    # member stuck evacuating/readonly.
+    dd if=/dev/zero of=/mnt/hdd-only bs=16M count=96 oflag=direct status=progress
+    sync
+    bcachefs fs usage -h /mnt
+
+    if bcachefs device remove ${ktest_scratch_dev[2]} /mnt; then
+	echo "device remove unexpectedly succeeded"
+	return 1
+    fi
+
+    bcachefs fs usage -h /mnt
+    grep -q '\[rw\]' /sys/fs/bcachefs/*/dev-1/state
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]} ${ktest_scratch_dev[2]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+test_device_remove_rewrites_metadata()
+{
+    set_watchdog 240
+
+    run_quiet "" bcachefs format -f			\
+	--block_size=4k					\
+	--bucket_size=256k				\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}	\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}	\
+	--metadata_target=ssd				\
+	--foreground_target=hdd				\
+	--promote_target=ssd				\
+	--background_target=hdd
+
+    mount -t bcachefs ${ktest_scratch_dev[0]}:${ktest_scratch_dev[2]} /mnt
+
+    # Populate enough small-file metadata that the SSD metadata target owns
+    # btree nodes.  Device removal has to rewrite those nodes elsewhere before
+    # dropping the SSD member's metadata pointers.
+    for i in $(seq 0 100000); do
+	echo $i > /mnt/file-$i
+    done
+    sync
+    bcachefs fs usage -h --all /mnt
+
+    bcachefs device remove ${ktest_scratch_dev[0]} /mnt
+    bcachefs fs usage -h /mnt
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[2]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[2]}
 }
 
 test_mount_umount_torture()


### PR DESCRIPTION
Adds focused bcachefs regression tests for the current device-remove and allocator/debug queue:

- `failed_device_remove_restores_rw` for a failed `device remove` leaving a still-present member usable again
- `device_remove_rewrites_metadata` for metadata-target btree nodes during member removal
- `foreground_target_full_fallback` for soft foreground-target fallback when the preferred tier fills
- `prjquota_after_primary_device_remove` for quota lookup after removing the initial member
- `directory_stat_size_nonzero` for directory `stat(2)` size reporting
- `foreground_target_durability_counts` for foreground-target durable replica accounting

Current branch state:

- Rebased onto current `koverstreet/ktest` `master` at `e2da0fe`.
- Head: `951f1b8`.
- Related current code PR: koverstreet/bcachefs-tools#596 for the failed-remove state cleanup.
- Related already-applied/fixed bcachefs-tools testing topics include directory size reporting, allocator copygc diagnostics, async object debug lifetime, printbuf overflow, and fast-discard revalidation.

Validation:

- `git diff --check origin/master...HEAD -- tests/fs/bcachefs/quota.ktest tests/fs/bcachefs/single_device.ktest tests/fs/bcachefs/tier.ktest`
- `bash -n tests/fs/bcachefs/quota.ktest tests/fs/bcachefs/single_device.ktest tests/fs/bcachefs/tier.ktest`

Earlier QEMU validation before this rebase passed these lanes on the refreshed bcachefs aggregate stack:

- `tier.ktest failed_device_remove_restores_rw`
- `tier.ktest device_remove_rewrites_metadata`
- `tier.ktest foreground_target_full_fallback`
- `quota.ktest prjquota_after_primary_device_remove`
- `single_device.ktest directory_stat_size_nonzero`
