### PR TITLE
build-test-kernel: keep source -k local

### DIFF
--- a/build-test-kernel
+++ b/build-test-kernel
@@ -69,9 +69,13 @@ ktest_build_variant=""
 ktest_build_destdir=""
 
 while getopts "k:Pc:M:KV:D:h${ktest_args}" arg; do
+    parse_shared_arg=true
     case $arg in
 	k)
 	    ktest_kernel_source="$OPTARG"
+	    # build-test-kernel owns -k as "kernel source"; libktest owns -k as
+	    # "prebuilt kernel". Do not feed this one to the shared parser.
+	    parse_shared_arg=false
 	    ;;
 	P)
 	    ktest_precise=true
@@ -106,7 +110,9 @@ while getopts "k:Pc:M:KV:D:h${ktest_args}" arg; do
 	    exit 0
 	    ;;
     esac
-    parse_ktest_arg $arg
+    if $parse_shared_arg; then
+	parse_ktest_arg $arg
+    fi
 done
 shift $(( OPTIND - 1 ))
 

--- a/src/bin/cgi.rs
+++ b/src/bin/cgi.rs
@@ -4,8 +4,8 @@ extern crate cgi;
 extern crate querystring;
 
 use ci_cgi::{
-    api, branch_get_results, ciconfig_read, last_good_line, update_lcov, CiConfig,
-    CommitResults, TestResultsMap, TestStatus, Userrc,
+    api, branch_get_results, ciconfig_read, last_good_line, update_lcov, CiConfig, CommitResults,
+    TestResultsMap, TestStatus, Userrc,
 };
 
 const STYLESHEET: &str = "bootstrap.min.css";
@@ -141,7 +141,11 @@ fn ci_log(ci: &Ci) -> cgi::Response {
 
     let commits = ci_branch_get_results(ci);
     if let Err(e) = commits {
-        return if ci.json { json_error(e) } else { error_response(e) };
+        return if ci.json {
+            json_error(e)
+        } else {
+            error_response(e)
+        };
     }
 
     let commits = commits.unwrap();
@@ -353,7 +357,11 @@ fn ci_commit(ci: &Ci) -> cgi::Response {
 
     let commits = ci_branch_get_results(ci);
     if let Err(e) = commits {
-        return if ci.json { json_error(e) } else { error_response(e) };
+        return if ci.json {
+            json_error(e)
+        } else {
+            error_response(e)
+        };
     }
     let commits = commits.unwrap();
 
@@ -506,7 +514,11 @@ fn ci_user(ci: &Ci) -> cgi::Response {
 
     if u.is_none() {
         let e = format!("User {} not found", &username);
-        return if ci.json { json_error(e) } else { error_response(e) };
+        return if ci.json {
+            json_error(e)
+        } else {
+            error_response(e)
+        };
     }
     let u = u.unwrap();
 
@@ -630,7 +642,6 @@ fn error_response(msg: String) -> cgi::Response {
     writeln!(&mut out, "env: {:?}", env).unwrap();
     cgi::text_response(200, out)
 }
-
 
 /// CSS for the live status page.
 const STATUS_CSS: &str = "

--- a/src/bin/ci-daemon.rs
+++ b/src/bin/ci-daemon.rs
@@ -15,20 +15,20 @@
 // on branch change (it currently refills only as the window drains).
 
 use anyhow::Result;
+use chrono::Utc;
 use ci_cgi::jobs::{desired_jobs, Job, JobKey};
 use ci_cgi::{
     ciconfig_read, read_test_result, result_basename, subtest_result_key, CiConfig, TestResult,
     TestResultsMap, TestResultsStore, TestStatus,
 };
-use std::sync::Arc;
-use chrono::Utc;
 use clap::Parser;
 use jobkit::{
-    ClaimedJob, Choir, Command, ExecutorConfig, ExecutorHandle, JobId, JobOutcome, JobSpec,
+    Choir, ClaimedJob, Command, ExecutorConfig, ExecutorHandle, JobId, JobOutcome, JobSpec,
     TaskError,
 };
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Bounded job window: jobkit never holds much more than this — the
@@ -47,15 +47,22 @@ const MAINTENANCE_INTERVAL: Duration = Duration::from_secs(30 * 60);
 /// ssh calls to one worker share a single connection. BatchMode so a
 /// missing key fails fast instead of hanging on a prompt.
 const SSH_OPTS: &[&str] = &[
-    "-o", "ControlMaster=auto",
-    "-o", "ControlPath=~/.ssh/ci-master-%r@%h:%p",
-    "-o", "ControlPersist=10m",
-    "-o", "ServerAliveInterval=10",
-    "-o", "ConnectTimeout=20",
-    "-o", "BatchMode=yes",
+    "-o",
+    "ControlMaster=auto",
+    "-o",
+    "ControlPath=~/.ssh/ci-master-%r@%h:%p",
+    "-o",
+    "ControlPersist=10m",
+    "-o",
+    "ServerAliveInterval=10",
+    "-o",
+    "ConnectTimeout=20",
+    "-o",
+    "BatchMode=yes",
     // Trust a worker's host key on first contact (the farm is ours);
     // BatchMode can't prompt, so an unknown host would otherwise fail.
-    "-o", "StrictHostKeyChecking=accept-new",
+    "-o",
+    "StrictHostKeyChecking=accept-new",
 ];
 
 #[derive(Parser)]
@@ -168,7 +175,13 @@ fn format_full_log(
 ) -> Vec<u8> {
     let header = format!(
         "# host={} slot={} commit={} kernel={} test={} env={} subtests={}\n",
-        host, slot, p.commit, p.kernel, p.test, p.env, subtests.join(","),
+        host,
+        slot,
+        p.commit,
+        p.kernel,
+        p.test,
+        p.env,
+        subtests.join(","),
     );
     let exec_slice = std::fs::read(exec_log_path)
         .ok()
@@ -183,7 +196,8 @@ fn format_full_log(
         &exec_slice,
         b"\n# --- supervisor full_log ---\n",
         supervisor_body,
-    ].concat()
+    ]
+    .concat()
 }
 
 /// Brotli-compress `path` to `<path>.br` and remove the original — the
@@ -237,9 +251,7 @@ async fn run_ktest_job(
     let exec_log_offset_start = handle.log_offset();
     let exec_log_path = handle.log_path().to_path_buf();
 
-    let result = run_ktest_job_inner(
-        handle, host, slot, &exec_log_path, results, batch,
-    ).await;
+    let result = run_ktest_job_inner(handle, host, slot, &exec_log_path, results, batch).await;
 
     // Drop the worker-side per-batch ktest-tmp dir (scratch devices,
     // sockets, env files). ktest's own EXIT trap usually cleans it
@@ -247,9 +259,9 @@ async fn run_ktest_job(
     // mechanism the /tmp/ktest-* leaks were going through. Always
     // ssh+rm here so the daemon is the source of truth for that dir.
     let ws = format!("ktest-ci/{}", slot);
-    let _ = handle.run_command(
-        ssh_cmd(host, &format!("rm -rf {}/ktest-tmp", ws), false),
-    ).await;
+    let _ = handle
+        .run_command(ssh_cmd(host, &format!("rm -rf {}/ktest-tmp", ws), false))
+        .await;
 
     let p = &batch[0].payload;
     let commit_dir = p.output_dir.join(&p.commit);
@@ -259,30 +271,49 @@ async fn run_ktest_job(
     // full_log written here so the dashboard has something. The
     // executor-log slice from batch start to now captures whatever
     // ssh output we saw.
-    let missing: Vec<&ClaimedJob<JobParams>> = batch.iter().filter(|j| {
-        let key = subtest_result_key(
-            &j.payload.test, &j.payload.subtest, &j.payload.kernel, &j.payload.env,
-        );
-        !commit_dir.join(&key).join("full_log.br").exists()
-    }).collect();
+    let missing: Vec<&ClaimedJob<JobParams>> = batch
+        .iter()
+        .filter(|j| {
+            let key = subtest_result_key(
+                &j.payload.test,
+                &j.payload.subtest,
+                &j.payload.kernel,
+                &j.payload.env,
+            );
+            !commit_dir.join(&key).join("full_log.br").exists()
+        })
+        .collect();
 
     if !missing.is_empty() {
         let content = format_full_log(
-            host, slot, p, &batch.iter().map(|j| j.payload.subtest.as_str())
+            host,
+            slot,
+            p,
+            &batch
+                .iter()
+                .map(|j| j.payload.subtest.as_str())
                 .collect::<Vec<_>>(),
-            &exec_log_path, exec_log_offset_start,
-            &[],  // no supervisor body — inner didn't reach the pull
+            &exec_log_path,
+            exec_log_offset_start,
+            &[], // no supervisor body — inner didn't reach the pull
         );
         for j in missing {
             let key = subtest_result_key(
-                &j.payload.test, &j.payload.subtest, &j.payload.kernel, &j.payload.env,
+                &j.payload.test,
+                &j.payload.subtest,
+                &j.payload.kernel,
+                &j.payload.env,
             );
             let d = commit_dir.join(&key);
             let full_log_path = d.join("full_log");
-            if let Err(e) = std::fs::create_dir_all(&d)
-                .and_then(|()| std::fs::write(&full_log_path, &content))
+            if let Err(e) =
+                std::fs::create_dir_all(&d).and_then(|()| std::fs::write(&full_log_path, &content))
             {
-                handle.log_line(format!("fallback full_log {}: {}", full_log_path.display(), e));
+                handle.log_line(format!(
+                    "fallback full_log {}: {}",
+                    full_log_path.display(),
+                    e
+                ));
                 continue;
             }
             if let Err(e) = brotli_compress(&full_log_path) {
@@ -303,17 +334,23 @@ async fn run_ktest_job(
         let mut updates = TestResultsMap::new();
         for j in batch {
             let key = subtest_result_key(
-                &j.payload.test, &j.payload.subtest, &j.payload.kernel, &j.payload.env,
+                &j.payload.test,
+                &j.payload.subtest,
+                &j.payload.kernel,
+                &j.payload.env,
             );
             if results.lookup(&p.commit, &key) == Some(TestStatus::Inprogress) {
                 let d = commit_dir.join(&key);
                 let _ = std::fs::create_dir_all(&d)
                     .and_then(|()| std::fs::write(d.join("status"), "FAILED TO RUN\n"));
-                updates.insert(key, TestResult {
-                    status: TestStatus::FailedToRun,
-                    starttime: now,
-                    duration: 0,
-                });
+                updates.insert(
+                    key,
+                    TestResult {
+                        status: TestStatus::FailedToRun,
+                        starttime: now,
+                        duration: 0,
+                    },
+                );
             }
         }
         results.update(&p.commit, updates);
@@ -341,8 +378,7 @@ async fn run_ktest_job_inner(
     handle.log_line(format!("=== batch on {}:{} ===", host, slot));
 
     // Subtests still owed a verdict — the whole claimed batch to start.
-    let mut remaining: Vec<String> =
-        batch.iter().map(|j| j.payload.subtest.clone()).collect();
+    let mut remaining: Vec<String> = batch.iter().map(|j| j.payload.subtest.clone()).collect();
 
     // Mark every subtest in-progress immediately: in the store (which
     // is what the cgi reads via the capnp) and in our output_dir
@@ -361,11 +397,14 @@ async fn run_ktest_job_inner(
         {
             handle.log_line(format!("marking {st} in-progress: {e}"));
         }
-        inprogress_map.insert(key, TestResult {
-            status: TestStatus::Inprogress,
-            starttime: now,
-            duration: 0,
-        });
+        inprogress_map.insert(
+            key,
+            TestResult {
+                status: TestStatus::Inprogress,
+                starttime: now,
+                duration: 0,
+            },
+        );
     }
     results.update(&p.commit, inprogress_map);
 
@@ -396,14 +435,21 @@ async fn run_ktest_job_inner(
     run_step(handle, host, &checkout, "checkout").await?;
 
     // 2. Build the supervisor (idempotent C helper).
-    run_step(handle, host, "make -C ~/ktest/lib supervisor", "build supervisor").await?;
+    run_step(
+        handle,
+        host,
+        "make -C ~/ktest/lib supervisor",
+        "build supervisor",
+    )
+    .await?;
 
     // 3. Clean ktest-out (keep the kernel build cache); mark every
     //    subtest in-progress worker-side too so a dead VM still leaves
     //    a status for the supervisor to scan. Once: the resume loop
     //    re-runs only not-completed subtests and must not wipe the
     //    rest's results.
-    let mark = remaining.iter()
+    let mark = remaining
+        .iter()
         .map(|st| {
             let d = subtest_result_key(&p.test, st, &p.kernel, &p.env);
             format!("mkdir -p ktest-out/out/{d}; echo 'IN PROGRESS' > ktest-out/out/{d}/status")
@@ -416,7 +462,8 @@ async fn run_ktest_job_inner(
              find ktest-out -mindepth 1 -maxdepth 1 ! -name 'kernel*' -exec rm -rf {{}} +; \
          fi; \
          {mark}",
-        ws = ws, mark = mark,
+        ws = ws,
+        mark = mark,
     );
     run_step(handle, host, &prepare, "prepare").await?;
 
@@ -437,7 +484,10 @@ async fn run_ktest_job_inner(
         // teardown below catches it even if bash's EXIT trap doesn't
         // fire (SIGKILL, OOM); avoids /tmp/ktest-* leaks.
         let runner = if p.kernel.is_empty() {
-            format!("~/ktest/build-test-kernel run -k {}/{} -T ktest-tmp -P", ws, p.repo)
+            format!(
+                "~/ktest/build-test-kernel run -k {}/{} -T ktest-tmp -P",
+                ws, p.repo
+            )
         } else {
             format!("~/ktest/ktest run -k {} -T ktest-tmp", p.kernel)
         };
@@ -472,18 +522,22 @@ async fn run_ktest_job_inner(
         let run = format!(
             "( {run} ) || {{ echo '=== run failed -- git clean + retry ==='; \
              git -C ~/{ws}/{repo} clean -fdqx; ( {run} ); }}",
-            run = run, ws = ws, repo = p.repo,
+            run = run,
+            ws = ws,
+            repo = p.repo,
         );
         // -tt: force a pty so a dropped ssh hangs up and SIGHUP reaps
         // the supervisor, the kernel build, and the VM together.
-        handle.run_command(ssh_cmd(host, &run, true))
+        handle
+            .run_command(ssh_cmd(host, &run, true))
             .await
             .map_err(|e| TaskError::Retry(format!("running supervisor: {e}")))?;
 
         // 5. Pull the remaining subtests' result dirs back to the
         //    daemon's output_dir.
         handle.log_line("=== pull results ===".to_string());
-        let dirs = remaining.iter()
+        let dirs = remaining
+            .iter()
             .map(|st| subtest_result_key(&p.test, st, &p.kernel, &p.env))
             .collect::<Vec<_>>()
             .join(" ");
@@ -492,7 +546,9 @@ async fn run_ktest_job_inner(
              | tar -x -C {dst}",
             dst = commit_dir.display(),
             opts = SSH_OPTS.join(" "),
-            host = host, ws = ws, dirs = dirs,
+            host = host,
+            ws = ws,
+            dirs = dirs,
         );
         let mut pull_cmd = Command::new("bash");
         pull_cmd.arg("-c").arg(&pull);
@@ -515,7 +571,8 @@ async fn run_ktest_job_inner(
             let _ = std::fs::remove_file(
                 commit_dir
                     .join(subtest_result_key(&p.test, st, &p.kernel, &p.env))
-                    .join("full_log.br"));
+                    .join("full_log.br"),
+            );
         }
 
         // Compose this iter's full_log: batch header + iter slice of
@@ -527,9 +584,12 @@ async fn run_ktest_job_inner(
         let primary_path = primary_dir.join("full_log");
         let supervisor_body = std::fs::read(&primary_path).unwrap_or_default();
         let content = format_full_log(
-            host, slot, p,
+            host,
+            slot,
+            p,
             &remaining.iter().map(String::as_str).collect::<Vec<_>>(),
-            exec_log_path, iter_offset,
+            exec_log_path,
+            iter_offset,
             &supervisor_body,
         );
         if let Err(e) = std::fs::write(&primary_path, &content) {
@@ -591,7 +651,9 @@ async fn run_ktest_job_inner(
         // failure — re-running the same VM the same way won't help.
         if next.len() == remaining.len() {
             return Err(TaskError::Retry(format!(
-                "run completed no subtests: {}", remaining.join(" "))));
+                "run completed no subtests: {}",
+                remaining.join(" ")
+            )));
         }
         remaining = next;
     }
@@ -627,7 +689,11 @@ async fn run_executor(
 fn make_job_spec(rc: &CiConfig, job: &Job) -> JobSpec<JobParams> {
     let k = &job.key;
     let name = format!("{} {} {}", short_commit(&k.commit), k.test, k.subtest);
-    let repo_url = rc.ktest.repo_url(&k.repo).map(String::from).unwrap_or_default();
+    let repo_url = rc
+        .ktest
+        .repo_url(&k.repo)
+        .map(String::from)
+        .unwrap_or_default();
     let params = JobParams {
         repo: k.repo.clone(),
         commit: k.commit.clone(),
@@ -756,7 +822,11 @@ fn prewarm_ssh_masters(rc: &CiConfig) {
     for (host, mut child) in spawned {
         match child.wait() {
             Ok(s) if s.success() => eprintln!("ci-daemon: ssh master to {} ready", host),
-            Ok(s) => eprintln!("ci-daemon: ssh master to {} failed (exit {:?})", host, s.code()),
+            Ok(s) => eprintln!(
+                "ci-daemon: ssh master to {} failed (exit {:?})",
+                host,
+                s.code()
+            ),
             Err(e) => eprintln!("ci-daemon: ssh master to {}: {}", host, e),
         }
     }
@@ -764,12 +834,7 @@ fn prewarm_ssh_masters(rc: &CiConfig) {
 
 /// `git fetch <fetch>` in `path`, then point the local ref
 /// `<user>/<branch>` at the freshly-fetched FETCH_HEAD.
-fn fetch_branch(
-    path: &std::path::Path,
-    user: &str,
-    branch: &str,
-    fetch: &str,
-) -> Result<()> {
+fn fetch_branch(path: &std::path::Path, user: &str, branch: &str, fetch: &str) -> Result<()> {
     let status = std::process::Command::new("git")
         .arg("-C")
         .arg(path)
@@ -801,10 +866,13 @@ fn spawn_repo_fetcher(rc: &CiConfig) {
         let Ok(userconfig) = userconfig else { continue };
         for (branch, bc) in &userconfig.branches {
             match rc.ktest.repo_path(&bc.repo) {
-                Some(path) =>
-                    branches.push((user.clone(), branch.clone(), path.to_path_buf(), bc.fetch.clone())),
-                None =>
-                    eprintln!("ci-daemon: repo-fetcher: no path for repo {}", bc.repo),
+                Some(path) => branches.push((
+                    user.clone(),
+                    branch.clone(),
+                    path.to_path_buf(),
+                    bc.fetch.clone(),
+                )),
+                None => eprintln!("ci-daemon: repo-fetcher: no path for repo {}", bc.repo),
             }
         }
     }

--- a/src/bin/ci-status.rs
+++ b/src/bin/ci-status.rs
@@ -1,7 +1,6 @@
 use ci_cgi::{
-    api, branch_entries, branch_get_results, commitdir_get_results_full,
-    format_duration, ktestrc_read, Ktestrc, BranchEntry,
-    TestStatus,
+    api, branch_entries, branch_get_results, commitdir_get_results_full, format_duration,
+    ktestrc_read, BranchEntry, Ktestrc, TestStatus,
 };
 use clap::{Parser, Subcommand};
 use std::io::Read;
@@ -27,7 +26,11 @@ struct Args {
     user: Option<String>,
 
     /// Dashboard URL for --user mode
-    #[arg(long, global = true, default_value = "https://evilpiepirate.org/~testdashboard/ci")]
+    #[arg(
+        long,
+        global = true,
+        default_value = "https://evilpiepirate.org/~testdashboard/ci"
+    )]
     dashboard: String,
 
     /// Branch context for `show` in --user mode (the server resolves
@@ -117,18 +120,26 @@ enum Command {
 }
 
 // ANSI color helpers
-fn color_passed(s: &str) -> String   { format!("\x1b[32m{}\x1b[0m", s) }
-fn color_failed(s: &str) -> String   { format!("\x1b[31m{}\x1b[0m", s) }
-fn color_inprog(s: &str) -> String   { format!("\x1b[33m{}\x1b[0m", s) }
-fn color_dim(s: &str) -> String      { format!("\x1b[2m{}\x1b[0m", s) }
+fn color_passed(s: &str) -> String {
+    format!("\x1b[32m{}\x1b[0m", s)
+}
+fn color_failed(s: &str) -> String {
+    format!("\x1b[31m{}\x1b[0m", s)
+}
+fn color_inprog(s: &str) -> String {
+    format!("\x1b[33m{}\x1b[0m", s)
+}
+fn color_dim(s: &str) -> String {
+    format!("\x1b[2m{}\x1b[0m", s)
+}
 
 fn color_status(status: TestStatus) -> String {
     let s = status.to_str();
     match status {
-        TestStatus::Passed     => color_passed(s),
-        TestStatus::Failed     => color_failed(s),
+        TestStatus::Passed => color_passed(s),
+        TestStatus::Failed => color_failed(s),
         TestStatus::Inprogress => color_inprog(s),
-        _                      => color_dim(s),
+        _ => color_dim(s),
     }
 }
 
@@ -149,7 +160,10 @@ fn resolve_branch(repo: &git2::Repository, ktest: &Ktestrc, name: &str) -> anyho
         return Ok(name.to_string());
     }
 
-    anyhow::bail!("can't resolve '{}' — try a full ref like 'remote/branch'", name)
+    anyhow::bail!(
+        "can't resolve '{}' — try a full ref like 'remote/branch'",
+        name
+    )
 }
 
 /// Open the git repo a branch's commits live in. Branches name their
@@ -161,7 +175,8 @@ fn open_branch_repo(ktest: &Ktestrc, branch: &str) -> anyhow::Result<git2::Repos
         let userrc = ci_cgi::users::userrc_read_str(&config).ok()?;
         let b = userrc.branches.get(branch)?;
         ktest.repo_path(&b.repo).map(|p| p.to_path_buf())
-    })().unwrap_or_else(|| ktest.linux_repo.clone());
+    })()
+    .unwrap_or_else(|| ktest.linux_repo.clone());
 
     Ok(git2::Repository::open(repo_path)?)
 }
@@ -190,11 +205,7 @@ fn resolve_commit_prefix(ktest: &Ktestrc, prefix: &str) -> anyhow::Result<String
     }
 }
 
-fn cmd_log(
-    branch: &str,
-    ktest: &Ktestrc,
-    json: bool,
-) -> anyhow::Result<()> {
+fn cmd_log(branch: &str, ktest: &Ktestrc, json: bool) -> anyhow::Result<()> {
     unsafe {
         git2::opts::set_verify_owner_validation(false)
             .expect("set_verify_owner_validation should never fail");
@@ -222,23 +233,42 @@ fn render_log(entries: &[BranchEntry], branch: &str, json: bool) -> anyhow::Resu
     }
 
     // Header
-    println!("{:<14} {:>6} {:>6} {:>6} {:>6} {:>8}  {}",
-        "COMMIT", "PASS", "FAIL", "FTRUN", "INPRO", "DURATION", "MESSAGE");
+    println!(
+        "{:<14} {:>6} {:>6} {:>6} {:>6} {:>8}  {}",
+        "COMMIT", "PASS", "FAIL", "FTRUN", "INPRO", "DURATION", "MESSAGE"
+    );
     println!("{}", "-".repeat(80));
 
     for e in entries {
         let subject = e.message.lines().next().unwrap_or("");
-        let subject = if subject.len() > 50 { &subject[..50] } else { subject };
+        let subject = if subject.len() > 50 {
+            &subject[..50]
+        } else {
+            subject
+        };
 
-        let commit = if e.commit_id.len() >= 12 { &e.commit_id[..12] } else { &e.commit_id };
+        let commit = if e.commit_id.len() >= 12 {
+            &e.commit_id[..12]
+        } else {
+            &e.commit_id
+        };
 
         let pass_s = format!("{}", e.passed);
         let fail_s = format!("{}", e.failed);
 
-        println!("{:<14} {:>6} {:>6} {:>6} {:>6} {:>8}  {}",
+        println!(
+            "{:<14} {:>6} {:>6} {:>6} {:>6} {:>8}  {}",
             commit,
-            if e.passed > 0 { color_passed(&pass_s) } else { pass_s },
-            if e.failed > 0 { color_failed(&fail_s) } else { fail_s },
+            if e.passed > 0 {
+                color_passed(&pass_s)
+            } else {
+                pass_s
+            },
+            if e.failed > 0 {
+                color_failed(&fail_s)
+            } else {
+                fail_s
+            },
             e.failed_to_run,
             e.inprogress,
             format_duration(e.duration),
@@ -249,11 +279,7 @@ fn render_log(entries: &[BranchEntry], branch: &str, json: bool) -> anyhow::Resu
     Ok(())
 }
 
-fn cmd_show(
-    commit: &str,
-    ktest: &Ktestrc,
-    json: bool,
-) -> anyhow::Result<()> {
+fn cmd_show(commit: &str, ktest: &Ktestrc, json: bool) -> anyhow::Result<()> {
     let commit = resolve_commit_prefix(ktest, commit)?;
 
     let full = commitdir_get_results_full(ktest, &commit)?;
@@ -294,19 +320,20 @@ fn render_show(detail: &api::CommitTests, json: bool) -> anyhow::Result<()> {
     // Sort tests: failed first, then in-progress, then passed, then rest
     let mut tests: Vec<_> = detail.tests.iter().collect();
     tests.sort_by_key(|t| match TestStatus::from_str(&t.status) {
-        TestStatus::Failed     => 0,
+        TestStatus::Failed => 0,
         TestStatus::Inprogress => 1,
-        TestStatus::Notrun     => 2,
-        TestStatus::Unknown    => 3,
+        TestStatus::Notrun => 2,
+        TestStatus::Unknown => 3,
         TestStatus::FailedToRun => 4,
-        TestStatus::Passed     => 5,
+        TestStatus::Passed => 5,
     });
 
     println!("{:<60} {:>12} {:>8}", "TEST", "STATUS", "DURATION");
     println!("{}", "-".repeat(82));
 
     for t in &tests {
-        println!("{:<60} {:>12} {:>8}",
+        println!(
+            "{:<60} {:>12} {:>8}",
             t.name,
             color_status(TestStatus::from_str(&t.status)),
             format_duration(t.duration),
@@ -314,12 +341,16 @@ fn render_show(detail: &api::CommitTests, json: bool) -> anyhow::Result<()> {
     }
 
     fn count(tests: &[api::TestEntry], s: TestStatus) -> usize {
-        tests.iter().filter(|t| TestStatus::from_str(&t.status) == s).count()
+        tests
+            .iter()
+            .filter(|t| TestStatus::from_str(&t.status) == s)
+            .count()
     }
     let total_duration: u64 = detail.tests.iter().map(|t| t.duration).sum();
 
     println!();
-    println!("{} total: {} passed, {} failed, {} in progress, {}",
+    println!(
+        "{} total: {} passed, {} failed, {} in progress, {}",
         detail.tests.len(),
         color_passed(&count(&detail.tests, TestStatus::Passed).to_string()),
         color_failed(&count(&detail.tests, TestStatus::Failed).to_string()),
@@ -335,7 +366,9 @@ fn user_config_path(ktest: &Ktestrc) -> std::path::PathBuf {
 }
 
 fn ci_scp_path(ktest: &Ktestrc) -> anyhow::Result<String> {
-    let host = ktest.ci_host.as_deref()
+    let host = ktest
+        .ci_host
+        .as_deref()
         .ok_or_else(|| anyhow::anyhow!("ci_host not set in config"))?;
     Ok(format!("{}:ci.json5", host))
 }
@@ -351,7 +384,10 @@ fn cmd_pull_config(ktest: &Ktestrc) -> anyhow::Result<()> {
         .status()?;
 
     if !status.success() {
-        anyhow::bail!("scp {} failed — you may need to set up ~/ci.json5 on the server", remote);
+        anyhow::bail!(
+            "scp {} failed — you may need to set up ~/ci.json5 on the server",
+            remote
+        );
     }
 
     println!("Config saved to {}", dest.display());
@@ -363,7 +399,10 @@ fn cmd_push_config(ktest: &Ktestrc) -> anyhow::Result<()> {
     let src = user_config_path(ktest);
 
     if !src.exists() {
-        anyhow::bail!("no local config at {} — run pull-config first", src.display());
+        anyhow::bail!(
+            "no local config at {} — run pull-config first",
+            src.display()
+        );
     }
 
     let status = std::process::Command::new("scp")
@@ -386,13 +425,17 @@ fn cmd_branches(ktest: &Ktestrc, json: bool) -> anyhow::Result<()> {
     let userrc = ci_cgi::users::userrc_read_str(&config)?;
 
     if json {
-        let branches: Vec<serde_json::Value> = userrc.branches.iter().map(|(name, b)| {
-            serde_json::json!({
-                "name": name,
-                "fetch": &b.fetch,
-                "test_groups": &b.test_groups,
+        let branches: Vec<serde_json::Value> = userrc
+            .branches
+            .iter()
+            .map(|(name, b)| {
+                serde_json::json!({
+                    "name": name,
+                    "fetch": &b.fetch,
+                    "test_groups": &b.test_groups,
+                })
             })
-        }).collect();
+            .collect();
         println!("{}", serde_json::to_string_pretty(&branches)?);
         return Ok(());
     }
@@ -423,7 +466,9 @@ fn fetch_log(ktest: &Ktestrc, commit: &str, test: &str, full: bool) -> anyhow::R
     }
 
     // Fall back to remote
-    let ci_url = ktest.ci_url.as_deref()
+    let ci_url = ktest
+        .ci_url
+        .as_deref()
         .ok_or_else(|| anyhow::anyhow!("no ci_url configured and log not found locally"))?;
 
     let url = format!("{}/{}/{}/{}", ci_url, commit, test, filename);
@@ -437,12 +482,7 @@ fn fetch_log(ktest: &Ktestrc, commit: &str, test: &str, full: bool) -> anyhow::R
     decompress_brotli(&data)
 }
 
-fn cmd_logs(
-    commit: &str,
-    test: Option<&str>,
-    full: bool,
-    ktest: &Ktestrc,
-) -> anyhow::Result<()> {
+fn cmd_logs(commit: &str, test: Option<&str>, full: bool, ktest: &Ktestrc) -> anyhow::Result<()> {
     let commit = resolve_commit_prefix(ktest, commit)?;
 
     let results = commitdir_get_results_full(ktest, &commit)?;
@@ -450,7 +490,9 @@ fn cmd_logs(
     match test {
         Some(filter) => {
             // Find matching test(s)
-            let matches: Vec<_> = results.tests.iter()
+            let matches: Vec<_> = results
+                .tests
+                .iter()
                 .filter(|(name, _)| name.contains(filter))
                 .collect();
 
@@ -482,7 +524,9 @@ fn cmd_logs(
         }
         None => {
             // No test specified — list failed tests
-            let mut failed: Vec<_> = results.tests.iter()
+            let mut failed: Vec<_> = results
+                .tests
+                .iter()
                 .filter(|(_, r)| r.status == TestStatus::Failed)
                 .collect();
             failed.sort_by_key(|(name, _)| (*name).clone());
@@ -496,7 +540,10 @@ fn cmd_logs(
             for (i, (name, r)) in failed.iter().enumerate() {
                 println!("  {:>3}. {} ({}s)", i + 1, name, r.duration);
             }
-            println!("\nUse: ci-status logs {} <test-name-or-substring>", &commit[..12]);
+            println!(
+                "\nUse: ci-status logs {} <test-name-or-substring>",
+                &commit[..12]
+            );
         }
     }
 
@@ -526,7 +573,9 @@ fn run() -> anyhow::Result<()> {
             }
             Command::Show { ref commit } => {
                 let branch = args.branch.as_deref().ok_or_else(|| {
-                    anyhow::anyhow!("show --user needs --branch (the server resolves commits per-branch)")
+                    anyhow::anyhow!(
+                        "show --user needs --branch (the server resolves commits per-branch)"
+                    )
                 })?;
                 let detail = server_show(&args.dashboard, user, branch, commit)?;
                 render_show(&detail, args.json)
@@ -554,23 +603,11 @@ fn run() -> anyhow::Result<()> {
     }
 
     match args.command {
-        Command::Log { branch } => {
-            cmd_log(&branch, &ktest, args.json)
-        }
-        Command::Show { commit } => {
-            cmd_show(&commit, &ktest, args.json)
-        }
-        Command::Logs { commit, test, full } => {
-            cmd_logs(&commit, test.as_deref(), full, &ktest)
-        }
-        Command::Branches => {
-            cmd_branches(&ktest, args.json)
-        }
-        Command::PullConfig => {
-            cmd_pull_config(&ktest)
-        }
-        Command::PushConfig => {
-            cmd_push_config(&ktest)
-        }
+        Command::Log { branch } => cmd_log(&branch, &ktest, args.json),
+        Command::Show { commit } => cmd_show(&commit, &ktest, args.json),
+        Command::Logs { commit, test, full } => cmd_logs(&commit, test.as_deref(), full, &ktest),
+        Command::Branches => cmd_branches(&ktest, args.json),
+        Command::PullConfig => cmd_pull_config(&ktest),
+        Command::PushConfig => cmd_push_config(&ktest),
     }
 }

--- a/src/bin/distro-kernel-fetch.rs
+++ b/src/bin/distro-kernel-fetch.rs
@@ -92,7 +92,8 @@ struct Source {
 }
 
 fn deserialize_repo_url<'de, D>(d: D) -> Result<Vec<String>, D::Error>
-where D: serde::Deserializer<'de>
+where
+    D: serde::Deserializer<'de>,
 {
     #[derive(Deserialize)]
     #[serde(untagged)]
@@ -102,8 +103,9 @@ where D: serde::Deserializer<'de>
     }
     match StringOrList::deserialize(d)? {
         StringOrList::Single(s) => Ok(vec![s]),
-        StringOrList::Multiple(v) if v.is_empty() =>
-            Err(serde::de::Error::custom("repo_url must have at least one entry")),
+        StringOrList::Multiple(v) if v.is_empty() => Err(serde::de::Error::custom(
+            "repo_url must have at least one entry",
+        )),
         StringOrList::Multiple(v) => Ok(v),
     }
 }
@@ -167,13 +169,13 @@ trait DistroFetcher {
 // ============================================================================
 
 fn http_get_bytes(url: &str) -> Result<Vec<u8>> {
-    let resp = reqwest::blocking::get(url)
-        .with_context(|| format!("GET {}", url))?;
+    let resp = reqwest::blocking::get(url).with_context(|| format!("GET {}", url))?;
     let status = resp.status();
     if !status.is_success() {
         bail!("GET {}: HTTP {}", url, status);
     }
-    let bytes = resp.bytes()
+    let bytes = resp
+        .bytes()
         .with_context(|| format!("reading body of {}", url))?;
     Ok(bytes.to_vec())
 }
@@ -260,12 +262,18 @@ fn natural_cmp(a: &str, b: &str) -> Ordering {
                     let (na, ra) = take_digits(a);
                     let (nb, rb) = take_digits(b);
                     match na.cmp(&nb) {
-                        Ordering::Equal => { a = ra; b = rb; }
+                        Ordering::Equal => {
+                            a = ra;
+                            b = rb;
+                        }
                         o => return o,
                     }
                 } else {
                     match ca.cmp(&cb) {
-                        Ordering::Equal => { a = &a[1..]; b = &b[1..]; }
+                        Ordering::Equal => {
+                            a = &a[1..];
+                            b = &b[1..];
+                        }
                         o => return o,
                     }
                 }
@@ -276,7 +284,10 @@ fn natural_cmp(a: &str, b: &str) -> Ordering {
 
 fn take_digits(s: &[u8]) -> (u64, &[u8]) {
     let end = s.iter().take_while(|c| c.is_ascii_digit()).count();
-    let n: u64 = std::str::from_utf8(&s[..end]).unwrap_or("0").parse().unwrap_or(0);
+    let n: u64 = std::str::from_utf8(&s[..end])
+        .unwrap_or("0")
+        .parse()
+        .unwrap_or(0);
     (n, &s[end..])
 }
 
@@ -309,7 +320,10 @@ fn apt_fetch_stanzas(src: &Source) -> Result<Vec<AptStanza>> {
         let text = String::from_utf8(gunzip(&body)?)
             .with_context(|| format!("Packages.gz from {} not UTF-8", url))?;
         for fields in parse_packages(&text) {
-            all.push(AptStanza { repo: repo.clone(), fields });
+            all.push(AptStanza {
+                repo: repo.clone(),
+                fields,
+            });
         }
     }
     Ok(all)
@@ -326,7 +340,11 @@ fn apt_stanza_to_pkgfile(s: &AptStanza) -> Option<PkgFile> {
     let filename = s.fields.get("Filename")?;
     let url = apt_url(&s.repo, filename);
     let sha256 = s.fields.get("SHA256").cloned();
-    Some(PkgFile { url, sha256, role: None })
+    Some(PkgFile {
+        url,
+        sha256,
+        role: None,
+    })
 }
 
 // ----------- Debian -----------
@@ -340,7 +358,9 @@ fn debian_abi_from_image<'a>(name: &'a str, arch: &str) -> Option<&'a str> {
 }
 
 fn debian_is_vanilla_image(name: &str, arch: &str) -> bool {
-    let Some(abi) = debian_abi_from_image(name, arch) else { return false };
+    let Some(abi) = debian_abi_from_image(name, arch) else {
+        return false;
+    };
     abi.chars().next().is_some_and(|c| c.is_ascii_digit())
         && !abi.contains("cloud")
         && !abi.ends_with("-rt")
@@ -384,12 +404,15 @@ fn debian_fixup(extracted: &Path, stage: &Path, version: &str) -> Result<()> {
     }
     if let Some(src) = kbuild_dir {
         let stage_lib = stage.join("lib");
-        fs::create_dir_all(&stage_lib)
-            .with_context(|| format!("mkdir {}", stage_lib.display()))?;
+        fs::create_dir_all(&stage_lib).with_context(|| format!("mkdir {}", stage_lib.display()))?;
         let dst = stage_lib.join(src.file_name().unwrap());
-        rename_or_copy(&src, &dst)
-            .with_context(|| format!("placing linux-kbuild {} -> {}",
-                                     src.display(), dst.display()))?;
+        rename_or_copy(&src, &dst).with_context(|| {
+            format!(
+                "placing linux-kbuild {} -> {}",
+                src.display(),
+                dst.display()
+            )
+        })?;
     } else {
         // Not fatal — older Debian releases (where headers shipped their
         // own scripts) didn't have this split. Pre-forky bookworm/trixie
@@ -416,7 +439,8 @@ fn debian_fixup(extracted: &Path, stage: &Path, version: &str) -> Result<()> {
     // Substitute `/usr/src/` → `$(THIS_DIR)/../` (since the Makefile lives
     // inside one of those /usr/src/linux-headers-<...> dirs, .. takes you
     // up to the equivalent of /usr/src, where the sibling dirs sit).
-    let hdrs_amd64 = stage.join("headers")
+    let hdrs_amd64 = stage
+        .join("headers")
         .join(format!("linux-headers-{}", version));
     let makefile = hdrs_amd64.join("Makefile");
     if makefile.is_file() {
@@ -427,7 +451,8 @@ fn debian_fixup(extracted: &Path, stage: &Path, version: &str) -> Result<()> {
                 "# Rewritten by distro-kernel-fetch — was /usr/src-anchored.\n\
                  THIS_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))\n\
                  {}",
-                text.replace("/usr/src/", "$(THIS_DIR)/../"));
+                text.replace("/usr/src/", "$(THIS_DIR)/../")
+            );
             use std::os::unix::fs::PermissionsExt;
             let mut perms = fs::metadata(&makefile)?.permissions();
             perms.set_mode(perms.mode() | 0o200);
@@ -461,10 +486,14 @@ fn opensuse_fixup(stage: &Path) -> Result<()> {
         Err(_) => return Ok(()),
     };
     let makefile = obj_dir.join("Makefile");
-    if !makefile.is_file() { return Ok(()) }
-    let text = fs::read_to_string(&makefile)
-        .with_context(|| format!("reading {}", makefile.display()))?;
-    if !text.contains("/usr/src/") { return Ok(()) }
+    if !makefile.is_file() {
+        return Ok(());
+    }
+    let text =
+        fs::read_to_string(&makefile).with_context(|| format!("reading {}", makefile.display()))?;
+    if !text.contains("/usr/src/") {
+        return Ok(());
+    }
 
     // The KBUILD_OUTPUT path always names this very directory, so map any
     // `/usr/src/linux-<...>-obj/<arch>/<flavor>` reference to $(THIS_DIR).
@@ -492,8 +521,7 @@ fn opensuse_fixup(stage: &Path) -> Result<()> {
     perms.set_mode(perms.mode() | 0o200);
     fs::set_permissions(&makefile, perms)
         .with_context(|| format!("chmod +w {}", makefile.display()))?;
-    fs::write(&makefile, out)
-        .with_context(|| format!("rewriting {}", makefile.display()))?;
+    fs::write(&makefile, out).with_context(|| format!("rewriting {}", makefile.display()))?;
     Ok(())
 }
 
@@ -501,25 +529,39 @@ struct DebianFetcher;
 impl DistroFetcher for DebianFetcher {
     fn latest_kernels(&self, src: &Source) -> Result<Vec<KernelPkg>> {
         let stanzas = apt_fetch_stanzas(src)?;
-        let by_name: HashMap<&str, &AptStanza> = stanzas.iter()
+        let by_name: HashMap<&str, &AptStanza> = stanzas
+            .iter()
             .filter_map(|s| s.fields.get("Package").map(|n| (n.as_str(), s)))
             .collect();
 
         let mut candidates: Vec<(&str, &str, &str)> = Vec::new();
         for s in &stanzas {
-            let Some(name) = s.fields.get("Package") else { continue };
-            if !debian_is_vanilla_image(name, &src.arch) { continue }
-            let Some(version) = s.fields.get("Version") else { continue };
-            let Some(abi) = debian_abi_from_image(name, &src.arch) else { continue };
+            let Some(name) = s.fields.get("Package") else {
+                continue;
+            };
+            if !debian_is_vanilla_image(name, &src.arch) {
+                continue;
+            }
+            let Some(version) = s.fields.get("Version") else {
+                continue;
+            };
+            let Some(abi) = debian_abi_from_image(name, &src.arch) else {
+                continue;
+            };
             candidates.push((name.as_str(), version.as_str(), abi));
         }
         if candidates.is_empty() {
-            bail!("no kernel-image packages found for {}/{}", src.distro, src.release);
+            bail!(
+                "no kernel-image packages found for {}/{}",
+                src.distro,
+                src.release
+            );
         }
         candidates.sort_by(|a, b| natural_cmp(a.1, b.1));
         let (img_name, _img_ver, abi) = *candidates.last().unwrap();
 
-        let img_stanza = by_name.get(img_name)
+        let img_stanza = by_name
+            .get(img_name)
             .ok_or_else(|| anyhow!("{}: stanza lost", img_name))?;
         let image = apt_stanza_to_pkgfile(img_stanza)
             .ok_or_else(|| anyhow!("{}: no Filename", img_name))?;
@@ -544,13 +586,19 @@ impl DistroFetcher for DebianFetcher {
         //
         // Silently skip any of the binary/modules pair that doesn't exist —
         // pre-forky releases ship them inside linux-image.
-        let arch_hdr   = format!("linux-headers-{}-{}", abi, src.arch);
+        let arch_hdr = format!("linux-headers-{}-{}", abi, src.arch);
         let common_hdr = format!("linux-headers-{}-common", abi);
         let kbuild_pkg = format!("linux-kbuild-{}", abi);
         let binary_pkg = format!("linux-binary-{}-{}", abi, src.arch);
         let modules_pkg = format!("linux-modules-{}-{}", abi, src.arch);
         let mut headers = Vec::new();
-        for hdr in [&arch_hdr, &common_hdr, &kbuild_pkg, &binary_pkg, &modules_pkg] {
+        for hdr in [
+            &arch_hdr,
+            &common_hdr,
+            &kbuild_pkg,
+            &binary_pkg,
+            &modules_pkg,
+        ] {
             if let Some(stanza) = by_name.get(hdr.as_str()) {
                 if let Some(p) = apt_stanza_to_pkgfile(stanza) {
                     headers.push(p);
@@ -586,7 +634,9 @@ fn ubuntu_abi_from_image(name: &str) -> Option<&str> {
 }
 
 fn ubuntu_is_vanilla_image(name: &str) -> bool {
-    let Some(abi) = ubuntu_abi_from_image(name) else { return false };
+    let Some(abi) = ubuntu_abi_from_image(name) else {
+        return false;
+    };
     abi.chars().next().is_some_and(|c| c.is_ascii_digit())
         && !abi.contains("-unsigned")
         && !abi.contains("-dbgsym")
@@ -596,18 +646,29 @@ struct UbuntuFetcher;
 impl DistroFetcher for UbuntuFetcher {
     fn latest_kernels(&self, src: &Source) -> Result<Vec<KernelPkg>> {
         let stanzas = apt_fetch_stanzas(src)?;
-        let by_name: HashMap<&str, &AptStanza> = stanzas.iter()
+        let by_name: HashMap<&str, &AptStanza> = stanzas
+            .iter()
             .filter_map(|s| s.fields.get("Package").map(|n| (n.as_str(), s)))
             .collect();
 
         let mut candidates: Vec<(&str, &str, &str)> = Vec::new();
         for s in &stanzas {
-            let Some(name) = s.fields.get("Package") else { continue };
-            if !ubuntu_is_vanilla_image(name) { continue }
+            let Some(name) = s.fields.get("Package") else {
+                continue;
+            };
+            if !ubuntu_is_vanilla_image(name) {
+                continue;
+            }
             // Filter to Architecture matching src.arch (Ubuntu has -generic on all arches).
-            if s.fields.get("Architecture").map(String::as_str) != Some(src.arch.as_str()) { continue }
-            let Some(version) = s.fields.get("Version") else { continue };
-            let Some(abi) = ubuntu_abi_from_image(name) else { continue };
+            if s.fields.get("Architecture").map(String::as_str) != Some(src.arch.as_str()) {
+                continue;
+            }
+            let Some(version) = s.fields.get("Version") else {
+                continue;
+            };
+            let Some(abi) = ubuntu_abi_from_image(name) else {
+                continue;
+            };
             candidates.push((name.as_str(), version.as_str(), abi));
         }
         if candidates.is_empty() {
@@ -616,7 +677,8 @@ impl DistroFetcher for UbuntuFetcher {
         candidates.sort_by(|a, b| natural_cmp(a.1, b.1));
         let (img_name, _img_ver, abi) = *candidates.last().unwrap();
 
-        let img_stanza = by_name.get(img_name)
+        let img_stanza = by_name
+            .get(img_name)
             .ok_or_else(|| anyhow!("{}: stanza lost", img_name))?;
         let image = apt_stanza_to_pkgfile(img_stanza)
             .ok_or_else(|| anyhow!("{}: no Filename", img_name))?;
@@ -643,15 +705,16 @@ impl DistroFetcher for UbuntuFetcher {
         // Packages list as Architecture: all (linux-riscv-X.Y on amd64,
         // etc.).
         let hdr_suffix = format!("-headers-{}", abi);
-        let flavor_stanza = by_name.get(flavor_hdr.as_str())
+        let flavor_stanza = by_name
+            .get(flavor_hdr.as_str())
             .ok_or_else(|| anyhow!("{}: flavor headers stanza missing", flavor_hdr))?;
-        let flavor_source = flavor_stanza.fields.get("Source")
-            .map(String::as_str);
-        let common_hdrs: Vec<&str> = by_name.iter()
+        let flavor_source = flavor_stanza.fields.get("Source").map(String::as_str);
+        let common_hdrs: Vec<&str> = by_name
+            .iter()
             .filter(|(name, stanza)| {
                 **name != flavor_hdr
-                && name.ends_with(&hdr_suffix)
-                && stanza.fields.get("Source").map(String::as_str) == flavor_source
+                    && name.ends_with(&hdr_suffix)
+                    && stanza.fields.get("Source").map(String::as_str) == flavor_source
             })
             .map(|(name, _)| *name)
             .collect();
@@ -682,7 +745,8 @@ impl DistroFetcher for UbuntuFetcher {
         let lib_rust_suffix = format!("-lib-rust-{}-generic", abi);
         for (name, stanza) in by_name.iter() {
             if name.ends_with(&lib_rust_suffix)
-                && stanza.fields.get("Source").map(String::as_str) == flavor_source {
+                && stanza.fields.get("Source").map(String::as_str) == flavor_source
+            {
                 if let Some(p) = apt_stanza_to_pkgfile(stanza) {
                     headers.push(p);
                 }
@@ -716,9 +780,9 @@ impl DistroFetcher for UbuntuFetcher {
 struct DnfPkg {
     name: String,
     arch: String,
-    version: String,   // <ver>
-    release: String,   // <rel>
-    location: String,  // href, relative to repo_base
+    version: String,  // <ver>
+    release: String,  // <rel>
+    location: String, // href, relative to repo_base
     sha256: Option<String>,
     /// The repo_url this package came from. RHEL-likes have kernel-core
     /// in BaseOS and kernel-devel in AppStream; storing repo_base on each
@@ -758,9 +822,7 @@ fn dnf_fetch_primary_url(repo: &str) -> Result<String> {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) if e.name().as_ref() == b"data" => {
                 for attr in e.attributes().flatten() {
-                    if attr.key.as_ref() == b"type"
-                        && attr.value.as_ref() == b"primary"
-                    {
+                    if attr.key.as_ref() == b"type" && attr.value.as_ref() == b"primary" {
                         in_primary = true;
                     }
                 }
@@ -808,8 +870,10 @@ fn dnf_fetch_packages(repo: &str) -> Result<Vec<DnfPkg>> {
                 match e.name().as_ref() {
                     b"package" => {
                         // Confirm type="rpm".
-                        let is_rpm = e.attributes().flatten().any(|a|
-                            a.key.as_ref() == b"type" && a.value.as_ref() == b"rpm");
+                        let is_rpm = e
+                            .attributes()
+                            .flatten()
+                            .any(|a| a.key.as_ref() == b"type" && a.value.as_ref() == b"rpm");
                         if is_rpm {
                             in_package = true;
                             cur = Some(DnfPkg {
@@ -827,39 +891,41 @@ fn dnf_fetch_packages(repo: &str) -> Result<Vec<DnfPkg>> {
                     b"arch" if in_package => text_target = Some("arch"),
                     b"checksum" if in_package => {
                         // Only capture sha256 — the only one we verify.
-                        let is_sha256 = e.attributes().flatten().any(|a|
-                            a.key.as_ref() == b"type" && a.value.as_ref() == b"sha256");
-                        if is_sha256 { text_target = Some("sha256"); }
-                    }
-                    _ => {}
-                }
-            }
-            Ok(Event::Empty(e)) if in_package => {
-                match e.name().as_ref() {
-                    b"version" => {
-                        if let Some(c) = cur.as_mut() {
-                            for attr in e.attributes().flatten() {
-                                let v = String::from_utf8_lossy(&attr.value).to_string();
-                                match attr.key.as_ref() {
-                                    b"ver" => c.version = v,
-                                    b"rel" => c.release = v,
-                                    _ => {}
-                                }
-                            }
-                        }
-                    }
-                    b"location" => {
-                        if let Some(c) = cur.as_mut() {
-                            for attr in e.attributes().flatten() {
-                                if attr.key.as_ref() == b"href" {
-                                    c.location = String::from_utf8_lossy(&attr.value).to_string();
-                                }
-                            }
+                        let is_sha256 = e
+                            .attributes()
+                            .flatten()
+                            .any(|a| a.key.as_ref() == b"type" && a.value.as_ref() == b"sha256");
+                        if is_sha256 {
+                            text_target = Some("sha256");
                         }
                     }
                     _ => {}
                 }
             }
+            Ok(Event::Empty(e)) if in_package => match e.name().as_ref() {
+                b"version" => {
+                    if let Some(c) = cur.as_mut() {
+                        for attr in e.attributes().flatten() {
+                            let v = String::from_utf8_lossy(&attr.value).to_string();
+                            match attr.key.as_ref() {
+                                b"ver" => c.version = v,
+                                b"rel" => c.release = v,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+                b"location" => {
+                    if let Some(c) = cur.as_mut() {
+                        for attr in e.attributes().flatten() {
+                            if attr.key.as_ref() == b"href" {
+                                c.location = String::from_utf8_lossy(&attr.value).to_string();
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            },
             Ok(Event::Text(t)) => {
                 if let Some(target) = text_target {
                     if let Some(c) = cur.as_mut() {
@@ -877,20 +943,18 @@ fn dnf_fetch_packages(repo: &str) -> Result<Vec<DnfPkg>> {
                 }
                 text_target = None;
             }
-            Ok(Event::End(e)) => {
-                match e.name().as_ref() {
-                    b"package" if in_package => {
-                        if let Some(c) = cur.take() {
-                            if !c.name.is_empty() {
-                                packages.push(c);
-                            }
+            Ok(Event::End(e)) => match e.name().as_ref() {
+                b"package" if in_package => {
+                    if let Some(c) = cur.take() {
+                        if !c.name.is_empty() {
+                            packages.push(c);
                         }
-                        in_package = false;
                     }
-                    b"name" | b"arch" | b"checksum" => text_target = None,
-                    _ => {}
+                    in_package = false;
                 }
-            }
+                b"name" | b"arch" | b"checksum" => text_target = None,
+                _ => {}
+            },
             Ok(Event::Eof) => break,
             Err(e) => bail!("parsing primary.xml: {}", e),
             _ => {}
@@ -932,18 +996,27 @@ fn fetch_dnf_kernel_core_family(src: &Source) -> Result<Vec<KernelPkg>> {
     let image = core.to_pkgfile();
 
     // Collect aux packages at the same version-release.
-    let aux_names = ["kernel-modules-core", "kernel-modules",
-                     "kernel-modules-extra", "kernel-devel"];
+    let aux_names = [
+        "kernel-modules-core",
+        "kernel-modules",
+        "kernel-modules-extra",
+        "kernel-devel",
+    ];
     let mut headers = Vec::new();
     for name in aux_names {
-        if let Some(p) = pkgs.iter().find(|p|
-            p.name == name && p.arch == src.arch && p.full_version() == core_ver)
+        if let Some(p) = pkgs
+            .iter()
+            .find(|p| p.name == name && p.arch == src.arch && p.full_version() == core_ver)
         {
             headers.push(p.to_pkgfile());
         }
     }
     if headers.is_empty() {
-        bail!("no kernel aux packages found at v {} for {}", core_ver, src.distro);
+        bail!(
+            "no kernel aux packages found at v {} for {}",
+            core_ver,
+            src.distro
+        );
     }
 
     Ok(vec![KernelPkg {
@@ -999,24 +1072,27 @@ impl DistroFetcher for SuseFetcher {
         //     different patchlevels (e.g. .21.2 vs kernel-default's .21.3) but
         //     extract to a dir whose name aligns at the SP-release level, so
         //     loose match (latest matching name+arch) is right
-        let tight = ["kernel-default-devel", "kernel-default-base",
-                     "kernel-default-extra"];
+        let tight = [
+            "kernel-default-devel",
+            "kernel-default-base",
+            "kernel-default-extra",
+        ];
         let loose = ["kernel-devel", "kernel-source", "kernel-syms"];
         let mut headers = Vec::new();
         for name in tight {
-            if let Some(p) = pkgs.iter().find(|p|
+            if let Some(p) = pkgs.iter().find(|p| {
                 p.name == name
-                && (p.arch == src.arch || p.arch == "noarch")
-                && p.full_version() == kver)
-            {
+                    && (p.arch == src.arch || p.arch == "noarch")
+                    && p.full_version() == kver
+            }) {
                 headers.push(p.to_pkgfile());
             }
         }
         // Pick the latest matching name+arch (drop the strict version-lock).
         for name in loose {
-            if let Some(p) = pkgs.iter()
-                .filter(|p| p.name == name
-                            && (p.arch == src.arch || p.arch == "noarch"))
+            if let Some(p) = pkgs
+                .iter()
+                .filter(|p| p.name == name && (p.arch == src.arch || p.arch == "noarch"))
                 .max_by(|a, b| natural_cmp(&a.full_version(), &b.full_version()))
             {
                 headers.push(p.to_pkgfile());
@@ -1062,10 +1138,14 @@ fn pacman_fetch_packages(db_url: &str) -> Result<Vec<PacmanPkg>> {
     for entry in archive.entries().context("pacman db: read entries")? {
         let mut entry = entry.context("pacman db: bad entry")?;
         let path = entry.path().context("pacman db: bad entry path")?;
-        if !path.ends_with("desc") { continue }
+        if !path.ends_with("desc") {
+            continue;
+        }
 
         let mut text = String::new();
-        entry.read_to_string(&mut text).context("pacman db: read desc")?;
+        entry
+            .read_to_string(&mut text)
+            .context("pacman db: read desc")?;
         packages.push(parse_pacman_desc(&text));
     }
     Ok(packages.into_iter().flatten().collect())
@@ -1088,7 +1168,9 @@ fn parse_pacman_desc(text: &str) -> Option<PacmanPkg> {
                 _ => "_",
             });
         } else if cur_key.is_some() && !line.is_empty() {
-            if !cur_val.is_empty() { cur_val.push('\n'); }
+            if !cur_val.is_empty() {
+                cur_val.push('\n');
+            }
             cur_val.push_str(line);
         }
     }
@@ -1125,20 +1207,22 @@ impl DistroFetcher for ArchFetcher {
         for repo in &src.repo_url {
             let base = format!("{}/core/os/{}", repo.trim_end_matches('/'), src.arch);
             let db_url = format!("{}/core.db", base);
-            let pkgs = pacman_fetch_packages(&db_url)
-                .with_context(|| format!("fetching {}", db_url))?;
+            let pkgs =
+                pacman_fetch_packages(&db_url).with_context(|| format!("fetching {}", db_url))?;
             for pkg in pkgs {
                 all.push((base.clone(), pkg));
             }
         }
 
         // The plain `linux` package; also pair with `linux-headers`.
-        let (kernel_base, kernel) = all.iter()
+        let (kernel_base, kernel) = all
+            .iter()
             .filter(|(_, p)| p.name == "linux")
             .max_by(|a, b| natural_cmp(&a.1.version, &b.1.version))
             .ok_or_else(|| anyhow!("no `linux` package in any of {:?}", src.repo_url))?;
-        let headers_pkg = all.iter().find(|(_, p)|
-            p.name == "linux-headers" && p.version == kernel.version);
+        let headers_pkg = all
+            .iter()
+            .find(|(_, p)| p.name == "linux-headers" && p.version == kernel.version);
 
         let image = PkgFile {
             url: format!("{}/{}", kernel_base, kernel.filename),
@@ -1214,11 +1298,20 @@ const NIXOS_CACHE_BASE: &str = "https://cache.nixos.org";
 /// The attr is the part before `.<arch>` — caller appends e.g. `.x86_64-linux`.
 fn nixos_jobset_attr(release: &str) -> (String, &'static str) {
     if release == "unstable" {
-        ("unstable".to_string(), "nixpkgs.linuxPackages_latest.kernel")
+        (
+            "unstable".to_string(),
+            "nixpkgs.linuxPackages_latest.kernel",
+        )
     } else if let Some(rel) = release.strip_suffix("-latest") {
-        (format!("release-{}", rel), "nixpkgs.linuxPackages_latest.kernel")
+        (
+            format!("release-{}", rel),
+            "nixpkgs.linuxPackages_latest.kernel",
+        )
     } else {
-        (format!("release-{}", release), "nixpkgs.linuxPackages.kernel")
+        (
+            format!("release-{}", release),
+            "nixpkgs.linuxPackages.kernel",
+        )
     }
 }
 
@@ -1226,16 +1319,19 @@ fn nixos_jobset_attr(release: &str) -> (String, &'static str) {
 /// uses "x86_64-linux" / "aarch64-linux". Map.
 fn nixos_hydra_arch(arch: &str) -> Result<&'static str> {
     match arch {
-        "x86_64"  => Ok("x86_64-linux"),
+        "x86_64" => Ok("x86_64-linux"),
         "aarch64" => Ok("aarch64-linux"),
-        a => bail!("nixos: unsupported arch `{}` (expected x86_64 or aarch64)", a),
+        a => bail!(
+            "nixos: unsupported arch `{}` (expected x86_64 or aarch64)",
+            a
+        ),
     }
 }
 
 #[derive(Debug)]
 struct HydraOutputs {
-    nixname: String,    // e.g. "linux-7.0.5"
-    out_path: String,   // /nix/store/<hash>-linux-X.Y.Z
+    nixname: String,  // e.g. "linux-7.0.5"
+    out_path: String, // /nix/store/<hash>-linux-X.Y.Z
     modules_path: String,
     dev_path: String,
 }
@@ -1244,35 +1340,42 @@ struct HydraOutputs {
 /// redirects /job/nixos/trunk-combined/* → /job/nixos/unstable/*. We rely on
 /// the default redirect policy and add an explicit Accept header.
 fn nixos_fetch_hydra(jobset: &str, attr: &str, hydra_arch: &str) -> Result<HydraOutputs> {
-    let url = format!("{}/job/nixos/{}/{}.{}/latest-finished",
-                      NIXOS_HYDRA_BASE, jobset, attr, hydra_arch);
+    let url = format!(
+        "{}/job/nixos/{}/{}.{}/latest-finished",
+        NIXOS_HYDRA_BASE, jobset, attr, hydra_arch
+    );
     let client = reqwest::blocking::Client::builder()
         .build()
         .context("building reqwest client")?;
-    let resp = client.get(&url)
+    let resp = client
+        .get(&url)
         .header("Accept", "application/json")
         .send()
         .with_context(|| format!("GET {}", url))?;
     if !resp.status().is_success() {
         bail!("Hydra GET {}: HTTP {}", url, resp.status());
     }
-    let body = resp.bytes()
+    let body = resp
+        .bytes()
         .with_context(|| format!("reading Hydra body from {}", url))?;
     let v: serde_json::Value = serde_json::from_slice(&body)
         .with_context(|| format!("parsing Hydra JSON from {}", url))?;
-    let nixname = v["nixname"].as_str()
-        .ok_or_else(|| anyhow!("{}: missing nixname", url))?.to_string();
+    let nixname = v["nixname"]
+        .as_str()
+        .ok_or_else(|| anyhow!("{}: missing nixname", url))?
+        .to_string();
     let outputs = &v["buildoutputs"];
     let read = |key: &str| -> Result<String> {
-        outputs[key]["path"].as_str()
+        outputs[key]["path"]
+            .as_str()
             .map(str::to_string)
             .ok_or_else(|| anyhow!("{}: missing buildoutputs.{}.path", url, key))
     };
     Ok(HydraOutputs {
         nixname,
-        out_path:     read("out")?,
+        out_path: read("out")?,
         modules_path: read("modules")?,
-        dev_path:     read("dev")?,
+        dev_path: read("dev")?,
     })
 }
 
@@ -1292,13 +1395,13 @@ struct NarInfo {
 /// trust HTTPS-to-cache.nixos.org for integrity. The existing PkgFile.sha256
 /// is therefore None for nixos.
 fn nixos_fetch_narinfo(store_path: &str) -> Result<NarInfo> {
-    let hash = store_path.strip_prefix("/nix/store/")
+    let hash = store_path
+        .strip_prefix("/nix/store/")
         .and_then(|s| s.split('-').next())
         .ok_or_else(|| anyhow!("malformed store path: {}", store_path))?;
     let url = format!("{}/{}.narinfo", NIXOS_CACHE_BASE, hash);
     let bytes = http_get_bytes(&url)?;
-    let text = std::str::from_utf8(&bytes)
-        .with_context(|| format!("narinfo {}: not utf8", url))?;
+    let text = std::str::from_utf8(&bytes).with_context(|| format!("narinfo {}: not utf8", url))?;
     let mut nar_url: Option<String> = None;
     for line in text.lines() {
         if let Some(v) = line.strip_prefix("URL: ") {
@@ -1326,17 +1429,19 @@ fn nixos_extract_and_layout(
     // 1. Index by role and extract.
     let mut role_dir: HashMap<String, PathBuf> = HashMap::new();
     for (file, path) in downloaded {
-        let role = file.role.as_deref()
+        let role = file
+            .role
+            .as_deref()
             .ok_or_else(|| anyhow!("nixos: PkgFile {} missing role", file.url))?;
         let dst = extracted.join(role);
         // nix-nar's Decoder::unpack refuses to write into an existing
         // directory — it wants to mkdir it. Don't pre-create.
-        extract_nar_xz(path, &dst)
-            .with_context(|| format!("extracting nixos {} NAR", role))?;
+        extract_nar_xz(path, &dst).with_context(|| format!("extracting nixos {} NAR", role))?;
         role_dir.insert(role.to_string(), dst);
     }
     let get = |r: &str| -> Result<&Path> {
-        role_dir.get(r)
+        role_dir
+            .get(r)
             .map(PathBuf::as_path)
             .ok_or_else(|| anyhow!("nixos: missing `{}` role in downloads", r))
     };
@@ -1347,16 +1452,18 @@ fn nixos_extract_and_layout(
     //    handles both name forms.
     let vmlinuz = find_vmlinuz(out)
         .with_context(|| format!("locating vmlinuz in nixos `out` ({})", out.display()))?;
-    rename_or_copy(&vmlinuz, &stage.join("vmlinuz"))
-        .context("placing nixos vmlinuz")?;
+    rename_or_copy(&vmlinuz, &stage.join("vmlinuz")).context("placing nixos vmlinuz")?;
 
     // 3. Place modules tree. The dangling symlinks `build` and `source`
     //    inside lib/modules/<v>/ point into /nix/store; remove them before
     //    moving so we can drop the real headers tree at build/ in step 4.
     let mods_src = modules.join("lib").join("modules").join(version);
     if !mods_src.is_dir() {
-        bail!("nixos modules NAR missing lib/modules/{} at {}",
-              version, modules.display());
+        bail!(
+            "nixos modules NAR missing lib/modules/{} at {}",
+            version,
+            modules.display()
+        );
     }
     for stale in ["build", "source"] {
         let p = mods_src.join(stale);
@@ -1370,8 +1477,7 @@ fn nixos_extract_and_layout(
     }
     let mods_dst = stage.join("lib").join("modules").join(version);
     fs::create_dir_all(mods_dst.parent().unwrap())?;
-    rename_or_copy(&mods_src, &mods_dst)
-        .context("placing nixos modules")?;
+    rename_or_copy(&mods_src, &mods_dst).context("placing nixos modules")?;
 
     // 4. Place the build (and source) trees from the dev NAR. nixpkgs's
     //    dev output lays its content out at
@@ -1385,12 +1491,17 @@ fn nixos_extract_and_layout(
     //    nix-support is just a propagated-build-inputs marker.)
     let dev_inner = dev.join("lib").join("modules").join(version);
     if !dev_inner.is_dir() {
-        bail!("nixos dev NAR missing lib/modules/{} at {}",
-              version, dev.display());
+        bail!(
+            "nixos dev NAR missing lib/modules/{} at {}",
+            version,
+            dev.display()
+        );
     }
     for kind in ["build", "source"] {
         let src = dev_inner.join(kind);
-        if !src.exists() { continue }
+        if !src.exists() {
+            continue;
+        }
         let dst = mods_dst.join(kind);
         rename_or_copy(&src, &dst)
             .with_context(|| format!("placing nixos kernel.dev `{}` tree", kind))?;
@@ -1400,8 +1511,11 @@ fn nixos_extract_and_layout(
     let bd = mods_dst.join("build");
     for required in ["Makefile", "Module.symvers"] {
         if !bd.join(required).exists() {
-            bail!("nixos kernel.dev didn't yield {}/{} — layout changed?",
-                  bd.display(), required);
+            bail!(
+                "nixos kernel.dev didn't yield {}/{} — layout changed?",
+                bd.display(),
+                required
+            );
         }
     }
 
@@ -1428,7 +1542,8 @@ include $(THIS_DIR)/../source/Makefile
         // regular files). Bump +w before writing.
         use std::os::unix::fs::PermissionsExt;
         let mut perms = fs::metadata(&stub)
-            .with_context(|| format!("stat {}", stub.display()))?.permissions();
+            .with_context(|| format!("stat {}", stub.display()))?
+            .permissions();
         perms.set_mode(perms.mode() | 0o200);
         fs::set_permissions(&stub, perms)
             .with_context(|| format!("chmod +w {}", stub.display()))?;
@@ -1440,8 +1555,7 @@ include $(THIS_DIR)/../source/Makefile
     //    patchelf any ELF interpreters. Without this, `make modules` fails
     //    on the first script (e.g. scripts/pahole-version.sh) or pre-built
     //    binary (e.g. tools/objtool/objtool).
-    nixos_denixify_tree(&mods_dst)
-        .context("de-nixifying kernel.dev tree")?;
+    nixos_denixify_tree(&mods_dst).context("de-nixifying kernel.dev tree")?;
 
     // 6. Standard uniform build symlink — relative path into our own tree.
     create_build_symlink(stage, version)?;
@@ -1462,8 +1576,10 @@ fn nixos_denixify_tree(root: &Path) -> Result<()> {
     // tree and fail in the middle.
     let pe_check = Command::new("patchelf").arg("--version").output();
     if pe_check.is_err() || !pe_check.unwrap().status.success() {
-        bail!("nixos kernel.dev fixup requires `patchelf` on PATH \
-               (install via `apt install patchelf` / `dnf install patchelf`)");
+        bail!(
+            "nixos kernel.dev fixup requires `patchelf` on PATH \
+               (install via `apt install patchelf` / `dnf install patchelf`)"
+        );
     }
 
     // Canonical paths of the host's glibc dynamic linker, keyed by
@@ -1471,30 +1587,41 @@ fn nixos_denixify_tree(root: &Path) -> Result<()> {
     // whatever ld.so the host has — that's what dkms-built userspace
     // helpers (fixdep, modpost, ...) would use anyway.
     let ldso_candidates: &[&str] = match std::env::consts::ARCH {
-        "x86_64"  => &["/lib64/ld-linux-x86-64.so.2", "/lib/ld-linux-x86-64.so.2"],
+        "x86_64" => &["/lib64/ld-linux-x86-64.so.2", "/lib/ld-linux-x86-64.so.2"],
         "aarch64" => &["/lib/ld-linux-aarch64.so.1"],
         "riscv64" => &["/lib/ld-linux-riscv64-lp64d.so.1"],
-        other     => bail!("no host glibc ld.so candidates known for arch {}", other),
+        other => bail!("no host glibc ld.so candidates known for arch {}", other),
     };
-    let host_ldso = ldso_candidates.iter().map(Path::new).find(|p| p.exists())
-        .ok_or_else(|| anyhow!("no glibc dynamic linker on this host (tried {:?})",
-                               ldso_candidates))?;
+    let host_ldso = ldso_candidates
+        .iter()
+        .map(Path::new)
+        .find(|p| p.exists())
+        .ok_or_else(|| {
+            anyhow!(
+                "no glibc dynamic linker on this host (tried {:?})",
+                ldso_candidates
+            )
+        })?;
 
     let mut shebangs_patched = 0usize;
     let mut elfs_patched = 0usize;
 
     for entry in walkdir::WalkDir::new(root).follow_links(false) {
         let entry = entry.context("walking tree for de-nixify")?;
-        if !entry.file_type().is_file() { continue }
+        if !entry.file_type().is_file() {
+            continue;
+        }
         let path = entry.path();
 
         // Peek the first few bytes. ELF magic = "\x7fELF"; shebang = "#!".
         let mut hdr = [0u8; 4];
         let n = match fs::File::open(path).and_then(|mut f| std::io::Read::read(&mut f, &mut hdr)) {
             Ok(n) => n,
-            Err(_) => continue,  // unreadable file — leave it alone
+            Err(_) => continue, // unreadable file — leave it alone
         };
-        if n < 2 { continue }
+        if n < 2 {
+            continue;
+        }
 
         let ensure_writable = |p: &Path| -> Result<()> {
             let mut perms = fs::metadata(p)?.permissions();
@@ -1509,13 +1636,15 @@ fn nixos_denixify_tree(root: &Path) -> Result<()> {
             // Shebang: read first line, check for /nix/store prefix, rewrite.
             let text = match fs::read_to_string(path) {
                 Ok(t) => t,
-                Err(_) => continue,  // binary with #! prefix coincidence? leave.
+                Err(_) => continue, // binary with #! prefix coincidence? leave.
             };
             let (first, rest) = match text.split_once('\n') {
                 Some(pair) => pair,
-                None       => (text.as_str(), ""),
+                None => (text.as_str(), ""),
             };
-            if !first.starts_with("#!/nix/store/") { continue }
+            if !first.starts_with("#!/nix/store/") {
+                continue;
+            }
             // The path after #! is `/nix/store/<hash>-<pkg>/bin/<binary>` plus
             // optional args. Pick the binary name and route through /usr/bin/env
             // — bash, perl, python3 all live in different places across distros;
@@ -1524,9 +1653,10 @@ fn nixos_denixify_tree(root: &Path) -> Result<()> {
             let cmd_line = first.trim_start_matches("#!").trim();
             let (interp_path, args) = match cmd_line.split_once(char::is_whitespace) {
                 Some((p, a)) => (p, a.trim()),
-                None         => (cmd_line, ""),
+                None => (cmd_line, ""),
             };
-            let binary = Path::new(interp_path).file_name()
+            let binary = Path::new(interp_path)
+                .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or("sh");
             let new_first = if args.is_empty() {
@@ -1536,8 +1666,7 @@ fn nixos_denixify_tree(root: &Path) -> Result<()> {
                 // we conservatively pass through for shells that ignore extras.
                 format!("#!/usr/bin/env -S {} {}", binary, args)
             };
-            ensure_writable(path)
-                .with_context(|| format!("chmod +w {}", path.display()))?;
+            ensure_writable(path).with_context(|| format!("chmod +w {}", path.display()))?;
             let new_text = format!("{}\n{}", new_first, rest);
             fs::write(path, new_text)
                 .with_context(|| format!("rewriting shebang in {}", path.display()))?;
@@ -1549,24 +1678,26 @@ fn nixos_denixify_tree(root: &Path) -> Result<()> {
             // Ask patchelf what the current interpreter is. If it's not a
             // /nix/store path, no work to do (some .o files have no INTERP).
             let out = Command::new("patchelf")
-                .args(["--print-interpreter"]).arg(path)
+                .args(["--print-interpreter"])
+                .arg(path)
                 .output()
-                .with_context(|| format!("patchelf --print-interpreter {}",
-                                         path.display()))?;
-            if !out.status.success() { continue }
+                .with_context(|| format!("patchelf --print-interpreter {}", path.display()))?;
+            if !out.status.success() {
+                continue;
+            }
             let interp = String::from_utf8_lossy(&out.stdout);
             let interp = interp.trim();
-            if !interp.starts_with("/nix/store/") { continue }
+            if !interp.starts_with("/nix/store/") {
+                continue;
+            }
 
-            ensure_writable(path)
-                .with_context(|| format!("chmod +w {}", path.display()))?;
+            ensure_writable(path).with_context(|| format!("chmod +w {}", path.display()))?;
             let status = Command::new("patchelf")
                 .args(["--set-interpreter"])
                 .arg(host_ldso)
                 .arg(path)
                 .status()
-                .with_context(|| format!("patchelf --set-interpreter on {}",
-                                         path.display()))?;
+                .with_context(|| format!("patchelf --set-interpreter on {}", path.display()))?;
             if !status.success() {
                 bail!("patchelf failed on {}: exit {}", path.display(), status);
             }
@@ -1575,8 +1706,10 @@ fn nixos_denixify_tree(root: &Path) -> Result<()> {
     }
 
     if shebangs_patched + elfs_patched > 0 {
-        eprintln!("    de-nixify: rewrote {} shebangs, patched {} ELF interpreters",
-                  shebangs_patched, elfs_patched);
+        eprintln!(
+            "    de-nixify: rewrote {} shebangs, patched {} ELF interpreters",
+            shebangs_patched, elfs_patched
+        );
     }
     Ok(())
 }
@@ -1590,9 +1723,15 @@ impl DistroFetcher for NixosFetcher {
             .with_context(|| format!("Hydra lookup for nixos/{}", src.release))?;
 
         // nixname is "linux-X.Y.Z"; uname -r inside the booted kernel is "X.Y.Z".
-        let version = outs.nixname.strip_prefix("linux-")
-            .ok_or_else(|| anyhow!("unexpected nixname `{}` (expected linux-X.Y.Z)",
-                                   outs.nixname))?
+        let version = outs
+            .nixname
+            .strip_prefix("linux-")
+            .ok_or_else(|| {
+                anyhow!(
+                    "unexpected nixname `{}` (expected linux-X.Y.Z)",
+                    outs.nixname
+                )
+            })?
             .to_string();
 
         let out_nar = nixos_fetch_narinfo(&outs.out_path)?;
@@ -1610,11 +1749,8 @@ impl DistroFetcher for NixosFetcher {
             release: src.release.clone(),
             arch: src.arch.clone(),
             version,
-            image:   tag(out_nar, "out"),
-            headers: vec![
-                tag(modules_nar, "modules"),
-                tag(dev_nar, "dev"),
-            ],
+            image: tag(out_nar, "out"),
+            headers: vec![tag(modules_nar, "modules"), tag(dev_nar, "dev")],
         }])
     }
 }
@@ -1625,15 +1761,13 @@ impl DistroFetcher for NixosFetcher {
 
 fn fetcher_for(distro: &str) -> Result<Box<dyn DistroFetcher>> {
     match distro {
-        "debian"    => Ok(Box::new(DebianFetcher)),
-        "ubuntu"    => Ok(Box::new(UbuntuFetcher)),
-        "fedora"    => Ok(Box::new(FedoraFetcher)),
-        "centos" | "rhel" | "rocky" | "alma"
-                    => Ok(Box::new(CentosFetcher)),
-        "opensuse" | "suse"
-                    => Ok(Box::new(SuseFetcher)),
-        "arch"      => Ok(Box::new(ArchFetcher)),
-        "nixos"     => Ok(Box::new(NixosFetcher)),
+        "debian" => Ok(Box::new(DebianFetcher)),
+        "ubuntu" => Ok(Box::new(UbuntuFetcher)),
+        "fedora" => Ok(Box::new(FedoraFetcher)),
+        "centos" | "rhel" | "rocky" | "alma" => Ok(Box::new(CentosFetcher)),
+        "opensuse" | "suse" => Ok(Box::new(SuseFetcher)),
+        "arch" => Ok(Box::new(ArchFetcher)),
+        "nixos" => Ok(Box::new(NixosFetcher)),
         d => Err(anyhow!("unsupported distro: {}", d)),
     }
 }
@@ -1649,7 +1783,10 @@ fn source_dir(output: &Path, pkg: &KernelPkg) -> PathBuf {
 }
 
 fn already_have(output: &Path, pkg: &KernelPkg) -> bool {
-    source_dir(output, pkg).join(&pkg.version).join("manifest.json").exists()
+    source_dir(output, pkg)
+        .join(&pkg.version)
+        .join("manifest.json")
+        .exists()
 }
 
 /// Delete every version subdirectory under the source dir except `keep`.
@@ -1663,12 +1800,15 @@ fn prune_older_versions(src_dir: &Path, keep: &str) -> Result<()> {
     for entry in entries {
         let entry = entry?;
         let name = entry.file_name();
-        if name == keep { continue }
+        if name == keep {
+            continue;
+        }
         let path = entry.path();
         // Skip files (e.g. `_work` doesn't live here, but be defensive).
-        if !path.is_dir() { continue }
-        fs::remove_dir_all(&path)
-            .with_context(|| format!("pruning {}", path.display()))?;
+        if !path.is_dir() {
+            continue;
+        }
+        fs::remove_dir_all(&path).with_context(|| format!("pruning {}", path.display()))?;
     }
     Ok(())
 }
@@ -1686,20 +1826,18 @@ fn prune_older_versions(src_dir: &Path, keep: &str) -> Result<()> {
 // ============================================================================
 
 fn download_to(url: &str, dst: &Path) -> Result<()> {
-    let mut resp = reqwest::blocking::get(url)
-        .with_context(|| format!("GET {}", url))?;
+    let mut resp = reqwest::blocking::get(url).with_context(|| format!("GET {}", url))?;
     if !resp.status().is_success() {
         bail!("GET {}: HTTP {}", url, resp.status());
     }
-    let mut out = fs::File::create(dst)
-        .with_context(|| format!("creating {}", dst.display()))?;
-    std::io::copy(&mut resp, &mut out)
-        .with_context(|| format!("downloading {}", url))?;
+    let mut out = fs::File::create(dst).with_context(|| format!("creating {}", dst.display()))?;
+    std::io::copy(&mut resp, &mut out).with_context(|| format!("downloading {}", url))?;
     Ok(())
 }
 
 fn run_extractor(mut cmd: Command, what: &str) -> Result<()> {
-    let status = cmd.status()
+    let status = cmd
+        .status()
         .with_context(|| format!("spawning extractor for {}", what))?;
     if !status.success() {
         bail!("extractor failed on {}: exit {}", what, status);
@@ -1708,7 +1846,8 @@ fn run_extractor(mut cmd: Command, what: &str) -> Result<()> {
 }
 
 fn extract_archive(archive: &Path, dst: &Path) -> Result<()> {
-    let fname = archive.file_name()
+    let fname = archive
+        .file_name()
         .and_then(|f| f.to_str())
         .ok_or_else(|| anyhow!("bad archive path: {}", archive.display()))?;
     let a = archive.to_str().unwrap();
@@ -1726,7 +1865,9 @@ fn extract_archive(archive: &Path, dst: &Path) -> Result<()> {
             .stdout(Stdio::piped())
             .spawn()
             .with_context(|| format!("spawning rpm2cpio on {}", fname))?;
-        let stdout = r2c.stdout.take()
+        let stdout = r2c
+            .stdout
+            .take()
             .ok_or_else(|| anyhow!("rpm2cpio: no stdout"))?;
         let cpio_status = Command::new("cpio")
             .args(["-idm", "--quiet"])
@@ -1766,16 +1907,14 @@ fn extract_archive(archive: &Path, dst: &Path) -> Result<()> {
 /// under it). Compared to the deb/rpm/tar branches we don't shell out: xz
 /// and NAR are both in-process via crates.
 fn extract_nar_xz(archive: &Path, dst: &Path) -> Result<()> {
-    let xz_bytes = fs::read(archive)
-        .with_context(|| format!("reading {}", archive.display()))?;
+    let xz_bytes = fs::read(archive).with_context(|| format!("reading {}", archive.display()))?;
     let mut nar_bytes = Vec::with_capacity(xz_bytes.len() * 4);
     lzma_rs::xz_decompress(&mut std::io::Cursor::new(&xz_bytes), &mut nar_bytes)
         .with_context(|| format!("xz-decompressing {}", archive.display()))?;
     let dec = nix_nar::Decoder::new(std::io::Cursor::new(&nar_bytes))
         .with_context(|| format!("opening NAR {}", archive.display()))?;
     dec.unpack(dst)
-        .with_context(|| format!("unpacking NAR {} -> {}",
-                                 archive.display(), dst.display()))?;
+        .with_context(|| format!("unpacking NAR {} -> {}", archive.display(), dst.display()))?;
     Ok(())
 }
 
@@ -1787,15 +1926,23 @@ fn find_vmlinuz(root: &Path) -> Result<PathBuf> {
     let mut best: Option<(PathBuf, u64)> = None;
     for entry in walkdir::WalkDir::new(root).follow_links(false) {
         let entry = entry.context("walking for vmlinuz")?;
-        if !entry.file_type().is_file() { continue }
+        if !entry.file_type().is_file() {
+            continue;
+        }
         let name = entry.file_name().to_string_lossy();
         let is_image = name.starts_with("vmlinuz")
             || name.starts_with("bzImage")
-            || name == "Image" || name.starts_with("Image.")
-            || name == "zImage" || name.starts_with("zImage.");
-        if !is_image { continue }
+            || name == "Image"
+            || name.starts_with("Image.")
+            || name == "zImage"
+            || name.starts_with("zImage.");
+        if !is_image {
+            continue;
+        }
         let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
-        if size < 1024 * 1024 { continue }
+        if size < 1024 * 1024 {
+            continue;
+        }
         if best.as_ref().map(|(_, s)| size > *s).unwrap_or(true) {
             best = Some((entry.path().to_path_buf(), size));
         }
@@ -1809,12 +1956,17 @@ fn find_vmlinuz(root: &Path) -> Result<PathBuf> {
 fn find_modules_dir(root: &Path) -> Result<PathBuf> {
     for entry in walkdir::WalkDir::new(root).follow_links(false) {
         let entry = entry.context("walking for modules dir")?;
-        if !entry.file_type().is_dir() { continue }
+        if !entry.file_type().is_dir() {
+            continue;
+        }
         let path = entry.path();
-        let parent_name = path.parent()
+        let parent_name = path
+            .parent()
             .and_then(|p| p.file_name())
             .and_then(|f| f.to_str());
-        if parent_name != Some("modules") { continue }
+        if parent_name != Some("modules") {
+            continue;
+        }
         if path.join("modules.order").exists() || path.join("kernel").is_dir() {
             return Ok(path.to_path_buf());
         }
@@ -1825,33 +1977,32 @@ fn find_modules_dir(root: &Path) -> Result<PathBuf> {
 /// Move src into dst. If they're on different filesystems, fall back to
 /// recursive copy + remove.
 fn rename_or_copy(src: &Path, dst: &Path) -> Result<()> {
-    if fs::rename(src, dst).is_ok() { return Ok(()); }
+    if fs::rename(src, dst).is_ok() {
+        return Ok(());
+    }
     copy_dir_recursive(src, dst)?;
     fs::remove_dir_all(src).ok();
     Ok(())
 }
 
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
-    fs::create_dir_all(dst)
-        .with_context(|| format!("mkdir {}", dst.display()))?;
-    for entry in fs::read_dir(src)
-        .with_context(|| format!("read_dir {}", src.display()))?
-    {
+    fs::create_dir_all(dst).with_context(|| format!("mkdir {}", dst.display()))?;
+    for entry in fs::read_dir(src).with_context(|| format!("read_dir {}", src.display()))? {
         let entry = entry?;
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
         let ft = entry.file_type()?;
         if ft.is_symlink() {
             let target = fs::read_link(&src_path)?;
-            std::os::unix::fs::symlink(&target, &dst_path)
-                .with_context(|| format!("symlink {} -> {}",
-                                         dst_path.display(), target.display()))?;
+            std::os::unix::fs::symlink(&target, &dst_path).with_context(|| {
+                format!("symlink {} -> {}", dst_path.display(), target.display())
+            })?;
         } else if ft.is_dir() {
             copy_dir_recursive(&src_path, &dst_path)?;
         } else {
-            fs::copy(&src_path, &dst_path)
-                .with_context(|| format!("copy {} -> {}",
-                                         src_path.display(), dst_path.display()))?;
+            fs::copy(&src_path, &dst_path).with_context(|| {
+                format!("copy {} -> {}", src_path.display(), dst_path.display())
+            })?;
         }
     }
     Ok(())
@@ -1872,9 +2023,16 @@ fn collect_headers(extracted: &Path, stage: &Path, uname_r: &str) -> Result<()> 
             .with_context(|| format!("collecting headers from {}", usrsrc.display()))?;
         return Ok(());
     }
-    let modules_build = stage.join("lib").join("modules").join(uname_r).join("build");
+    let modules_build = stage
+        .join("lib")
+        .join("modules")
+        .join(uname_r)
+        .join("build");
     if modules_build.is_dir() {
-        let target = PathBuf::from("lib").join("modules").join(uname_r).join("build");
+        let target = PathBuf::from("lib")
+            .join("modules")
+            .join(uname_r)
+            .join("build");
         std::os::unix::fs::symlink(&target, &dst_headers)
             .with_context(|| format!("symlinking headers -> {}", target.display()))?;
         return Ok(());
@@ -1893,8 +2051,7 @@ fn write_manifest(stage: &Path, pkg: &KernelPkg) -> Result<()> {
         headers: pkg.headers.clone(),
         fetched_at: Utc::now().to_rfc3339(),
     };
-    let text = serde_json::to_string_pretty(&manifest)
-        .context("serializing manifest")?;
+    let text = serde_json::to_string_pretty(&manifest).context("serializing manifest")?;
     fs::write(stage.join("manifest.json"), text)
         .with_context(|| format!("writing {}/manifest.json", stage.display()))?;
     Ok(())
@@ -1903,12 +2060,13 @@ fn write_manifest(stage: &Path, pkg: &KernelPkg) -> Result<()> {
 fn sha256_file(path: &Path) -> Result<String> {
     use sha2::{Digest, Sha256};
     use std::io::Read;
-    let mut f = fs::File::open(path)
-        .with_context(|| format!("opening {} for hashing", path.display()))?;
+    let mut f =
+        fs::File::open(path).with_context(|| format!("opening {} for hashing", path.display()))?;
     let mut hasher = Sha256::new();
     let mut buf = [0u8; 64 * 1024];
     loop {
-        let n = f.read(&mut buf)
+        let n = f
+            .read(&mut buf)
             .with_context(|| format!("reading {} for hashing", path.display()))?;
         if n == 0 {
             break;
@@ -1921,8 +2079,12 @@ fn sha256_file(path: &Path) -> Result<String> {
 fn verify_sha256(path: &Path, expected: &str) -> Result<()> {
     let actual = sha256_file(path)?;
     if !actual.eq_ignore_ascii_case(expected) {
-        bail!("SHA256 mismatch for {}: expected {}, got {}",
-              path.display(), expected, actual);
+        bail!(
+            "SHA256 mismatch for {}: expected {}, got {}",
+            path.display(),
+            expected,
+            actual
+        );
     }
     Ok(())
 }
@@ -1937,13 +2099,16 @@ fn verify_sha256(path: &Path, expected: &str) -> Result<()> {
 /// `<stage>/headers/`, we just rebase the target. For Arch, that path is
 /// itself the real build directory.
 fn create_build_symlink(stage: &Path, uname_r: &str) -> Result<()> {
-    let modules_build = stage.join("lib").join("modules").join(uname_r).join("build");
+    let modules_build = stage
+        .join("lib")
+        .join("modules")
+        .join(uname_r)
+        .join("build");
     let meta = fs::symlink_metadata(&modules_build)
         .with_context(|| format!("no modules/build at {}", modules_build.display()))?;
 
     let rel = if meta.file_type().is_symlink() {
-        let target = fs::read_link(&modules_build)
-            .context("reading modules/build symlink")?;
+        let target = fs::read_link(&modules_build).context("reading modules/build symlink")?;
         // Target may be absolute (`/usr/src/linux-headers-<v>-<arch>`) or
         // relative (`../../../src/linux-headers-...`, Debian trixie's
         // Usr-Merge style). Either way it lands under `/usr/src/` in the
@@ -1954,14 +2119,21 @@ fn create_build_symlink(stage: &Path, uname_r: &str) -> Result<()> {
             std::path::Component::Normal(n) => n.to_str() == Some("src"),
             _ => false,
         });
-        let src_pos = src_pos.ok_or_else(|| anyhow!(
-            "modules/build target {} has no `src` component — can't rebase \
-             into headers/", target.display()))?;
+        let src_pos = src_pos.ok_or_else(|| {
+            anyhow!(
+                "modules/build target {} has no `src` component — can't rebase \
+             into headers/",
+                target.display()
+            )
+        })?;
         let rest: PathBuf = components[src_pos + 1..].iter().collect();
         PathBuf::from("headers").join(rest)
     } else {
         // Arch / Arch-like: lib/modules/<v>/build is the real build directory.
-        PathBuf::from("lib").join("modules").join(uname_r).join("build")
+        PathBuf::from("lib")
+            .join("modules")
+            .join(uname_r)
+            .join("build")
     };
 
     if !stage.join(&rel).exists() {
@@ -1982,9 +2154,13 @@ fn create_build_symlink(stage: &Path, uname_r: &str) -> Result<()> {
         let rel_from_modules = Path::new("../../..").join(&rel);
         fs::remove_file(&modules_build)
             .with_context(|| format!("removing stale {}", modules_build.display()))?;
-        std::os::unix::fs::symlink(&rel_from_modules, &modules_build)
-            .with_context(|| format!("repointing {} -> {}",
-                                     modules_build.display(), rel_from_modules.display()))?;
+        std::os::unix::fs::symlink(&rel_from_modules, &modules_build).with_context(|| {
+            format!(
+                "repointing {} -> {}",
+                modules_build.display(),
+                rel_from_modules.display()
+            )
+        })?;
     }
     Ok(())
 }
@@ -2051,10 +2227,12 @@ struct ModuleInfo {
 /// Strip ".ko" + any compression suffix, take basename, convert `-` to `_`
 /// (the kernel module-name convention).
 fn module_name_from_path(path: &str) -> String {
-    let stem = Path::new(path).file_name()
+    let stem = Path::new(path)
+        .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or(path);
-    let stem = stem.strip_suffix(".ko.gz")
+    let stem = stem
+        .strip_suffix(".ko.gz")
         .or_else(|| stem.strip_suffix(".ko.xz"))
         .or_else(|| stem.strip_suffix(".ko.zst"))
         .or_else(|| stem.strip_suffix(".ko"))
@@ -2065,17 +2243,25 @@ fn module_name_from_path(path: &str) -> String {
 fn parse_modules_dep(text: &str) -> HashMap<String, ModuleInfo> {
     let mut out = HashMap::new();
     for line in text.lines() {
-        let Some((mod_path, deps_str)) = line.split_once(':') else { continue };
+        let Some((mod_path, deps_str)) = line.split_once(':') else {
+            continue;
+        };
         let mod_path = mod_path.trim();
-        if mod_path.is_empty() { continue }
+        if mod_path.is_empty() {
+            continue;
+        }
         let name = module_name_from_path(mod_path);
-        let deps: Vec<String> = deps_str.split_whitespace()
+        let deps: Vec<String> = deps_str
+            .split_whitespace()
             .map(module_name_from_path)
             .collect();
-        out.insert(name, ModuleInfo {
-            rel_path: PathBuf::from(mod_path),
-            deps,
-        });
+        out.insert(
+            name,
+            ModuleInfo {
+                rel_path: PathBuf::from(mod_path),
+                deps,
+            },
+        );
     }
     out
 }
@@ -2085,10 +2271,7 @@ fn parse_modules_dep(text: &str) -> HashMap<String, ModuleInfo> {
 /// either built into the kernel (no insmod needed; symbols already resolved
 /// against vmlinux) or genuinely missing (which insmod would have failed on
 /// anyway). Seed skips get an eprintln so the user can spot a typo.
-fn module_load_order(
-    modules: &HashMap<String, ModuleInfo>,
-    seeds: &[&str],
-) -> Vec<String> {
+fn module_load_order(modules: &HashMap<String, ModuleInfo>, seeds: &[&str]) -> Vec<String> {
     use std::collections::HashSet;
     let mut visited: HashSet<String> = HashSet::new();
     let mut ordered: Vec<String> = Vec::new();
@@ -2099,8 +2282,12 @@ fn module_load_order(
         visited: &mut HashSet<String>,
         ordered: &mut Vec<String>,
     ) {
-        if !visited.insert(name.to_string()) { return }
-        let Some(info) = modules.get(name) else { return };
+        if !visited.insert(name.to_string()) {
+            return;
+        }
+        let Some(info) = modules.get(name) else {
+            return;
+        };
         for dep in &info.deps {
             visit(dep, modules, visited, ordered);
         }
@@ -2161,8 +2348,11 @@ fn klibc_lib_dir() -> Result<PathBuf> {
             return Ok(c.clone());
         }
     }
-    bail!("klibc not found — tried {:?} (install klibc-utils + libklibc, \
-           or `nix profile install nixpkgs#klibc`)", candidates)
+    bail!(
+        "klibc not found — tried {:?} (install klibc-utils + libklibc, \
+           or `nix profile install nixpkgs#klibc`)",
+        candidates
+    )
 }
 
 /// Find klibc-<hash>.so — the runtime interpreter for klibc binaries.
@@ -2197,7 +2387,8 @@ fn run_depmod(stage: &Path, uname_r: &str) -> Result<()> {
     if let Ok(path) = std::env::var("PATH") {
         candidates.extend(std::env::split_paths(&path).map(|p| p.join("depmod")));
     }
-    let depmod_bin = candidates.iter()
+    let depmod_bin = candidates
+        .iter()
         .find(|p| p.is_file())
         .ok_or_else(|| anyhow!("depmod not found in /sbin, /usr/sbin, or $PATH"))?;
     let status = Command::new(depmod_bin)
@@ -2223,7 +2414,9 @@ fn generate_initramfs(stage: &Path, uname_r: &str) -> Result<()> {
 
     // Stage the initramfs filesystem tree.
     let irfs = stage.join("_irfs");
-    if irfs.exists() { fs::remove_dir_all(&irfs)?; }
+    if irfs.exists() {
+        fs::remove_dir_all(&irfs)?;
+    }
     for sub in ["bin", "usr/lib", "modules", "dev", "proc", "sys", "newroot"] {
         fs::create_dir_all(irfs.join(sub))?;
     }
@@ -2311,7 +2504,7 @@ fn generate_initramfs(stage: &Path, uname_r: &str) -> Result<()> {
         .context("spawning cpio")?;
     let cpio_stdout = cpio.stdout.unwrap();
     let gzip_status = Command::new("gzip")
-        .arg("-n")  // suppress timestamp for reproducibility
+        .arg("-n") // suppress timestamp for reproducibility
         .stdin(Stdio::from(cpio_stdout))
         .stdout(initramfs_file)
         .status()
@@ -2338,9 +2531,13 @@ fn repair_dangling_symlinks(root: &Path) -> Result<()> {
             let path = entry?.path();
             let md = fs::symlink_metadata(&path)?;
             if md.file_type().is_symlink() {
-                if path.exists() { continue; }              // already resolves
+                if path.exists() {
+                    continue;
+                } // already resolves
                 let target = fs::read_link(&path)?;
-                if target.is_absolute() { continue; }       // not our concern
+                if target.is_absolute() {
+                    continue;
+                } // not our concern
                 let parent = path.parent().unwrap();
                 let comps: Vec<_> = target.components().collect();
                 let mut cur = parent.to_path_buf();
@@ -2353,10 +2550,14 @@ fn repair_dangling_symlinks(root: &Path) -> Result<()> {
                         let missing = next.file_name().map(|n| n.to_owned());
                         for sib in fs::read_dir(&cur)? {
                             let sib = sib?.file_name();
-                            if Some(&sib) == missing.as_ref() { continue; }
+                            if Some(&sib) == missing.as_ref() {
+                                continue;
+                            }
                             if cur.join(&sib).join(&remainder).exists() {
                                 let mut newt = PathBuf::new();
-                                for cc in &comps[..i] { newt.push(cc); }
+                                for cc in &comps[..i] {
+                                    newt.push(cc);
+                                }
                                 newt.push(&sib);
                                 newt.push(&remainder);
                                 fs::remove_file(&path)?;
@@ -2382,11 +2583,12 @@ fn fetch_and_convert(output: &Path, pkg: &KernelPkg) -> Result<()> {
     let dst = src_dir.join(&pkg.version);
 
     // Work area sits under output/ so rename(work, dst) is intra-filesystem.
-    let work = output.join("_work").join(format!("{}-{}-{}-{}",
-        pkg.distro, pkg.release, pkg.arch, pkg.version));
+    let work = output.join("_work").join(format!(
+        "{}-{}-{}-{}",
+        pkg.distro, pkg.release, pkg.arch, pkg.version
+    ));
     if work.exists() {
-        fs::remove_dir_all(&work)
-            .with_context(|| format!("cleaning {}", work.display()))?;
+        fs::remove_dir_all(&work).with_context(|| format!("cleaning {}", work.display()))?;
     }
     let dl = work.join("dl");
     let extracted = work.join("extracted");
@@ -2407,8 +2609,7 @@ fn fetch_and_convert(output: &Path, pkg: &KernelPkg) -> Result<()> {
         let path = dl.join(fname);
         download_to(&f.url, &path)?;
         if let Some(expected) = &f.sha256 {
-            verify_sha256(&path, expected)
-                .with_context(|| format!("verifying {}", f.url))?;
+            verify_sha256(&path, expected).with_context(|| format!("verifying {}", f.url))?;
         }
         downloaded.push((f, path));
     }
@@ -2425,14 +2626,12 @@ fn fetch_and_convert(output: &Path, pkg: &KernelPkg) -> Result<()> {
                 .with_context(|| format!("extracting {}", archive.display()))?;
         }
         let vmlinuz = find_vmlinuz(&extracted)?;
-        rename_or_copy(&vmlinuz, &stage.join("vmlinuz"))
-            .context("placing vmlinuz")?;
+        rename_or_copy(&vmlinuz, &stage.join("vmlinuz")).context("placing vmlinuz")?;
 
         let modules = find_modules_dir(&extracted)?;
         let modules_dst = stage.join("lib").join("modules").join(&pkg.version);
         fs::create_dir_all(modules_dst.parent().unwrap())?;
-        rename_or_copy(&modules, &modules_dst)
-            .context("placing modules")?;
+        rename_or_copy(&modules, &modules_dst).context("placing modules")?;
 
         collect_headers(&extracted, &stage, &pkg.version)?;
         create_build_symlink(&stage, &pkg.version)?;
@@ -2452,8 +2651,7 @@ fn fetch_and_convert(output: &Path, pkg: &KernelPkg) -> Result<()> {
 
         // After all per-distro placement, repoint any dangling symlinks
         // (e.g. Ubuntu's headers `rust/` -> the differently-named lib-rust dir).
-        repair_dangling_symlinks(&stage)
-            .context("repairing dangling symlinks")?;
+        repair_dangling_symlinks(&stage).context("repairing dangling symlinks")?;
     }
     generate_initramfs(&stage, &pkg.version)
         .with_context(|| format!("generating initramfs for {}", pkg.version))?;
@@ -2465,11 +2663,9 @@ fn fetch_and_convert(output: &Path, pkg: &KernelPkg) -> Result<()> {
         fs::create_dir_all(parent)?;
     }
     if dst.exists() {
-        fs::remove_dir_all(&dst)
-            .with_context(|| format!("removing stale {}", dst.display()))?;
+        fs::remove_dir_all(&dst).with_context(|| format!("removing stale {}", dst.display()))?;
     }
-    fs::rename(&stage, &dst)
-        .with_context(|| format!("publishing to {}", dst.display()))?;
+    fs::rename(&stage, &dst).with_context(|| format!("publishing to {}", dst.display()))?;
 
     // 5. Drop older versions of this source.
     prune_older_versions(&src_dir, &pkg.version)
@@ -2482,12 +2678,18 @@ fn fetch_and_convert(output: &Path, pkg: &KernelPkg) -> Result<()> {
 
 fn process_source(args: &Args, output: &Path, src: &Source) -> Result<()> {
     let fetcher = fetcher_for(&src.distro)?;
-    let pkgs = fetcher.latest_kernels(src)
+    let pkgs = fetcher
+        .latest_kernels(src)
         .with_context(|| format!("listing kernels for {}/{}", src.distro, src.release))?;
 
     if args.verbose {
-        eprintln!("{}/{}/{}: {} candidate(s)",
-                  src.distro, src.release, src.arch, pkgs.len());
+        eprintln!(
+            "{}/{}/{}: {} candidate(s)",
+            src.distro,
+            src.release,
+            src.arch,
+            pkgs.len()
+        );
     }
 
     for pkg in pkgs {
@@ -2505,9 +2707,12 @@ fn process_source(args: &Args, output: &Path, src: &Source) -> Result<()> {
             continue;
         }
         eprintln!("  fetching {}", pkg.version);
-        fetch_and_convert(output, &pkg)
-            .with_context(|| format!("fetching {} for {}/{}",
-                                     pkg.version, pkg.distro, pkg.release))?;
+        fetch_and_convert(output, &pkg).with_context(|| {
+            format!(
+                "fetching {} for {}/{}",
+                pkg.version, pkg.distro, pkg.release
+            )
+        })?;
     }
     Ok(())
 }
@@ -2524,9 +2729,13 @@ fn ktest_data_dir() -> PathBuf {
 fn main() -> Result<()> {
     let args = Args::parse();
     let data_dir = ktest_data_dir();
-    let config_path = args.config.clone()
+    let config_path = args
+        .config
+        .clone()
         .unwrap_or_else(|| data_dir.join("distro-sources.json5"));
-    let output = args.output.clone()
+    let output = args
+        .output
+        .clone()
         .unwrap_or_else(|| data_dir.join("kernels"));
 
     let config_text = std::fs::read_to_string(&config_path)
@@ -2537,7 +2746,10 @@ fn main() -> Result<()> {
     let mut failed = 0;
     for src in &config.sources {
         if let Err(e) = process_source(&args, &output, src) {
-            eprintln!("ERROR: {}/{}/{}: {:#}", src.distro, src.release, src.arch, e);
+            eprintln!(
+                "ERROR: {}/{}/{}: {:#}",
+                src.distro, src.release, src.arch, e
+            );
             failed += 1;
         }
     }
@@ -2558,19 +2770,39 @@ mod tests {
 
     #[test]
     fn debian_vanilla_filter() {
-        assert!(debian_is_vanilla_image("linux-image-6.1.0-39-amd64", "amd64"));
+        assert!(debian_is_vanilla_image(
+            "linux-image-6.1.0-39-amd64",
+            "amd64"
+        ));
         assert!(!debian_is_vanilla_image("linux-image-amd64", "amd64"));
-        assert!(!debian_is_vanilla_image("linux-image-6.1.0-39-amd64-dbg", "amd64"));
-        assert!(!debian_is_vanilla_image("linux-image-6.1.0-39-amd64-unsigned", "amd64"));
-        assert!(!debian_is_vanilla_image("linux-image-6.1.0-39-cloud-amd64", "amd64"));
-        assert!(!debian_is_vanilla_image("linux-image-6.1.0-39-rt-amd64", "amd64"));
-        assert!(!debian_is_vanilla_image("linux-headers-6.1.0-39-amd64", "amd64"));
+        assert!(!debian_is_vanilla_image(
+            "linux-image-6.1.0-39-amd64-dbg",
+            "amd64"
+        ));
+        assert!(!debian_is_vanilla_image(
+            "linux-image-6.1.0-39-amd64-unsigned",
+            "amd64"
+        ));
+        assert!(!debian_is_vanilla_image(
+            "linux-image-6.1.0-39-cloud-amd64",
+            "amd64"
+        ));
+        assert!(!debian_is_vanilla_image(
+            "linux-image-6.1.0-39-rt-amd64",
+            "amd64"
+        ));
+        assert!(!debian_is_vanilla_image(
+            "linux-headers-6.1.0-39-amd64",
+            "amd64"
+        ));
     }
 
     #[test]
     fn debian_abi() {
-        assert_eq!(debian_abi_from_image("linux-image-6.1.0-39-amd64", "amd64"),
-                   Some("6.1.0-39"));
+        assert_eq!(
+            debian_abi_from_image("linux-image-6.1.0-39-amd64", "amd64"),
+            Some("6.1.0-39")
+        );
         assert_eq!(debian_abi_from_image("linux-image-amd64", "amd64"), None);
         assert_eq!(debian_abi_from_image("vim", "amd64"), None);
     }
@@ -2579,7 +2811,9 @@ mod tests {
     fn ubuntu_vanilla_filter() {
         assert!(ubuntu_is_vanilla_image("linux-image-6.8.0-31-generic"));
         assert!(!ubuntu_is_vanilla_image("linux-image-generic"));
-        assert!(!ubuntu_is_vanilla_image("linux-image-unsigned-6.8.0-31-generic"));
+        assert!(!ubuntu_is_vanilla_image(
+            "linux-image-unsigned-6.8.0-31-generic"
+        ));
         assert!(!ubuntu_is_vanilla_image("linux-headers-6.8.0-31-generic"));
     }
 
@@ -2606,8 +2840,10 @@ mod tests {
         let stanzas = parse_packages(text);
         assert_eq!(stanzas.len(), 2);
         assert_eq!(stanzas[0].get("Package").map(String::as_str), Some("foo"));
-        assert_eq!(stanzas[0].get("Description").map(String::as_str),
-                   Some("line one\nline two"));
+        assert_eq!(
+            stanzas[0].get("Description").map(String::as_str),
+            Some("line one\nline two")
+        );
         assert_eq!(stanzas[1].get("Package").map(String::as_str), Some("bar"));
     }
 
@@ -2629,18 +2865,27 @@ kernel/fs/mbcache.ko.xz:
     #[test]
     fn module_load_order_is_post_order() {
         let mut modules = HashMap::new();
-        modules.insert("ext4".to_string(), ModuleInfo {
-            rel_path: PathBuf::from("ext4.ko"),
-            deps: vec!["jbd2".to_string(), "mbcache".to_string()],
-        });
-        modules.insert("jbd2".to_string(), ModuleInfo {
-            rel_path: PathBuf::from("jbd2.ko"),
-            deps: vec![],
-        });
-        modules.insert("mbcache".to_string(), ModuleInfo {
-            rel_path: PathBuf::from("mbcache.ko"),
-            deps: vec![],
-        });
+        modules.insert(
+            "ext4".to_string(),
+            ModuleInfo {
+                rel_path: PathBuf::from("ext4.ko"),
+                deps: vec!["jbd2".to_string(), "mbcache".to_string()],
+            },
+        );
+        modules.insert(
+            "jbd2".to_string(),
+            ModuleInfo {
+                rel_path: PathBuf::from("jbd2.ko"),
+                deps: vec![],
+            },
+        );
+        modules.insert(
+            "mbcache".to_string(),
+            ModuleInfo {
+                rel_path: PathBuf::from("mbcache.ko"),
+                deps: vec![],
+            },
+        );
         let order = module_load_order(&modules, &["ext4"]);
         // jbd2 + mbcache must precede ext4.
         let pos = |n: &str| order.iter().position(|x| x == n).unwrap();

--- a/src/bin/gen-avg-duration.rs
+++ b/src/bin/gen-avg-duration.rs
@@ -19,8 +19,11 @@ fn read_duration_sums(rc: &Ktestrc) -> TestDurationMap {
     let entries = match std::fs::read_dir(&rc.output_dir) {
         Ok(d) => d,
         Err(e) => {
-            eprintln!("gen-avg-duration: reading {}: {}",
-                      rc.output_dir.display(), e);
+            eprintln!(
+                "gen-avg-duration: reading {}: {}",
+                rc.output_dir.display(),
+                e
+            );
             return durations;
         }
     };

--- a/src/build.rs
+++ b/src/build.rs
@@ -5,7 +5,11 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 fn main() {
-    for schema in ["src/testresult.capnp", "src/durations.capnp", "src/branchlog.capnp"] {
+    for schema in [
+        "src/testresult.capnp",
+        "src/durations.capnp",
+        "src/branchlog.capnp",
+    ] {
         println!("cargo:rerun-if-changed={}", schema);
         capnpc::CompilerCommand::new()
             .output_path(".")

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -71,8 +71,11 @@ fn get_subtests(test_path: PathBuf) -> Vec<String> {
             .map(|s| s.to_string())
             .collect(),
         Ok(o) => {
-            eprintln!("listing subtests of {:?}: list-tests exited {:?}",
-                      test_path, o.status.code());
+            eprintln!(
+                "listing subtests of {:?}: list-tests exited {:?}",
+                test_path,
+                o.status.code()
+            );
             Vec::new()
         }
         Err(e) => {
@@ -107,9 +110,10 @@ fn get_subtests(test_path: PathBuf) -> Vec<String> {
 /// Whitelist, not blacklist: a future TestStatus variant defaults to
 /// "not done" — at worst a wasted re-run, never a silent loss.
 fn result_is_done(status: TestStatus) -> bool {
-    matches!(status,
-             TestStatus::Passed | TestStatus::Failed |
-             TestStatus::Notrun | TestStatus::FailedToRun)
+    matches!(
+        status,
+        TestStatus::Passed | TestStatus::Failed | TestStatus::Notrun | TestStatus::FailedToRun
+    )
 }
 
 /// Whether desired_jobs() should emit a job for a subtest, given its
@@ -296,8 +300,10 @@ pub fn desired_jobs(rc: &CiConfig, results: &TestResultsStore, limit: usize) -> 
                 // gen-job-list did, and summed into the weight. The per-kernel
                 // duration below is only jobkit's batch-sizing cost — it must
                 // not feed the priority ordering.
-                let nice = job_nice(spec.tg,
-                                    test_stats(durations, &spec.test, subtest, "", "").as_ref());
+                let nice = job_nice(
+                    spec.tg,
+                    test_stats(durations, &spec.test, subtest, "", "").as_ref(),
+                );
 
                 for kernel in &spec.kernels {
                     let duration = test_stats(durations, &spec.test, subtest, kernel, &spec.env)
@@ -355,16 +361,16 @@ mod tests {
         assert!(result_is_done(TestStatus::Failed));
         assert!(result_is_done(TestStatus::Notrun));
         assert!(result_is_done(TestStatus::FailedToRun)); // daemon failed to run — terminal
-        // not verdicts — must re-run, not silently "done"
+                                                          // not verdicts — must re-run, not silently "done"
         assert!(!result_is_done(TestStatus::Inprogress)); // still running
-        assert!(!result_is_done(TestStatus::Unknown));    // garbled status
+        assert!(!result_is_done(TestStatus::Unknown)); // garbled status
     }
 
     #[test]
     fn inprogress_is_not_re_emitted() {
-        assert!(job_wanted(None));                          // never run
-        assert!(job_wanted(Some(TestStatus::Unknown)));     // garbled — re-run
-        assert!(!job_wanted(Some(TestStatus::Passed)));     // verdict
+        assert!(job_wanted(None)); // never run
+        assert!(job_wanted(Some(TestStatus::Unknown))); // garbled — re-run
+        assert!(!job_wanted(Some(TestStatus::Passed))); // verdict
         assert!(!job_wanted(Some(TestStatus::Inprogress))); // in flight — don't double-run
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,10 +130,9 @@ pub fn ktestrc_read() -> anyhow::Result<Ktestrc> {
         .map(|dir| dir.join("public_html/ktest-ci.json5"))
         .find(|p| p.exists())
         .context("public_html/ktest-ci.json5 not found above the binary")?;
-    let config = read_to_string(&path)
-        .with_context(|| format!("reading {}", path.display()))?;
-    let ktestrc: Ktestrc = json_five::from_str(&config)
-        .with_context(|| format!("parsing {}", path.display()))?;
+    let config = read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let ktestrc: Ktestrc =
+        json_five::from_str(&config).with_context(|| format!("parsing {}", path.display()))?;
     Ok(ktestrc)
 }
 
@@ -170,12 +169,12 @@ impl TestStatus {
     pub fn from_str(status: &str) -> TestStatus {
         /* exact inverse of to_str() first - the JSON wire format */
         match status {
-            "In progress"   => return TestStatus::Inprogress,
-            "Passed"        => return TestStatus::Passed,
-            "Failed"        => return TestStatus::Failed,
-            "Not run"       => return TestStatus::Notrun,
+            "In progress" => return TestStatus::Inprogress,
+            "Passed" => return TestStatus::Passed,
+            "Failed" => return TestStatus::Failed,
+            "Not run" => return TestStatus::Notrun,
             "Failed to run" => return TestStatus::FailedToRun,
-            "Unknown"       => return TestStatus::Unknown,
+            "Unknown" => return TestStatus::Unknown,
             _ => {}
         }
 
@@ -262,8 +261,7 @@ impl TestResultsStore {
     /// capnp) doesn't keep showing the cleared status on the dashboard.
     pub fn load(output_dir: PathBuf, clear_failed_to_run: bool) -> Self {
         let drop_status = |s: TestStatus| -> bool {
-            s == TestStatus::Inprogress
-                || (clear_failed_to_run && s == TestStatus::FailedToRun)
+            s == TestStatus::Inprogress || (clear_failed_to_run && s == TestStatus::FailedToRun)
         };
 
         let mut by_commit: HashMap<String, TestResultsMap> = HashMap::new();
@@ -287,20 +285,18 @@ impl TestResultsStore {
                     Some(c) => c.tests,
                     None => continue,
                 };
-                let stale: Vec<String> = m.iter()
+                let stale: Vec<String> = m
+                    .iter()
                     .filter(|(_, r)| drop_status(r.status))
                     .map(|(k, _)| k.clone())
                     .collect();
                 if !stale.is_empty() {
                     for k in &stale {
                         m.remove(k);
-                        let _ = std::fs::remove_dir_all(
-                            output_dir.join(&commit_id).join(k),
-                        );
+                        let _ = std::fs::remove_dir_all(output_dir.join(&commit_id).join(k));
                     }
                     if let Err(e) = results_to_capnp(&output_dir, &commit_id, None, &m) {
-                        eprintln!("TestResultsStore::load: capnp for {}: {:#}",
-                                  commit_id, e);
+                        eprintln!("TestResultsStore::load: capnp for {}: {:#}", commit_id, e);
                     }
                 }
                 if !m.is_empty() {
@@ -473,11 +469,7 @@ pub fn commit_update_results(output_dir: &Path, commit_id: &str) {
         .ok();
 }
 
-pub fn commit_update_results_with_message(
-    output_dir: &Path,
-    commit_id: &str,
-    message: &str,
-) {
+pub fn commit_update_results_with_message(output_dir: &Path, commit_id: &str, message: &str) {
     let results = commitdir_get_results_fs(output_dir, commit_id);
     results_to_capnp(output_dir, commit_id, Some(message), &results)
         .map_err(|e| eprintln!("error generating capnp for {}: {:#}", commit_id, e))
@@ -494,8 +486,11 @@ pub fn cleanup_inprogress_results(output_dir: &Path) {
     let entries = match output_dir.read_dir() {
         Ok(d) => d,
         Err(e) => {
-            eprintln!("cleanup_inprogress_results: reading {}: {}",
-                      output_dir.display(), e);
+            eprintln!(
+                "cleanup_inprogress_results: reading {}: {}",
+                output_dir.display(),
+                e
+            );
             return;
         }
     };
@@ -518,20 +513,24 @@ pub fn cleanup_inprogress_results(output_dir: &Path) {
         };
         let mut deleted = 0;
         for s in subtests.filter_map(|i| i.ok()) {
-            let status = read_to_string(s.path().join("status"))
-                .map(|t| TestStatus::from_str(&t));
+            let status = read_to_string(s.path().join("status")).map(|t| TestStatus::from_str(&t));
             if matches!(status, Ok(TestStatus::Inprogress)) {
                 match std::fs::remove_dir_all(s.path()) {
                     Ok(()) => deleted += 1,
-                    Err(e) => eprintln!("cleanup_inprogress_results: removing {}: {}",
-                                        s.path().display(), e),
+                    Err(e) => eprintln!(
+                        "cleanup_inprogress_results: removing {}: {}",
+                        s.path().display(),
+                        e
+                    ),
                 }
             }
         }
 
         if deleted != 0 {
-            eprintln!("cleanup_inprogress_results: {commit_id}: deleted \
-                       {deleted} stale in-progress result(s)");
+            eprintln!(
+                "cleanup_inprogress_results: {commit_id}: deleted \
+                       {deleted} stale in-progress result(s)"
+            );
             commit_update_results(output_dir, &commit_id);
         }
     }
@@ -561,11 +560,15 @@ fn parse_test_results(f: &[u8]) -> anyhow::Result<CommitResultsCapnp> {
         serialize::read_message_from_flat_slice(&mut &f[..], capnp::message::ReaderOptions::new())?;
     let root = message_reader.get_root::<test_results::Reader>()?;
 
-    let message = root.get_message()
-        .ok().and_then(|s| s.to_string().ok())
+    let message = root
+        .get_message()
+        .ok()
+        .and_then(|s| s.to_string().ok())
         .unwrap_or_default();
-    let commit_id = root.get_commit_id()
-        .ok().and_then(|s| s.to_string().ok())
+    let commit_id = root
+        .get_commit_id()
+        .ok()
+        .and_then(|s| s.to_string().ok())
         .unwrap_or_default();
     let entries = root.get_entries()?;
 
@@ -604,8 +607,10 @@ fn fetch_capnp_cached(
     if let Ok(meta) = std::fs::metadata(&cache_path) {
         if let Ok(mtime) = meta.modified() {
             let dt: DateTime<Utc> = mtime.into();
-            req = req.header("If-Modified-Since",
-                dt.format("%a, %d %b %Y %H:%M:%S GMT").to_string());
+            req = req.header(
+                "If-Modified-Since",
+                dt.format("%a, %d %b %Y %H:%M:%S GMT").to_string(),
+            );
         }
     }
 
@@ -618,7 +623,7 @@ fn fetch_capnp_cached(
             Ok(true)
         }
         404 => Ok(false),
-        s   => anyhow::bail!("HTTP {}: {}", s, url),
+        s => anyhow::bail!("HTTP {}: {}", s, url),
     }
 }
 
@@ -633,7 +638,9 @@ fn prefetch_capnp(base_url: &str, cache_dir: &Path, commit_ids: &[String]) {
     // the rest only fetch if not cached at all.
     const N_FRESH: usize = 5;
 
-    let to_fetch: Vec<(&str, bool)> = commit_ids.iter().enumerate()
+    let to_fetch: Vec<(&str, bool)> = commit_ids
+        .iter()
+        .enumerate()
         .filter_map(|(i, id)| {
             let cache_path = cache_dir.join(format!("{}.capnp", id));
             let cached = cache_path.exists();
@@ -642,14 +649,16 @@ fn prefetch_capnp(base_url: &str, cache_dir: &Path, commit_ids: &[String]) {
                 // Recent: always check (conditional request if cached)
                 Some((id.as_str(), cached))
             } else if cached {
-                None  // Old + cached: skip entirely
+                None // Old + cached: skip entirely
             } else {
-                Some((id.as_str(), false))  // Old + not cached: fetch
+                Some((id.as_str(), false)) // Old + not cached: fetch
             }
         })
         .collect();
 
-    if to_fetch.is_empty() { return; }
+    if to_fetch.is_empty() {
+        return;
+    }
 
     let client = reqwest::blocking::Client::new();
     let n_threads = 8.min(to_fetch.len()).max(1);
@@ -670,14 +679,19 @@ fn prefetch_capnp(base_url: &str, cache_dir: &Path, commit_ids: &[String]) {
 }
 
 fn commit_read_capnp(ktestrc: &Ktestrc, commit_id: &str) -> anyhow::Result<Vec<u8>> {
-    Ok(std::fs::read(ktestrc.output_dir.join(format!("{}.capnp", commit_id)))?)
+    Ok(std::fs::read(
+        ktestrc.output_dir.join(format!("{}.capnp", commit_id)),
+    )?)
 }
 
 pub fn commitdir_get_results(ktestrc: &Ktestrc, commit_id: &str) -> anyhow::Result<TestResultsMap> {
     Ok(parse_test_results(&commit_read_capnp(ktestrc, commit_id)?)?.tests)
 }
 
-pub fn commitdir_get_results_full(ktestrc: &Ktestrc, commit_id: &str) -> anyhow::Result<CommitResultsCapnp> {
+pub fn commitdir_get_results_full(
+    ktestrc: &Ktestrc,
+    commit_id: &str,
+) -> anyhow::Result<CommitResultsCapnp> {
     // For single-commit access, ensure cache is fresh
     if let Some(ref base_url) = ktestrc.ci_url {
         let _ = create_dir_all(&ktestrc.output_dir);
@@ -826,7 +840,11 @@ pub fn subtest_result_key(test: &str, subtest: &str, kernel: &str, env: &str) ->
     // result-dir name. commit_update_results() keys the capnp by dir
     // name, so this key and that name must agree exactly — otherwise
     // desired_jobs() never finds the result and re-runs the job forever.
-    format!("{}.{}", result_basename(test, kernel, env), subtest.replace('/', "."))
+    format!(
+        "{}.{}",
+        result_basename(test, kernel, env),
+        subtest.replace('/', ".")
+    )
 }
 
 /// Wire format for the env column in `jobs.<user>` and the TEST_JOB
@@ -837,8 +855,7 @@ pub fn subtest_result_key(test: &str, subtest: &str, kernel: &str, env: &str) ->
 /// path component.
 pub fn encode_env(env: &std::collections::BTreeMap<String, String>) -> anyhow::Result<String> {
     use anyhow::anyhow;
-    let bad =
-        |s: &str| s.contains(' ') || s.contains('=') || s.contains(',') || s.contains('/');
+    let bad = |s: &str| s.contains(' ') || s.contains('=') || s.contains(',') || s.contains('/');
     let mut parts = Vec::with_capacity(env.len());
     for (k, v) in env {
         if k.is_empty() || bad(k) {
@@ -858,7 +875,10 @@ mod encode_env_tests {
     use std::collections::BTreeMap;
 
     fn m(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
-        pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
     }
 
     #[test]
@@ -915,7 +935,12 @@ mod kernel_key_tests {
         // `@` separates from the test prefix; supervisor's
         // `<basename>.<subtest>` layout still slots in cleanly.
         assert_eq!(
-            subtest_result_key("fs/bcachefs/single_device.ktest", "first_thing", "debian/forky", ""),
+            subtest_result_key(
+                "fs/bcachefs/single_device.ktest",
+                "first_thing",
+                "debian/forky",
+                ""
+            ),
             "fs.bcachefs.single_device@debian_forky.first_thing"
         );
         assert_eq!(
@@ -934,7 +959,10 @@ mod kernel_key_tests {
         );
         assert_eq!(
             subtest_result_key(
-                "fs/bcachefs/ec.ktest", "ec", "upstream/stable-default", "ktest_x=1"
+                "fs/bcachefs/ec.ktest",
+                "ec",
+                "upstream/stable-default",
+                "ktest_x=1"
             ),
             "fs.bcachefs.ec@upstream_stable-default@ktest_x=1.ec"
         );
@@ -955,8 +983,13 @@ pub struct TestStats {
 }
 
 use durations_capnp::durations;
-pub fn test_stats(durations: Option<&[u8]>, test: &str, subtest: &str,
-                  kernel: &str, env: &str) -> Option<TestStats> {
+pub fn test_stats(
+    durations: Option<&[u8]>,
+    test: &str,
+    subtest: &str,
+    kernel: &str,
+    env: &str,
+) -> Option<TestStats> {
     if let Some(d) = durations {
         let mut d = d;
 
@@ -1288,7 +1321,15 @@ pub fn branchlog_parse(f: &[u8]) -> anyhow::Result<Vec<BranchEntry>> {
     Ok(result)
 }
 
-pub fn branchlog_get(ktest: &Ktestrc, user: &str, branch: &str) -> anyhow::Result<Vec<BranchEntry>> {
-    let f = std::fs::read(ktest.output_dir.join(format!("branch.{}.{}.capnp", user, branch)))?;
+pub fn branchlog_get(
+    ktest: &Ktestrc,
+    user: &str,
+    branch: &str,
+) -> anyhow::Result<Vec<BranchEntry>> {
+    let f = std::fs::read(
+        ktest
+            .output_dir
+            .join(format!("branch.{}.{}.capnp", user, branch)),
+    )?;
     branchlog_parse(&f)
 }

--- a/src/users.rs
+++ b/src/users.rs
@@ -27,7 +27,9 @@ struct RawTestGroup {
     env: Option<BTreeMap<String, String>>,
 }
 
-fn default_repo() -> String { "linux".to_string() }
+fn default_repo() -> String {
+    "linux".to_string()
+}
 
 #[derive(Deserialize)]
 struct RawBranch {
@@ -96,7 +98,10 @@ fn resolve_group(
     let parent: Option<&RcTestGroup> = g.extends.as_deref().and_then(|p| resolved.get(p));
 
     let resolved_group = RcTestGroup {
-        max_commits: g.max_commits.or(parent.map(|p| p.max_commits)).unwrap_or(50),
+        max_commits: g
+            .max_commits
+            .or(parent.map(|p| p.max_commits))
+            .unwrap_or(50),
         nice: g.nice.or(parent.map(|p| p.nice)).unwrap_or(0),
         test_duration_nice: g
             .test_duration_nice
@@ -175,8 +180,7 @@ pub fn userrc_read_str(s: &str) -> anyhow::Result<Userrc> {
 }
 
 pub fn userrc_read(path: &Path) -> anyhow::Result<Userrc> {
-    let config = read_to_string(path)
-        .with_context(|| format!("reading {}", path.display()))?;
+    let config = read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     userrc_read_str(&config).with_context(|| format!("parsing {}", path.display()))
 }
 
@@ -186,7 +190,8 @@ mod tests {
 
     #[test]
     fn extends_inherits_tests_and_overrides_kernels() {
-        let rc = userrc_read_str(r#"{
+        let rc = userrc_read_str(
+            r#"{
             test_groups: {
                 base: {
                     max_commits: 100,
@@ -204,19 +209,28 @@ mod tests {
             branches: {
                 br: { fetch: "linux master", repo: "linux", test_groups: ["base", "ext"] },
             },
-        }"#).unwrap();
+        }"#,
+        )
+        .unwrap();
         let base = &rc.test_groups["base"];
         let ext = &rc.test_groups["ext"];
         assert_eq!(base.kernels, vec!["upstream/stable-default"]);
-        assert_eq!(ext.tests, vec![PathBuf::from("a.ktest"), PathBuf::from("b.ktest")]);
-        assert_eq!(ext.kernels, vec!["upstream/stable-kasan", "upstream/stable-lockdep"]);
+        assert_eq!(
+            ext.tests,
+            vec![PathBuf::from("a.ktest"), PathBuf::from("b.ktest")]
+        );
+        assert_eq!(
+            ext.kernels,
+            vec!["upstream/stable-kasan", "upstream/stable-lockdep"]
+        );
         assert_eq!(ext.max_commits, 5);
         assert_eq!(ext.nice, 5);
     }
 
     #[test]
     fn env_merges_with_parent() {
-        let rc = userrc_read_str(r#"{
+        let rc = userrc_read_str(
+            r#"{
             test_groups: {
                 base: {
                     tests: ["a.ktest"],
@@ -229,7 +243,9 @@ mod tests {
                 },
             },
             branches: {},
-        }"#).unwrap();
+        }"#,
+        )
+        .unwrap();
         let ext = &rc.test_groups["ext"];
         assert_eq!(ext.env.get("FOO").map(String::as_str), Some("1"));
         assert_eq!(ext.env.get("BAR").map(String::as_str), Some("child"));
@@ -238,22 +254,30 @@ mod tests {
 
     #[test]
     fn cycle_detected() {
-        let err = userrc_read_str(r#"{
+        let err = userrc_read_str(
+            r#"{
             test_groups: {
                 a: { extends: "b" },
                 b: { extends: "a" },
             },
             branches: {},
-        }"#).err().expect("expected cycle error");
+        }"#,
+        )
+        .err()
+        .expect("expected cycle error");
         assert!(err.to_string().contains("cycle"), "got: {}", err);
     }
 
     #[test]
     fn unknown_test_group_ref_errors() {
-        let err = userrc_read_str(r#"{
+        let err = userrc_read_str(
+            r#"{
             test_groups: { base: { tests: ["a.ktest"], kernels: ["k"] } },
             branches: { br: { fetch: "x", test_groups: ["base", "nope"] } },
-        }"#).err().expect("expected undefined test_group error");
+        }"#,
+        )
+        .err()
+        .expect("expected undefined test_group error");
         assert!(err.to_string().contains("nope"), "got: {}", err);
     }
 }


### PR DESCRIPTION
## Summary

`build-test-kernel` documents `-k <dir>` as the kernel source directory, but it also forwarded that same option to the shared ktest parser, where `-k` means a prebuilt kernel path/name.

That made `build-test-kernel run -k <source>` set both `ktest_kernel_source` and `ktest_kernel_binary` to the source tree. Later `build_kernel()` removes `$ktest_kernel_binary`, so the source tree could be deleted before make starts.

Keep `build-test-kernel`'s source-directory `-k` local to this wrapper and only forward non-overlapping options to the shared parser.

## Notes

The second commit is mechanical `cargo fmt` output. The current workflow checks whole-repo Rust formatting, and `master` was already failing `cargo +nightly fmt -- --check`; carrying the format pass here makes the focused shell fix CI-checkable.

## Validation

- `bash -n build-test-kernel`
- `./build-test-kernel run -k /home/kom/proj/kernel-src-7.1-full` exits at the expected missing-test usage path and leaves `/home/kom/proj/kernel-src-7.1-full` intact
- `git diff --check`
- `cargo fmt -- --check`
- `cargo build`
