### PR TITLE
tests/bcachefs: cover device remove with missing btree backpointer

### DIFF
--- a/tests/fs/bcachefs/device_remove_missing_backpointer.ktest
+++ b/tests/fs/bcachefs/device_remove_missing_backpointer.ktest
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+require-kernel-config BCACHEFS_TESTS
+
+config-scratch-devs 1G
+config-scratch-devs 4G
+config-scratch-devs 4G
+
+remove_rewrites_btree_node_with_missing_backpointer()
+{
+    set_watchdog 900
+
+    run_quiet "" bcachefs format -f			\
+	"$@"						\
+	--block_size=4k					\
+	--bucket_size=256k				\
+	--btree_node_size=64k				\
+	--metadata_replicas=2				\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}	\
+	--label=hdd.hdd1 ${ktest_scratch_dev[1]}	\
+	--label=hdd.hdd2 ${ktest_scratch_dev[2]}	\
+	--metadata_target=ssd				\
+	--foreground_target=hdd				\
+	--background_target=hdd
+
+    mount -t bcachefs "$(join_by : "${ktest_scratch_dev[@]}")" /mnt
+
+    for i in $(seq 0 100000); do
+	echo "$i" > /mnt/file-$i
+    done
+    sync
+
+    echo test_btree_ptr_missing_backpointer_dev 1 1 > /sys/fs/bcachefs/*/perf_test
+    sync
+
+    local fsck_log=/tmp/device_remove_missing_backpointer.fsck.log
+    if bcachefs fsck -k -f -y -v \
+	-o recovery_passes=check_extents_to_backpointers,read_only=0 \
+	/mnt > "$fsck_log" 2>&1; then
+	local fsck_rc=0
+    else
+	local fsck_rc=$?
+    fi
+    cat "$fsck_log"
+
+    if [[ $fsck_rc -ne 0 ]] && ! grep -q "errors fixed" "$fsck_log"; then
+	return "$fsck_rc"
+    fi
+
+    bcachefs device remove ${ktest_scratch_dev[0]} /mnt
+
+    umount /mnt
+
+    bcachefs reset-counters ${ktest_scratch_dev[1]} > /dev/null
+
+    bcachefs fsck -ny ${ktest_scratch_dev[1]} ${ktest_scratch_dev[2]}
+    check_expected_missing_backpointer_error ${ktest_scratch_dev[1]}
+    check_bcachefs_device_errors ${ktest_scratch_dev[1]}
+    check_bcachefs_counters ${ktest_scratch_dev[1]}
+}
+
+check_expected_missing_backpointer_error()
+{
+    local dev=$1
+    local errors=$(bcachefs show-super -f errors "$dev" |
+	sed -n '/^errors /,${/^errors /!p;}')
+
+    if [[ -n $errors ]] &&
+	echo "$errors" | grep -vE '^ptr_to_missing_backpointer[[:space:]]'; then
+	echo "unexpected bcachefs errors on $dev"
+	return 1
+    fi
+}
+
+test_legacy_scan_device_removal()
+{
+    remove_rewrites_btree_node_with_missing_backpointer --version=1.26
+}
+
+test_fast_backpointer_device_removal()
+{
+    remove_rewrites_btree_node_with_missing_backpointer
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add a focused bcachefs ktest for the device-remove failure mode from koverstreet/bcachefs#1140 and koverstreet/bcachefs-tools#599.

The current replacement tools fix is koverstreet/bcachefs-tools#601.
Related field report: koverstreet/bcachefs#1043.

The test exercises the same missing-btree-backpointer repair shape through both device-removal implementations:

- `test_legacy_scan_device_removal` formats with `--version=1.26`, before `BCH_FEATURE_fast_device_removal`, so direct remove uses the slower metadata scan path.
- `test_fast_backpointer_device_removal` uses the current default format, so direct remove uses the fast backpointer-driven path when the tested bcachefs-tools build enables it.

Each case:

- formats a three-device filesystem with metadata initially targeted at the SSD
- creates enough small files to populate btree metadata
- uses the new `test_btree_ptr_missing_backpointer_dev` debug hook from koverstreet/bcachefs-tools#599 to delete one btree-pointer backpointer for device 0
- runs the online backpointer fsck pass and accepts the expected repaired-error exit
- requires direct `bcachefs device remove` to finish and then fscks the remaining members

This is the simulation coverage for the btree-node rewrite path added in koverstreet/bcachefs-tools#599 and superseded by koverstreet/bcachefs-tools#601; it should fail without that fix because device remove can leave `BCH_DATA_btree` buckets behind.

The direct-remove shape is deliberate: an earlier local attempt that used `bcachefs device evacuate` first made slow reconcile progress but did not reach the remove path within a 30-minute outer timeout. This test is intended to cover the remove fallback, not evacuation throughput.

The test intentionally injects one missing btree-pointer backpointer. After online fsck repairs that expected condition, the final checks allow only the corresponding `ptr_to_missing_backpointer` superblock error entry and still check offline fsck, device checksum errors, and slowpath counters.

## Validation

Current pushed head: `c67daddedafd60c049d6da7e6a389add3511f317`.

Local validation for this rebased head:

- `bash -n tests/fs/bcachefs/device_remove_missing_backpointer.ktest`
- `git diff --check origin/master...HEAD`
- `cargo build --verbose`

Earlier VM validation of the same final test content used koverstreet/bcachefs-tools#599 head `5f17ca4607f3` via DKMS module `v1.38.5-191-g5f17ca4607f3`. Both cases passed in one run:

- `fast_backpointer_device_removal` passed in 8s on the current default format.
- `legacy_scan_device_removal` passed in 6s on `--version=1.26`.

The VM run injected a missing btree-pointer backpointer for device 0, ran the online backpointer fsck pass, completed direct `bcachefs device remove`, passed offline fsck on the remaining members, and ended with `TEST SUCCESS`.

GitHub `build-and-format` passed in 1m6s at https://github.com/koverstreet/ktest/actions/runs/28293795915/job/83830153358.
