### PR TITLE
tests/bcachefs: reproduce target fallback and idle writeback migration

### DIFF
--- a/lib/testrunner
+++ b/lib/testrunner
@@ -65,6 +65,17 @@ else
 fi
 
 mkdir -p /lib/modules
+
+# Kernel build trees are produced on the host and their generated Makefiles
+# can retain absolute source and output paths.  Make those paths resolve back
+# through virtiofs for in-guest external-module builds (notably bcachefs DKMS).
+for path in "$ktest_kernel_source" "$ktest_kernel_build"; do
+    if [[ $path = /* && ! -e $path ]]; then
+        mkdir -p "$(dirname "$path")"
+        ln -sfn "/host$path" "$path"
+    fi
+done
+
 # Mirror the kernel store entry into /lib/modules per-kver instead of as
 # a single dir-symlink, so we can override /lib/modules/<kver>/updates
 # with a writable symlink to /ktest-out. DKMS install lays bcachefs.ko
@@ -80,7 +91,17 @@ for kver_src in /host/$ktest_kernel_binary/lib/modules/*; do
         # -n: if the link name already exists as a symlink to a directory
         # (e.g. rerun in the same VM, or a previous run with the same kver),
         # replace the symlink itself instead of dereferencing into it
-        ln -sfn "$entry" "/lib/modules/$kver/$(basename "$entry")"
+        if [[ -L $entry ]]; then
+            target=$(readlink "$entry")
+            if [[ $target = /* ]]; then
+                target="/host$target"
+            else
+                target="$(dirname "$entry")/$target"
+            fi
+            ln -sfn "$target" "/lib/modules/$kver/$(basename "$entry")"
+        else
+            ln -sfn "$entry" "/lib/modules/$kver/$(basename "$entry")"
+        fi
     done
     mkdir -p /ktest-out/dkms
     ln -sfn /ktest-out/dkms "/lib/modules/$kver/updates"

--- a/tests/fs/bcachefs/target_allocation_repro.ktest
+++ b/tests/fs/bcachefs/target_allocation_repro.ktest
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/bcachefs-test-libs.sh"
+
+require-kernel-config BCACHEFS_FS=y
+
+config-scratch-devs 256M
+config-scratch-devs 2G
+
+dump_allocator_state()
+{
+    local uuid=$1
+    local d
+
+    bcachefs fs usage -h /mnt || true
+
+    for d in /sys/fs/bcachefs/"$uuid"/dev-*; do
+        echo "dev=${d##*/} label=$(cat "$d/label") state=$(cat "$d/state") data_allowed=$(cat "$d/data_allowed")"
+        sed -n '1,80p' "$d/alloc_debug"
+    done
+
+    cat "/sys/fs/bcachefs/$uuid/recovery_status" || true
+    cat "/sys/fs/bcachefs/$uuid/internal/moving_ctxts" || true
+}
+
+dev_sysfs_by_label()
+{
+    local uuid=$1
+    local label=$2
+    local d
+
+    for d in /sys/fs/bcachefs/"$uuid"/dev-*; do
+        if [[ $(cat "$d/label") = "$label" ]]; then
+            echo "$d"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+alloc_buckets_by_label()
+{
+    local uuid=$1
+    local label=$2
+    local type=$3
+
+    awk -v type="$type" '$1 == type { print $2 }' \
+        "$(dev_sysfs_by_label "$uuid" "$label")/alloc_debug"
+}
+
+wait_for_reconcile_idle()
+{
+    local uuid=$1
+    local deadline=$((SECONDS + 120))
+    local prev_moving=""
+    local prev_pending=""
+    local stable=0
+    local moving pending
+
+    while (( SECONDS < deadline )); do
+        moving=$(cat "/sys/fs/bcachefs/$uuid/internal/moving_ctxts" 2>/dev/null || true)
+        pending=$(cat "/sys/fs/bcachefs/$uuid/reconcile_scan_pending" 2>/dev/null || true)
+
+        if [[ $moving = "$prev_moving" ]] &&
+           [[ $pending = "$prev_pending" ]] &&
+           [[ $pending = 0 ]]; then
+            (( ++stable >= 3 )) && return 0
+        else
+            stable=0
+        fi
+
+        prev_moving=$moving
+        prev_pending=$pending
+        sleep 1
+    done
+
+    echo "reconcile did not go idle"
+    dump_allocator_state "$uuid"
+    return 1
+}
+
+wait_for_background_target_migration()
+{
+    local uuid=$1
+    local ssd_label=$2
+    local hdd_label=$3
+    local ssd_before=$4
+    local hdd_before=$5
+    local deadline=$((SECONDS + 120))
+    local ssd_after hdd_after
+
+    while (( SECONDS < deadline )); do
+        ssd_after=$(alloc_buckets_by_label "$uuid" "$ssd_label" user)
+        hdd_after=$(alloc_buckets_by_label "$uuid" "$hdd_label" user)
+
+        if (( ssd_after * 2 <= ssd_before && hdd_after > hdd_before )); then
+            return 0
+        fi
+
+        sleep 1
+    done
+
+    return 1
+}
+
+assert_ssd_write_precondition()
+{
+    local uuid=$1
+    local ssd_label=$2
+    local ssd_before=$3
+
+    if (( ssd_before == 0 )); then
+        echo "write did not allocate user buckets on SSD"
+        dump_allocator_state "$uuid"
+        return 1
+    fi
+}
+
+assert_background_target_migration()
+{
+    local uuid=$1
+    local ssd_label=$2
+    local hdd_label=$3
+    local ssd_before=$4
+    local hdd_before=$5
+    local ssd_after hdd_after
+
+    if ! wait_for_background_target_migration "$uuid" "$ssd_label" "$hdd_label" "$ssd_before" "$hdd_before"; then
+        ssd_after=$(alloc_buckets_by_label "$uuid" "$ssd_label" user)
+        hdd_after=$(alloc_buckets_by_label "$uuid" "$hdd_label" user)
+
+        echo "background_target=hdd did not move at least half of SSD user buckets"
+        echo "ssd_before=$ssd_before ssd_after=$ssd_after hdd_before=$hdd_before hdd_after=$hdd_after"
+        dump_allocator_state "$uuid"
+        return 1
+    fi
+}
+
+finish_test()
+{
+    umount /mnt
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+# Changing background_target while the filesystem is offline creates work for
+# existing extents. Mount must schedule and run that reconcile scan by itself;
+# this test intentionally never writes trigger_reconcile_wakeup.
+test_background_target_changed_offline_reconcile_progress()
+{
+    local uuid ssd_before hdd_before
+
+    set_watchdog 180
+
+    run_quiet "" bcachefs format -f                 \
+        --block_size=4k                              \
+        --bucket_size=256k                           \
+        --label=ssd.cache "${ktest_scratch_dev[0]}" \
+        --label=hdd.backing "${ktest_scratch_dev[1]}" \
+        --foreground_target=ssd                      \
+        --background_target=ssd
+
+    mount -t bcachefs "${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]}" /mnt
+    uuid=$(basename /sys/fs/bcachefs/*)
+
+    dd if=/dev/zero of=/mnt/writeback-data bs=4M count=32 oflag=direct status=none
+    sync
+
+    ssd_before=$(alloc_buckets_by_label "$uuid" ssd.cache user)
+    hdd_before=$(alloc_buckets_by_label "$uuid" hdd.backing user)
+    assert_ssd_write_precondition "$uuid" ssd.cache "$ssd_before" || return 1
+
+    umount /mnt
+    bcachefs set-fs-option --background_target=hdd \
+        "${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}"
+
+    mount -t bcachefs "${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]}" /mnt
+    uuid=$(basename /sys/fs/bcachefs/*)
+
+    if [[ $(cat "/sys/fs/bcachefs/$uuid/options/background_target") != hdd ]]; then
+        echo "background_target was not set to hdd"
+        dump_allocator_state "$uuid"
+        return 1
+    fi
+
+    assert_background_target_migration "$uuid" ssd.cache hdd.backing "$ssd_before" "$hdd_before" || return 1
+    wait_for_reconcile_idle "$uuid" || return 1
+    finish_test
+}
+
+main "$@"

--- a/tests/fs/bcachefs/target_allocation_repro.ktest
+++ b/tests/fs/bcachefs/target_allocation_repro.ktest
@@ -175,6 +175,23 @@ test_background_target_changed_offline_reconcile_progress()
     bcachefs set-fs-option --background_target=hdd \
         "${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}"
 
+    local scheduled_passes
+    scheduled_passes=$(bcachefs recovery-pass \
+        "${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}") || {
+        echo "could not read scheduled recovery passes"
+        return 1
+    }
+    if ! grep -qw set_fs_needs_reconcile <<<"$scheduled_passes"; then
+        echo "offline IO-option change did not persist set_fs_needs_reconcile"
+        echo "$scheduled_passes"
+        return 1
+    fi
+    if grep -qw check_reconcile_work <<<"$scheduled_passes"; then
+        echo "offline IO-option change incorrectly scheduled check_reconcile_work"
+        echo "$scheduled_passes"
+        return 1
+    fi
+
     mount -t bcachefs "${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]}" /mnt
     uuid=$(basename /sys/fs/bcachefs/*)
 


### PR DESCRIPTION
Adds one focused VM regression for idle writeback migration after an offline
`background_target` change.

The test formats a two-device filesystem with both foreground and background
targets on SSD, writes data, unmounts, changes `background_target` to HDD with
`bcachefs set-fs-option`, and remounts. Without writing
`internal/trigger_reconcile_wakeup`, it requires the durable
`set_fs_needs_reconcile` pass to be persisted and executed, reconcile to become
idle, and offline fsck to pass.

The test explicitly rejects scheduling `check_reconcile_work`: that pass is an
fsck validator, not the offline scheduling API. This isolates the repair in
koverstreet/bcachefs-tools#629 from the rejected direct work-index writes in
the earlier stack.

The small `lib/testrunner` change makes host-absolute kernel source/build paths
reachable through `/host` for in-guest external-module and DKMS builds.

Validation:

- `bash -n lib/testrunner tests/fs/bcachefs/target_allocation_repro.ktest`
- `git diff --check`
- Reran in a VM against koverstreet/bcachefs-tools#629 at
  `2bc289a7747c311393bfb0483fb297266550e5f6`:
  `background_target_changed_offline_reconcile_progress` PASSED in 13s,
  `TEST SUCCESS`, with the post-remount `bcachefs recovery-pass` readback
  showing the persisted `set_fs_needs_reconcile` pass instead of `(none)`.
