### PR TITLE
tests/bcachefs: cover offline evacuating scan intent

### DIFF
--- a/lib/testrunner
+++ b/lib/testrunner
@@ -65,6 +65,17 @@ else
 fi
 
 mkdir -p /lib/modules
+
+# Kernel build trees are produced on the host and their generated Makefiles
+# can retain absolute source and output paths.  Make those paths resolve back
+# through virtiofs for in-guest external-module builds (notably bcachefs DKMS).
+for path in "$ktest_kernel_source" "$ktest_kernel_build"; do
+    if [[ $path = /* && ! -e $path ]]; then
+        mkdir -p "$(dirname "$path")"
+        ln -sfn "/host$path" "$path"
+    fi
+done
+
 # Mirror the kernel store entry into /lib/modules per-kver instead of as
 # a single dir-symlink, so we can override /lib/modules/<kver>/updates
 # with a writable symlink to /ktest-out. DKMS install lays bcachefs.ko
@@ -80,7 +91,17 @@ for kver_src in /host/$ktest_kernel_binary/lib/modules/*; do
         # -n: if the link name already exists as a symlink to a directory
         # (e.g. rerun in the same VM, or a previous run with the same kver),
         # replace the symlink itself instead of dereferencing into it
-        ln -sfn "$entry" "/lib/modules/$kver/$(basename "$entry")"
+        if [[ -L $entry ]]; then
+            target=$(readlink "$entry")
+            if [[ $target = /* ]]; then
+                target="/host$target"
+            else
+                target="$(dirname "$entry")/$target"
+            fi
+            ln -sfn "$target" "/lib/modules/$kver/$(basename "$entry")"
+        else
+            ln -sfn "$entry" "/lib/modules/$kver/$(basename "$entry")"
+        fi
     done
     mkdir -p /ktest-out/dkms
     ln -sfn /ktest-out/dkms "/lib/modules/$kver/updates"

--- a/tests/fs/bcachefs/evacuating_startup_scan.ktest
+++ b/tests/fs/bcachefs/evacuating_startup_scan.ktest
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/bcachefs-test-libs.sh"
+
+require-kernel-config BCACHEFS_FS=y
+
+config-mem 4G
+config-scratch-devs 512M
+config-scratch-devs 512M
+config-scratch-devs 512M
+
+devs()
+{
+    join_by : "${ktest_scratch_dev[@]}"
+}
+
+dump_debug()
+{
+    bcachefs fs usage -h --all /mnt || true
+    cat /sys/fs/bcachefs/*/dev-0/state || true
+    cat /sys/fs/bcachefs/*/dev-0/has_data || true
+    cat /sys/fs/bcachefs/*/dev-0/alloc_debug || true
+    cat /sys/fs/bcachefs/*/reconcile_status || true
+    cat /sys/fs/bcachefs/*/internal/moving_ctxts || true
+}
+
+dev0_has_user_data()
+{
+    awk '$1 == "user" { found = $2 > 0 } END { exit !found }' \
+	/sys/fs/bcachefs/*/dev-0/alloc_debug
+}
+
+test_offline_evacuating_device_schedules_scan()
+{
+    set_watchdog 240
+
+    run_quiet "" bcachefs format -f		\
+	--block_size=4k				\
+	--bucket_size=256k			\
+	--replicas=1				\
+	--foreground_target=src			\
+	--label=src ${ktest_scratch_dev[0]}	\
+	--label=dst ${ktest_scratch_dev[1]}	\
+	--label=dst ${ktest_scratch_dev[2]}
+
+    mount -t bcachefs "$(devs)" /mnt
+
+    dd if=/dev/zero of=/mnt/src-data bs=4M count=16 oflag=direct status=none
+    sync
+
+    if ! dev0_has_user_data; then
+	echo "test setup failed: initial write did not place user data on dev 0"
+	dump_debug
+	return 1
+    fi
+
+    umount /mnt
+
+    bcachefs device set-state --offline --force evacuating ${ktest_scratch_dev[0]}
+    bcachefs show-super --field-only members_v2 ${ktest_scratch_dev[0]} |
+	grep -E 'Needs reconcile scan:[[:space:]]+1'
+
+    mount -t bcachefs "$(devs)" /mnt
+
+    if ! grep -qw evacuating /sys/fs/bcachefs/*/dev-0/state; then
+	echo "device 0 did not retain evacuating state across the offline transition"
+	dump_debug
+	return 1
+    fi
+
+    bcachefs reconcile wait -t high_priority /mnt
+
+    if dev0_has_user_data; then
+	echo "evacuating device still has user data after rw mount and high-priority reconcile"
+	dump_debug
+	return 1
+    fi
+
+    umount /mnt
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    ! bcachefs show-super --field-only members_v2 ${ktest_scratch_dev[0]} |
+	grep -E 'Needs reconcile scan:[[:space:]]+1'
+    # Offline state changes can legitimately upgrade an old transaction path;
+    # keep the generic end check focused on unexpected counters.
+    bcachefs reset-counters --counters=trans_restart_upgrade ${ktest_scratch_dev[1]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[1]}
+}
+
+main "$@"


### PR DESCRIPTION
Adds a focused VM negative control for persistent offline evacuation intent.

The test writes user data to device 0, unmounts, runs `bcachefs device set-state
--offline --force evacuating`, and requires the superblock member record to
contain `Needs reconcile scan: 1`. After remount it also verifies the device is
still `evacuating`, waits for high-priority reconcile, requires all source user
data to be drained, and verifies that the scan-intent bit is cleared before
offline fsck.

The shared `lib/testrunner` commit is identical to koverstreet/ktest#56 and
keeps host-absolute kernel build paths usable for in-guest DKMS builds.

Related tools change: koverstreet/bcachefs-tools#632.

Validation:

- `bash -n lib/testrunner tests/fs/bcachefs/evacuating_startup_scan.ktest`
- `git diff --check origin/master...HEAD`
- Reran in a VM against koverstreet/bcachefs-tools#632 at
  `85469f8ff1fc2173e167d4362a3cd4cb7c437a3d`:
  `offline_evacuating_device_schedules_scan` PASSED in 32s, `TEST SUCCESS`. The
  test's own `show-super` assertion (`Needs reconcile scan:\s+1`) is what the
  verdict reflects, not just the field label existing; the device stayed
  `evacuating` across remount, drained fully, and cleared the scan bit before
  offline fsck.
