### PR TITLE
tests/bcachefs: cover unlock empty passphrase file

### DIFF
--- a/tests/fs/bcachefs/single_device.ktest
+++ b/tests/fs/bcachefs/single_device.ktest
@@ -934,6 +934,29 @@ test_crypto_locked_mnt()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_unlock_empty_passphrase_file()
+{
+    set_watchdog 30
+
+    echo foo|bcachefs format -f --encrypted ${ktest_scratch_dev[0]}
+
+    set +o errexit
+    bcachefs unlock -f /dev/null ${ktest_scratch_dev[0]} </dev/null
+    local ret=$?
+    set -o errexit
+
+    [[ $ret -ne 0 ]] || { echo "unlock unexpectedly accepted empty passphrase"; return 1; }
+    [[ $ret -ne 139 ]] || { echo "unlock segfaulted on empty passphrase file"; return 1; }
+    [[ $ret -ne 134 ]] || { echo "unlock aborted on empty passphrase file"; return 1; }
+
+    echo foo|bcachefs unlock -k session ${ktest_scratch_dev[0]}
+    mount -t bcachefs -o verbose ${ktest_scratch_dev[0]} /mnt
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_crypto()
 {
     run_basic_fio_test				\


### PR DESCRIPTION
## Summary

- add a bcachefs regression for `bcachefs unlock -f /dev/null`
- assert the empty passphrase file is rejected without segfaulting or aborting
- unlock with the real passphrase afterward and mount/fsck to confirm the encrypted filesystem is still usable

This covers koverstreet/bcachefs-tools#314, which is fixed in current tools by the Rust `cmd_unlock` conversion but still lacked a regression.

## Testing

- `bash -n tests/fs/bcachefs/single_device.ktest`
- `git diff --check`
- `PATH=/usr/libexec:$PATH ./ktest run -k local/7.1 tests/fs/bcachefs/single_device.ktest unlock_empty_passphrase_file`

The local ktest run did not reach test dispatch: the local `local/7.1` VM entered emergency mode during boot, same as the previous bcachefs ktest attempt on this host.

## VM proof

VM run against master bcachefs-tools (kernel 7.2.0-rc4-ktest-dirty): `unlock_empty_passphrase_file` PASSED in 4s -- `bcachefs unlock -f /dev/null` is correctly rejected (non-zero exit, no segfault/abort), and the real passphrase still unlocks/mounts/fscks clean afterward.
