### PR TITLE
tests/bcachefs: cover high-priority move ioprio

### DIFF
--- a/lib/testrunner
+++ b/lib/testrunner
@@ -65,6 +65,17 @@ else
 fi
 
 mkdir -p /lib/modules
+
+# Kernel build trees are produced on the host and their generated Makefiles
+# can retain absolute source and output paths.  Make those paths resolve back
+# through virtiofs for in-guest external-module builds (notably bcachefs DKMS).
+for path in "$ktest_kernel_source" "$ktest_kernel_build"; do
+    if [[ $path = /* && ! -e $path ]]; then
+        mkdir -p "$(dirname "$path")"
+        ln -sfn "/host$path" "$path"
+    fi
+done
+
 # Mirror the kernel store entry into /lib/modules per-kver instead of as
 # a single dir-symlink, so we can override /lib/modules/<kver>/updates
 # with a writable symlink to /ktest-out. DKMS install lays bcachefs.ko
@@ -80,7 +91,17 @@ for kver_src in /host/$ktest_kernel_binary/lib/modules/*; do
         # -n: if the link name already exists as a symlink to a directory
         # (e.g. rerun in the same VM, or a previous run with the same kver),
         # replace the symlink itself instead of dereferencing into it
-        ln -sfn "$entry" "/lib/modules/$kver/$(basename "$entry")"
+        if [[ -L $entry ]]; then
+            target=$(readlink "$entry")
+            if [[ $target = /* ]]; then
+                target="/host$target"
+            else
+                target="$(dirname "$entry")/$target"
+            fi
+            ln -sfn "$target" "/lib/modules/$kver/$(basename "$entry")"
+        else
+            ln -sfn "$entry" "/lib/modules/$kver/$(basename "$entry")"
+        fi
     done
     mkdir -p /ktest-out/dkms
     ln -sfn /ktest-out/dkms "/lib/modules/$kver/updates"

--- a/tests/fs/bcachefs/bcachefs-test-libs.sh
+++ b/tests/fs/bcachefs/bcachefs-test-libs.sh
@@ -570,6 +570,33 @@ check_bcachefs_counters()
     done
 }
 
+trace_data_update_has_ioprio()
+{
+    local operation=$1
+    local priority=$2
+
+    awk -v operation="$operation" -v priority="$priority" '
+	function finish_event() {
+	    if (in_event && saw_operation && saw_priority)
+		found = 1
+	}
+	/ \[[0-9][0-9][0-9]\]/ {
+	    finish_event()
+	    in_event = $0 ~ /: data_update:/
+	    saw_operation = in_event && index($0, ": " operation)
+	    saw_priority = in_event && index($0, "ioprio: " priority)
+	    next
+	}
+	in_event && index($0, "ioprio:") && index($0, priority) {
+	    saw_priority = 1
+	}
+	END {
+	    finish_event()
+	    exit !found
+	}
+    ' /sys/kernel/tracing/trace
+}
+
 bcachefs_test_end_checks()
 {
     check_bcachefs_leaks

--- a/tests/fs/bcachefs/copygc_pressure_ioprio.ktest
+++ b/tests/fs/bcachefs/copygc_pressure_ioprio.ktest
@@ -21,33 +21,6 @@ pressure_run_count()
 	/sys/fs/bcachefs/*/internal/copy_gc_wait
 }
 
-trace_has_data_update_ioprio()
-{
-    local operation=$1
-    local priority=$2
-
-    awk -v operation="$operation" -v priority="$priority" '
-	function finish_event() {
-	    if (in_event && saw_operation && saw_priority)
-		found = 1
-	}
-	/bcachefs:[[:alnum:]_]+:/ {
-	    finish_event()
-	    in_event = $0 ~ /bcachefs:data_update:/
-	    saw_operation = in_event && index($0, ": " operation)
-	    saw_priority = in_event && index($0, "ioprio: " priority)
-	    next
-	}
-	in_event && index($0, "ioprio:") && index($0, priority) {
-	    saw_priority = 1
-	}
-	END {
-	    finish_event()
-	    exit !found
-	}
-    ' /sys/kernel/tracing/trace
-}
-
 check_pressure_copygc_ioprio()
 {
     local before=$1
@@ -56,7 +29,7 @@ check_pressure_copygc_ioprio()
     for _ in $(seq 1 100); do
 	after=$(pressure_run_count)
 	if [[ -n $after ]] && (( after > before )) &&
-	   trace_has_data_update_ioprio copygc best-effort:7; then
+	   trace_data_update_has_ioprio copygc best-effort:7; then
 	    return 0
 	fi
 	sleep .1

--- a/tests/fs/bcachefs/copygc_pressure_ioprio.ktest
+++ b/tests/fs/bcachefs/copygc_pressure_ioprio.ktest
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/bcachefs-test-libs.sh"
+
+require-kernel-config BCACHEFS_FS=y
+
+config-mem 4G
+config-scratch-devs 768M
+
+dump_copygc_debug()
+{
+    bcachefs fs usage -h --all /mnt || true
+    cat /sys/fs/bcachefs/*/internal/copy_gc_wait || true
+    cat /sys/fs/bcachefs/*/internal/moving_ctxts || true
+    tail -n 500 /sys/kernel/tracing/trace || true
+}
+
+pressure_run_count()
+{
+    awk -F '\t' '$1 == "pressure run count:" { print $2; exit }' \
+	/sys/fs/bcachefs/*/internal/copy_gc_wait
+}
+
+trace_has_data_update_ioprio()
+{
+    local operation=$1
+    local priority=$2
+
+    awk -v operation="$operation" -v priority="$priority" '
+	function finish_event() {
+	    if (in_event && saw_operation && saw_priority)
+		found = 1
+	}
+	/bcachefs:[[:alnum:]_]+:/ {
+	    finish_event()
+	    in_event = $0 ~ /bcachefs:data_update:/
+	    saw_operation = in_event && index($0, ": " operation)
+	    saw_priority = in_event && index($0, "ioprio: " priority)
+	    next
+	}
+	in_event && index($0, "ioprio:") && index($0, priority) {
+	    saw_priority = 1
+	}
+	END {
+	    finish_event()
+	    exit !found
+	}
+    ' /sys/kernel/tracing/trace
+}
+
+check_pressure_copygc_ioprio()
+{
+    local before=$1
+    local after
+
+    for _ in $(seq 1 100); do
+	after=$(pressure_run_count)
+	if [[ -n $after ]] && (( after > before )) &&
+	   trace_has_data_update_ioprio copygc best-effort:7; then
+	    return 0
+	fi
+	sleep .1
+    done
+
+    echo "did not observe pressure copygc data_update at best-effort:7"
+    dump_copygc_debug
+    return 1
+}
+
+test_pressure_copygc_uses_best_effort_ioprio()
+{
+    local pressure_runs_before
+
+    set_watchdog 300
+
+    run_quiet "" bcachefs format -f		\
+	--data_checksum=none			\
+	--bucket_size=32k			\
+	--btree_node_size=32k			\
+	"${ktest_scratch_dev[0]}"
+
+    mount -t bcachefs "${ktest_scratch_dev[0]}" /mnt
+
+    fill_device /mnt/fiotest
+
+    pressure_runs_before=$(pressure_run_count)
+    if [[ -z $pressure_runs_before ]]; then
+	echo "copygc pressure accounting is unavailable"
+	dump_copygc_debug
+	return 1
+    fi
+
+    setup_tracing 'bcachefs:data_update bcachefs:data_update_no_io bcachefs:data_update_read bcachefs:data_update_write'
+
+    for i in $(seq 1 3); do
+	run_fio_base				\
+	    --buffer_compress_percentage=50	\
+	    --name="pressure-copygc-$i"		\
+	    --rw=randwrite			\
+	    --bsrange=4k-128k			\
+	    --time_based=1			\
+	    --runtime=5
+
+	check_pressure_copygc_ioprio "$pressure_runs_before" && break
+
+	local cur_size=$(stat -c '%s' /mnt/fiotest)
+	local new_size=$((cur_size - 1048576))
+	if (( new_size > 0 )); then
+	    truncate --size="$new_size" /mnt/fiotest
+	fi
+    done
+
+    check_pressure_copygc_ioprio "$pressure_runs_before"
+
+    rm -f /mnt/fiotest
+    umount /mnt
+
+    bcachefs fsck -ny "${ktest_scratch_dev[0]}"
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/copygc_pressure_ioprio.ktest
+++ b/tests/fs/bcachefs/copygc_pressure_ioprio.ktest
@@ -17,7 +17,7 @@ dump_copygc_debug()
 
 pressure_run_count()
 {
-    awk -F '\t' '$1 == "pressure run count:" { print $2; exit }' \
+    awk '$1 == "pressure" && $2 == "run" && $3 == "count:" { print $4; exit }' \
 	/sys/fs/bcachefs/*/internal/copy_gc_wait
 }
 

--- a/tests/fs/bcachefs/reconcile_hipri_ioprio.ktest
+++ b/tests/fs/bcachefs/reconcile_hipri_ioprio.ktest
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/bcachefs-test-libs.sh"
+
+require-kernel-config BCACHEFS_FS=y
+
+config-mem 4G
+config-scratch-devs 1G
+config-scratch-devs 1G
+config-scratch-devs 1G
+
+devs()
+{
+    join_by : "${ktest_scratch_dev[@]}"
+}
+
+dump_reconcile_debug()
+{
+    bcachefs fs usage -h --all /mnt || true
+    cat /sys/fs/bcachefs/*/reconcile_status || true
+    cat /sys/fs/bcachefs/*/internal/moving_ctxts || true
+    tail -n 500 /sys/kernel/tracing/trace || true
+}
+
+check_hipri_reconcile_ioprio()
+{
+    for _ in $(seq 1 100); do
+	if trace_has_data_update_ioprio reconcile best-effort:7; then
+	    return 0
+	fi
+	sleep .1
+    done
+
+    echo "did not observe high-priority reconcile data_update at best-effort:7"
+    dump_reconcile_debug
+    return 1
+}
+
+trace_has_data_update_ioprio()
+{
+    local operation=$1
+    local priority=$2
+
+    awk -v operation="$operation" -v priority="$priority" '
+	function finish_event() {
+	    if (in_event && saw_operation && saw_priority)
+		found = 1
+	}
+	/bcachefs:[[:alnum:]_]+:/ {
+	    finish_event()
+	    in_event = $0 ~ /bcachefs:data_update:/
+	    saw_operation = in_event && index($0, ": " operation)
+	    saw_priority = in_event && index($0, "ioprio: " priority)
+	    next
+	}
+	in_event && index($0, "ioprio:") && index($0, priority) {
+	    saw_priority = 1
+	}
+	END {
+	    finish_event()
+	    exit !found
+	}
+    ' /sys/kernel/tracing/trace
+}
+
+src_has_user_data()
+{
+    awk '$1 == "user" { found = $2 > 0 } END { exit !found }' \
+	/sys/fs/bcachefs/*/dev-0/alloc_debug
+}
+
+wait_for_src_user_data_evacuated()
+{
+    local has_data
+
+    for _ in $(seq 1 1200); do
+	has_data=$(cat /sys/fs/bcachefs/*/dev-0/has_data)
+	if ! grep -qw user <<< "$has_data"; then
+	    return 0
+	fi
+	sleep .1
+    done
+
+    echo "source device still has user data after evacuation wait"
+    dump_reconcile_debug
+    return 1
+}
+
+test_hipri_reconcile_uses_best_effort_ioprio()
+{
+    set_watchdog 240
+
+    run_quiet "" bcachefs format -f			\
+	--block_size=4k					\
+	--bucket_size=256k				\
+	--replicas=1					\
+	--foreground_target=src			\
+	--background_target=src			\
+	--rotational=1 --label=src ${ktest_scratch_dev[0]} \
+	--rotational=1 --label=dst ${ktest_scratch_dev[1]} \
+	--rotational=1 --label=dst ${ktest_scratch_dev[2]}
+
+    mount -t bcachefs "$(devs)" /mnt
+
+    dd if=/dev/zero of=/mnt/src-only-data bs=4M count=64 oflag=direct status=none
+    sync
+
+    if ! src_has_user_data; then
+	echo "test setup failed: source device has no user data"
+	dump_reconcile_debug
+	return 1
+    fi
+
+    setup_tracing 'bcachefs:data_update bcachefs:data_update_no_io bcachefs:data_update_read bcachefs:data_update_write'
+
+    echo none > /sys/fs/bcachefs/*/options/foreground_target
+    echo none > /sys/fs/bcachefs/*/options/background_target
+    echo evacuating > /sys/fs/bcachefs/*/dev-0/state
+    wait_for_src_user_data_evacuated
+    check_hipri_reconcile_ioprio
+
+    umount /mnt
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/reconcile_hipri_ioprio.ktest
+++ b/tests/fs/bcachefs/reconcile_hipri_ioprio.ktest
@@ -25,7 +25,7 @@ dump_reconcile_debug()
 check_hipri_reconcile_ioprio()
 {
     for _ in $(seq 1 100); do
-	if trace_has_data_update_ioprio reconcile best-effort:7; then
+	if trace_data_update_has_ioprio reconcile best-effort:7; then
 	    return 0
 	fi
 	sleep .1
@@ -34,33 +34,6 @@ check_hipri_reconcile_ioprio()
     echo "did not observe high-priority reconcile data_update at best-effort:7"
     dump_reconcile_debug
     return 1
-}
-
-trace_has_data_update_ioprio()
-{
-    local operation=$1
-    local priority=$2
-
-    awk -v operation="$operation" -v priority="$priority" '
-	function finish_event() {
-	    if (in_event && saw_operation && saw_priority)
-		found = 1
-	}
-	/bcachefs:[[:alnum:]_]+:/ {
-	    finish_event()
-	    in_event = $0 ~ /bcachefs:data_update:/
-	    saw_operation = in_event && index($0, ": " operation)
-	    saw_priority = in_event && index($0, "ioprio: " priority)
-	    next
-	}
-	in_event && index($0, "ioprio:") && index($0, priority) {
-	    saw_priority = 1
-	}
-	END {
-	    finish_event()
-	    exit !found
-	}
-    ' /sys/kernel/tracing/trace
 }
 
 src_has_user_data()


### PR DESCRIPTION
## Summary

Add focused bcachefs tests for two move paths that must make forward progress without relying on idle IO scheduling:

- `reconcile_hipri_ioprio.ktest` writes data onto one source device, marks it evacuating, and requires a `reconcile` data-update event at `best-effort:7` before checking that the source drained and offline fsck succeeds.
- `copygc_pressure_ioprio.ktest` fills a filesystem, creates overwrite pressure, requires the pressure-run counter to increase, and then requires a `copygc` data-update event at `best-effort:7` before offline fsck.

The shared parser correlates the operation and priority within one multiline `data_update` trace event. It does not accept unrelated global `best-effort:7` output. Both tests use semantic completion and integrity checks rather than throughput thresholds.

Changes under test:

- koverstreet/bcachefs-tools#641
- koverstreet/bcachefs-tools#645

## Branch structure

The first commit is the same absolute-host-module-path bridge used by koverstreet/ktest#58. The two focused test commits and parser corrections are independent of that PR's target test.

## Validation

- `bash -n` on both tests and `bcachefs-test-libs.sh`
- `git diff --check`
- `cargo build --verbose`
- Reran in a VM against koverstreet/bcachefs-tools#641 at
  `591698ed232b754d125d20c076dae5edc6cd4448`:
  `hipri_reconcile_uses_best_effort_ioprio` PASSED in 13s, `TEST SUCCESS`, with
  the `reconcile` event's `ioprio:` field showing `best-effort:7` live off
  in-flight IO.
- Reran in a VM against koverstreet/bcachefs-tools#645 at
  `5c766ebd581e369deb45399f1d43d6699e29016d`:
  `pressure_copygc_uses_best_effort_ioprio` PASSED in 12s, `TEST SUCCESS`, with
  the copygc pressure-run counter increasing and the `copygc` event reporting
  `best-effort:7`.

During validation, the tests themselves caught two false negatives: trace events are multiline and `copy_gc_wait` uses aligned whitespace rather than a tab delimiter. Those parsers are now shared or field-based, respectively.
