### PR TITLE
tests/bcachefs: cover swapfile reclaim pressure

### DIFF
--- a/tests/fs/bcachefs/swapfile.ktest
+++ b/tests/fs/bcachefs/swapfile.ktest
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+require-kernel-config BCACHEFS_FS
+require-kernel-config SWAP
+
+config-mem 768M
+config-scratch-devs 2G
+
+dump_swap_debug()
+{
+    cat /proc/swaps || true
+    cat /proc/meminfo || true
+    dmesg | tail -n 200 || true
+}
+
+disable_swapfile()
+{
+    swapoff /mnt/swapfile 2>/dev/null || true
+}
+
+test_bcachefs_swapfile_under_reclaim()
+{
+    set_watchdog 300
+
+    run_quiet "" bcachefs format -f "${ktest_scratch_dev[0]}"
+    mount -t bcachefs "${ktest_scratch_dev[0]}" /mnt
+
+    fallocate -l 512M /mnt/swapfile
+    chmod 600 /mnt/swapfile
+    mkswap /mnt/swapfile
+
+    if ! swapon /mnt/swapfile; then
+	echo "bcachefs swapfile swapon failed"
+	dump_swap_debug
+	return 1
+    fi
+    trap disable_swapfile EXIT
+
+    grep -q /mnt/swapfile /proc/swaps
+
+    stress-ng --vm 2 --vm-bytes 600M --vm-keep -t 60 --metrics-brief || {
+	echo "swap pressure workload failed"
+	dump_swap_debug
+	return 1
+    }
+
+    swapoff /mnt/swapfile
+    trap - EXIT
+
+    rm -f /mnt/swapfile
+    umount /mnt
+
+    bcachefs fsck -ny "${ktest_scratch_dev[0]}"
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add a basic bcachefs ktest for swapfile support under reclaim pressure.

The test creates a bcachefs filesystem, creates a swapfile on it, enables that
swapfile, verifies it appears in `/proc/swaps`, and runs a memory-pressure
workload while swap remains active.

Source PR status has moved since this test was opened:

- the original companion source PR, https://github.com/koverstreet/bcachefs-tools/pull/646,
  is closed in favour of https://github.com/koverstreet/bcachefs-tools/pull/787;
- the broader memory-pressure/stress suite discussed on that thread is
  https://github.com/koverstreet/ktest/pull/98.

This PR remains the small smoke/regression test for the basic swapfile path. It
is expected to fail against bcachefs without `SWP_FS_OPS` swapfile support and
pass with the current swapfile series or an equivalent implementation. It is not
the discriminator for the deeper reclaim-armour question; that belongs with the
stress coverage in https://github.com/koverstreet/ktest/pull/98.

Source issue: https://github.com/koverstreet/bcachefs/issues/368. Duplicate
report: https://github.com/koverstreet/bcachefs/issues/923. Earlier kernel-side
draft: https://github.com/koverstreet/bcachefs/pull/1072.

## Validation

- `bash -n tests/fs/bcachefs/swapfile.ktest`
- `git diff --check`
