### PR TITLE
tests/bcachefs: cover subvol mount option

### DIFF
--- a/tests/fs/bcachefs/subvol_mount.ktest
+++ b/tests/fs/bcachefs/subvol_mount.ktest
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/bcachefs-test-libs.sh
+
+config-scratch-devs 4G
+
+test_subvol_mount_option()
+{
+    local dev=${ktest_scratch_dev[0]}
+
+    set_watchdog 30
+
+    run_quiet "" bcachefs format -f $dev
+    mount -t bcachefs $dev /mnt
+
+    echo root > /mnt/root-only
+    bcachefs subvolume create /mnt/subvol
+    echo subvol > /mnt/subvol/subvol-only
+
+    umount /mnt
+
+    mount -t bcachefs -o subvol=subvol $dev /mnt
+    test "$(cat /mnt/subvol-only)" = subvol
+    ! test -e /mnt/root-only
+    umount /mnt
+
+    bcachefs fsck -ny $dev
+    bcachefs_test_end_checks $dev
+}
+
+main "$@"


### PR DESCRIPTION
Adds a focused bcachefs test for mount-time subvolume selection.

The test creates a root-only marker plus a subvolume-only marker, unmounts the root filesystem, mounts with `-o subvol=subvol`, and verifies the mounted tree exposes the subvolume marker without the root marker. That checks the user-visible identity of the mount, not just `mount` exit status.

This is companion coverage for koverstreet/bcachefs-tools#647 and issue koverstreet/bcachefs-tools#181.

Validation:

- `bash -n tests/fs/bcachefs/subvol_mount.ktest`
- `git diff --check`
- Ran in a VM against koverstreet/bcachefs-tools#647 at
  `b63413f1f4e3aaf718a20c160b73440f3824bb36`: `subvol_mount_option` PASSED in
  8s, `TEST SUCCESS` — mounting with `-o subvol=subvol` exposed the
  subvolume-only marker and hid the root-only marker.
