### PR TITLE
tests/bcachefs: cover security.selinux xattrs

### DIFF
--- a/tests/fs/bcachefs/single_device.ktest
+++ b/tests/fs/bcachefs/single_device.ktest
@@ -1115,6 +1115,24 @@ test_xattr()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_security_selinux_xattr()
+{
+    set_watchdog 10
+    run_quiet "" bcachefs format -f		\
+	${ktest_scratch_dev[0]}
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    touch /mnt/selinux-test
+    setfattr -n security.selinux -v system_u:object_r:unlabeled_t:s0 /mnt/selinux-test
+    getfattr -n security.selinux --only-values /mnt/selinux-test |
+	grep -qx system_u:object_r:unlabeled_t:s0
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_quota()
 {
     set_watchdog 60


### PR DESCRIPTION
## Summary

- Add a focused `single_device.ktest` case that writes and reads a `security.selinux` xattr on bcachefs.
- Cover the behavior requested in koverstreet/bcachefs#642.
- Pair with the bcachefs-tools implementation in koverstreet/bcachefs-tools#651.

## Validation

- `git diff --check`
- `bash -n tests/fs/bcachefs/single_device.ktest`
- Focused local VM run was attempted with:
  `build-test-kernel run tests/fs/bcachefs/single_device.ktest security_selinux_xattr`
  but the local kernel checkout failed configuration before reaching the test:
  `Kernel config option RUST is n; should be y`.

## VM proof

VM run against master bcachefs-tools (kernel 7.2.0-rc4): `security_selinux_xattr` PASSED in 3s -- writing and reading a `security.selinux` xattr on bcachefs round-trips correctly, fsck clean.
