### PR TITLE
tests/bcachefs: cover 32-bit readdir dirents

### DIFF
--- a/root_image
+++ b/root_image
@@ -85,6 +85,25 @@ PACKAGES=(kexec-tools less psmisc openssh-server curl		\
     bc attr gawk acl rsync git python3-docutils			\
     stress-ng lsof xxd zstd ripgrep bpfcc-tools)
 
+if [[ $DEBIAN_ARCH = i386 ]]; then
+    # bpftrace and bpfcc-tools are not built for Debian i386, and the i386
+    # root image is still useful for 32-bit userspace compatibility tests.
+    FILTERED_PACKAGES=()
+    for package in "${PACKAGES[@]}"; do
+	case "$package" in
+	    bpftrace|bpfcc-tools) ;;
+	    *) FILTERED_PACKAGES+=("$package") ;;
+	esac
+    done
+    PACKAGES=("${FILTERED_PACKAGES[@]}")
+fi
+
+if [[ $DEBIAN_ARCH = amd64 ]]; then
+    # 32-bit userspace compatibility tests exercise Steam-style i386
+    # processes on an x86_64 kernel.
+    PACKAGES+=(gcc-multilib libc6-dev-i386)
+fi
+
 # build tools:
 PACKAGES+=(build-essential make gcc g++ clang lld)
 PACKAGES+=(autoconf automake autopoint bison flex pahole)

--- a/tests/fs/bcachefs/32bit.ktest
+++ b/tests/fs/bcachefs/32bit.ktest
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-ktest_arch=x86
+ktest_arch=x86_64
 
 . $(dirname $(readlink -e ${BASH_SOURCE[0]}))/bcachefs-test-libs.sh
 
 config-timeout 30
+config-scratch-devs 1G
+require-kernel-config IA32_EMULATION
 
 test_boot()
 {
@@ -63,6 +65,124 @@ test_readdir_stateless()
 	    die "$_ emitted $seen{$_} times" if $seen{$_} > 3;
 	}
     '
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+test_readdir_32bit_dirents()
+{
+    set_watchdog 60
+
+    cat > /root/readdir32.c <<-ZZ
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char **argv)
+{
+    if (argc != 3) {
+	fprintf(stderr, "usage: %s <path> <min_entries>\\n", argv[0]);
+	return 2;
+    }
+
+    DIR *dir = opendir(argv[1]);
+    if (!dir) {
+	perror("opendir");
+	return 1;
+    }
+
+    errno = 0;
+    unsigned entries = 0;
+    int saw_dot = 0;
+    int saw_dotdot = 0;
+    long cookie = -1;
+    struct dirent *de;
+    while ((de = readdir(dir))) {
+	entries++;
+	if (!strcmp(de->d_name, "."))
+	    saw_dot = 1;
+	if (!strcmp(de->d_name, ".."))
+	    saw_dotdot = 1;
+	if (entries == 16)
+	    cookie = telldir(dir);
+    }
+
+    if (errno) {
+	perror("readdir");
+	return 1;
+    }
+
+    if (!saw_dot || !saw_dotdot) {
+	fprintf(stderr, "missing dot entries: .=%d ..=%d\\n", saw_dot, saw_dotdot);
+	return 1;
+    }
+
+    if (entries < strtoul(argv[2], NULL, 10)) {
+	fprintf(stderr, "saw only %u entries\\n", entries);
+	return 1;
+    }
+
+    if (cookie >= 0) {
+	seekdir(dir, cookie);
+	errno = 0;
+	if (!readdir(dir) && errno) {
+	    perror("readdir after seekdir");
+	    return 1;
+	}
+    }
+
+    return 0;
+}
+ZZ
+
+    gcc -m32 -Wall -Wextra -O2 -o /root/readdir32 /root/readdir32.c
+
+    run_quiet "" bcachefs format -f ${ktest_scratch_dev[0]}
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    mkdir -p /mnt/home/someone/gamesdir
+    for i in $(seq 1 512); do
+	touch /mnt/root_$i
+	touch /mnt/home/someone/gamesdir/file_$i
+    done
+
+    /root/readdir32 /mnt 514
+    /root/readdir32 /mnt/home/someone/gamesdir 514
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+
+    run_quiet "" bcachefs format -f --str_hash=crc32c ${ktest_scratch_dev[0]}
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    mkdir -p /mnt/crc32c
+    for i in $(seq 1 512); do
+	touch /mnt/crc32c/file_$i
+    done
+
+    /root/readdir32 /mnt/crc32c 514
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+
+    run_quiet "" bcachefs format -f --inodes_32bit ${ktest_scratch_dev[0]}
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    mkdir -p /mnt/inodes32
+    for i in $(seq 1 512); do
+	touch /mnt/inodes32/file_$i
+    done
+
+    /root/readdir32 /mnt/inodes32 514
 
     umount /mnt
 


### PR DESCRIPTION
Replaces the old inodes_32bit-only case in 32bit.ktest with default-formatted 32-bit readdir coverage, run the way Steam/Wine actually exercises it: x86_64 kernel with IA32_EMULATION, 32-bit readdir(3) caller built with gcc -m32.

Builds a nested game-directory tree, reads it from the 32-bit helper, and checks for `.`/`..` (the dot-entry regression from koverstreet/bcachefs-tools#652) plus telldir()/seekdir() cookie handling. Also covers --str_hash=crc32c and --inodes_32bit formats since the cookie encoding differs by hash mode.

root_image changes: skip bpftrace/bpfcc-tools on the i386 root (not packaged for Debian i386) and add gcc-multilib/libc6-dev-i386 to the amd64 root so it can build the 32-bit helper.

bcachefs-tools#652 (the fix this covers) is merged and released, so this stands as regression coverage. Ran end-to-end in a VM against current bcachefs-tools master (`9ba35c439`) with an x86_64 kernel built with IA32_EMULATION: `readdir_32bit_dirents` PASSED in 10s, `TEST SUCCESS`. The `gcc -m32` helper built cleanly and read the default, `--str_hash=crc32c`, and `--inodes_32bit` mounts correctly, with `.`/`..` present, telldir()/seekdir() round-tripping, and fsck clean on all three.
