### PR TITLE
tests/bcachefs: cover direct io alignment

### DIFF
--- a/tests/fs/bcachefs/single_device.ktest
+++ b/tests/fs/bcachefs/single_device.ktest
@@ -108,6 +108,94 @@ test_directory_stat_size_nonzero()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_direct_io_alignment()
+{
+    set_watchdog 10
+
+    cat <<'EOF' > /root/dioalign.c
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/stat.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static int do_statx(int fd, struct statx *stx)
+{
+    return syscall(SYS_statx, fd, "", AT_EMPTY_PATH, STATX_DIOALIGN, stx);
+}
+
+int main(int argc, char **argv)
+{
+    struct statx stx = { 0 };
+    void *buf = NULL;
+    ssize_t ret;
+    int fd;
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s file\n", argv[0]);
+        return 2;
+    }
+
+    fd = open(argv[1], O_CREAT|O_TRUNC|O_RDWR|O_DIRECT, 0600);
+    if (fd < 0) {
+        perror("open");
+        return 1;
+    }
+
+    if (do_statx(fd, &stx)) {
+        perror("statx");
+        return 1;
+    }
+    if (!(stx.stx_mask & STATX_DIOALIGN)) {
+        fprintf(stderr, "STATX_DIOALIGN missing, mask=0x%x\n", stx.stx_mask);
+        return 1;
+    }
+    if (stx.stx_dio_mem_align != 512 || stx.stx_dio_offset_align != 4096) {
+        fprintf(stderr, "unexpected DIO align: mem=%u offset=%u\n",
+                stx.stx_dio_mem_align, stx.stx_dio_offset_align);
+        return 1;
+    }
+
+    if (posix_memalign(&buf, 4096, 4096)) {
+        fprintf(stderr, "posix_memalign failed\n");
+        return 1;
+    }
+    memset(buf, 0x5a, 4096);
+
+    errno = 0;
+    ret = pwrite(fd, buf, 512, 0);
+    if (ret != -1 || errno != EINVAL) {
+        fprintf(stderr, "512-byte O_DIRECT write: ret=%zd errno=%d\n", ret, errno);
+        return 1;
+    }
+
+    ret = pwrite(fd, buf, 4096, 0);
+    if (ret != 4096) {
+        fprintf(stderr, "4096-byte O_DIRECT write: ret=%zd errno=%d\n", ret, errno);
+        return 1;
+    }
+
+    free(buf);
+    close(fd);
+    return 0;
+}
+EOF
+    gcc -Wall -Wextra -O2 -o /root/dioalign /root/dioalign.c
+
+    run_quiet "" bcachefs format -f --block_size=4k ${ktest_scratch_dev[0]}
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+    /root/dioalign /mnt/dio-test
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_mount_again_after_ebusy()
 {
     set_watchdog 60


### PR DESCRIPTION
## Summary

- Add a focused bcachefs direct-I/O alignment regression to `single_device.ktest`.
- Verify regular files report `STATX_DIOALIGN` with 512-byte memory alignment and 4 KiB offset alignment on a 4 KiB block-size filesystem.
- Verify a 512-byte `O_DIRECT` write is rejected with `EINVAL`, while an aligned 4 KiB write succeeds.

## Issue

koverstreet/bcachefs#791 reports VM image I/O errors with QEMU `cache=none`. The issue discussion narrowed the common reproducer to `O_DIRECT` writes against a bcachefs filesystem formatted with 4 KiB blocks while the guest-visible disk path can issue 512-byte writes.

## Paired docs

- koverstreet/bcachefs-tools#653 documents QEMU `cache=none` and bcachefs direct-I/O alignment.

## Validation

- `bash -n tests/fs/bcachefs/single_device.ktest`
- extracted C helper compiled with `gcc -Wall -Wextra -O2`
- `git diff --check`

Focused local VM attempt:

- `PATH=/usr/libexec:$PATH ./build-test-kernel run -k <local kernel source tree> -I tests/fs/bcachefs/single_device.ktest direct_io_alignment` initially found `virtiofsd` only under `/usr/libexec`.
- `CC=gcc-16 PATH=/usr/libexec:$PATH ./build-test-kernel run -k <local kernel source tree> tests/fs/bcachefs/single_device.ktest direct_io_alignment` booted the VM, but the current ktest bcachefs DKMS helper still invoked plain `gcc` inside the guest for a kernel built with `gcc-16`, failed in `include/linux/blkdev.h` at `__counted_by_ptr`, and never loaded bcachefs. The test body itself did not run locally.

## VM proof

VM run against master bcachefs-tools (kernel 7.2.0-rc4): `direct_io_alignment` PASSED in 6s -- regular files report STATX_DIOALIGN with 512-byte memory / 4KiB offset alignment, and a 512-byte O_DIRECT write is rejected EINVAL as expected on a 4KiB block-size fs.
