### PR TITLE
syzbot-get: fix conflict in argument definitions

### DIFF
--- a/src/bin/syzbot-get.rs
+++ b/src/bin/syzbot-get.rs
@@ -5,9 +5,9 @@ use std::path::PathBuf;
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    #[arg(short, long)]
+    #[arg(long)]
     id: String,
-    #[arg(short, long)]
+    #[arg(long)]
     idx: Option<usize>,
     #[arg(short, long)]
     output: PathBuf,


### PR DESCRIPTION
Refreshes koverstreet/ktest#39 and preserves Bharadwaj Raju's original patch author.

The original PR was dirty after later rustfmt changes, but the underlying fix is still needed: current master panics in clap debug assertions because both `id` and `idx` claim short `-i`.

This rebases the same behavior change onto current `master`: remove the short aliases from `--id` and `--idx`, leaving long names for those two arguments and keeping `-o/--output` plus `-v/--verbose`.

Validation:
- old current-master negative control: `cargo run --quiet --bin syzbot-get -- --help` panics with `Short option names must be unique ... '-i' is in use by both 'id' and 'idx'`
- fixed branch: `cargo run --quiet --bin syzbot-get -- --help` prints help successfully
- `cargo test --quiet`

## VM proof

No VM needed (this is a CLI arg-parse fix, not a bcachefs test). Built and ran `syzbot-get --help`: on unpatched master it panics at clap's debug_assert (`Short option names must be unique for each argument, but '-i' is in use by both 'id' and 'idx'`); on this branch it builds clean and prints proper usage with `--id`/`--idx` as long-only flags.
