### PR TITLE
tests/bcachefs: cover same-second multidev resize

### DIFF
--- a/tests/fs/bcachefs/online_resize.ktest
+++ b/tests/fs/bcachefs/online_resize.ktest
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/bcachefs-test-libs.sh
+
+config-scratch-devs 4G
+config-scratch-devs 4G
+
+test_multidevice_same_second()
+{
+    set_watchdog 180
+    bcachefs_antagonist
+
+    run_quiet "" bcachefs format -f		\
+	--fs_size=1G				\
+	${ktest_scratch_dev[0]}			\
+	${ktest_scratch_dev[1]}
+
+    mount -t bcachefs ${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]} /mnt
+
+    df -h /mnt
+
+    bcachefs device resize ${ktest_scratch_dev[0]} &
+    local pid0=$!
+    bcachefs device resize ${ktest_scratch_dev[1]} &
+    local pid1=$!
+
+    wait $pid0
+    wait $pid1
+
+    df -h /mnt
+
+    fio --eta=always			\
+	--exitall_on_error=1		\
+	--randrepeat=0			\
+	--ioengine=libaio		\
+	--iodepth=16			\
+	--direct=1			\
+	--filename=/mnt/resize-io	\
+	--filesize=256M			\
+	--name=randwrite		\
+	--rw=randwrite			\
+	--bs=64k			\
+	--runtime=10
+
+    sync
+    umount /mnt
+
+    mount -t bcachefs ${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]} /mnt
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]} ${ktest_scratch_dev[1]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+main "$@"


### PR DESCRIPTION
Adds a bcachefs online resize regression test for the multi-device case discussed in koverstreet/bcachefs#833. The reported trigger there was two device resizes issued within the same second; existing ktest coverage only had single-device online/offline resize cases in `single_device.ktest`.

The new test formats two scratch devices with `--fs_size=1G`, mounts them together, launches both `bcachefs device resize` commands concurrently, then does post-resize I/O, remount, fsck, and the usual bcachefs end checks.

Local checks:
- `bash -n tests/fs/bcachefs/online_resize.ktest`
- `tests/fs/bcachefs/online_resize.ktest list-tests`

Related to koverstreet/bcachefs#833.

## VM proof

VM run against master bcachefs-tools (kernel 7.2.0-rc4): `multidevice_same_second` PASSED in 12s -- two device resizes issued within the same second on a multi-device fs both complete cleanly, offline fsck clean.
