### PR TITLE
tests/bcachefs: cover mount session keyring

### DIFF
--- a/root_image
+++ b/root_image
@@ -97,7 +97,7 @@ PACKAGES+=(fio dbench bonnie++ fsmark)
 
 # bcachefs-tools build dependencies:
 PACKAGES+=(libblkid-dev uuid-dev libscrypt-dev libsodium-dev)
-PACKAGES+=(libkeyutils-dev liburcu-dev libudev-dev zlib1g-dev libattr1-dev systemd-dev)
+PACKAGES+=(keyutils libkeyutils-dev liburcu-dev libudev-dev zlib1g-dev libattr1-dev systemd-dev)
 PACKAGES+=(libaio-dev libzstd-dev liblz4-dev libfuse3-dev valgrind)
 PACKAGES+=(llvm libclang-dev libunwind-dev libelf-dev)
 

--- a/tests/fs/bcachefs/single_device.ktest
+++ b/tests/fs/bcachefs/single_device.ktest
@@ -934,6 +934,33 @@ test_crypto_locked_mnt()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_crypto_mount_session_keyring()
+{
+    if ! bcachefs mount --help | grep -q 'session keyring'; then
+	echo "bcachefs mount lacks session-keyring prompted-key support, skipping"
+	return 0
+    fi
+
+    echo foo|bcachefs format -f --encrypted ${ktest_scratch_dev[0]}
+
+    local uuid=$(bcachefs show-super ${ktest_scratch_dev[0]} |
+		 awk '/^External UUID:/ { print $3; exit }')
+    [[ -n $uuid ]]
+
+    keyctl session - sh -ec '
+	keyctl unlink @u @s 2>/dev/null || true
+
+	echo foo|bcachefs mount -k stdin "$2" /mnt
+	keyctl search @s user "bcachefs:$1" >/dev/null
+	! keyctl search @u user "bcachefs:$1" >/dev/null
+	umount /mnt
+    ' sh "$uuid" ${ktest_scratch_dev[0]}
+
+    echo foo|bcachefs unlock -k session ${ktest_scratch_dev[0]}
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_crypto()
 {
     run_basic_fio_test				\


### PR DESCRIPTION
## Summary

- add a bcachefs single-device crypto test for the mount-helper session-keyring behavior from koverstreet/bcachefs-tools#655
- install `keyutils` in the ktest root image so the test can use `keyctl`
- gate the test until the mount helper advertises session-keyring prompted-key support, so current tools builds skip instead of failing before the companion tools change lands
- when active, format an encrypted filesystem, run `bcachefs mount -k stdin` in a fresh `keyctl session`, assert the key is in `@s` and not `@u`, then unlock for normal `fsck` and end checks

## Links

- Covers koverstreet/bcachefs#640
- Companion to koverstreet/bcachefs-tools#655

## Validation

- `git diff --check origin/master...HEAD`
- `bash -n root_image`
- `bash -n tests/fs/bcachefs/single_device.ktest`
- `bash tests/fs/bcachefs/single_device.ktest list-tests | grep -n 'crypto_mount_session_keyring'`
- `cargo build --verbose`
- GitHub Actions `build-and-format`: https://github.com/koverstreet/ktest/actions/runs/28328616848/job/83922801094

## VM proof

Correction: an earlier run of this test reported PASSED, but the guest was running a stale/wrong tools binary whose `bcachefs mount --help` didn't advertise session-keyring support, so the test's own capability probe made it self-skip in under a second -- it never actually exercised the mount path. Rerun on a verified harness (guest tools binary confirmed built from bcachefs-tools#655's exact head commit, `bcachefs mount --help` does list "session keyring"): `crypto_mount_session_keyring` now runs for real and FAILS -- after `bcachefs mount -k stdin` inside a freshly joined session keyring, `keyctl search @s user "bcachefs:<uuid>"` reports "Required key not available". The mount itself succeeds, so the key lands somewhere, just not where `Keyring::Session` is supposed to put it relative to the caller's session. Root cause not yet isolated (open question noted for follow-up: whether the key ends up in `@u` after all, or somewhere neither `@s` nor `@u` can see from this process).
