### PR TITLE
tests/bcachefs: cover update command wrapper

### DIFF
--- a/tests/fs/bcachefs/single_device.ktest
+++ b/tests/fs/bcachefs/single_device.ktest
@@ -1344,6 +1344,36 @@ test_set_option()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_update_command()
+{
+    set_watchdog 60
+
+    if ! bcachefs update --help | grep -q 'Upgrade a mounted filesystem'; then
+	echo "bcachefs update command not available, skipping"
+	return 0
+    fi
+
+    run_quiet "" bcachefs format -f ${ktest_scratch_dev[0]}
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    bcachefs update /mnt
+
+    # sysfs prints the whole choice list with the live one bracketed
+    # ("compatible incompatible [none]"), not a bare value - so extract
+    # the bracketed selection, don't compare the raw multi-word string.
+    local version_upgrade
+    version_upgrade="$(cat /sys/fs/bcachefs/*/options/version_upgrade)"
+    echo "version_upgrade after bcachefs update: $version_upgrade"
+    local version_upgrade_selected
+    version_upgrade_selected="$(grep -oP '\[\K[^\]]+' <<<"$version_upgrade")"
+    [[ $version_upgrade_selected == none ]]
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 disabled_test_swapfile()
 {
     run_quiet "" bcachefs format -f ${ktest_scratch_dev[0]}


### PR DESCRIPTION
## Summary

- add a gated bcachefs single-device test for the `bcachefs update` wrapper from koverstreet/bcachefs-tools#635
- format and mount a scratch filesystem, run `bcachefs update /mnt`, and assert `version_upgrade` is reset to `none` afterward
- skip cleanly when the installed bcachefs tools do not yet advertise the update command

## Links

- Covers koverstreet/bcachefs-tools#510
- Companion to koverstreet/bcachefs-tools#635

## Validation

- `git diff --check`
- `bash -n tests/fs/bcachefs/single_device.ktest`
- `bash tests/fs/bcachefs/single_device.ktest list-tests | grep -n update_command`
- `cargo build --verbose`
- `codex review --base origin/master`
- GitHub Actions `build-and-format`: https://github.com/koverstreet/ktest/actions/runs/28331948713/job/83931497110

## VM proof

Fixed a bug in this test's own assertion: `version_upgrade="$(cat /sys/fs/bcachefs/*/options/version_upgrade)"` was reading the sysfs option file's full choice-list display format (e.g. `compatible incompatible [none]`, current value bracketed, same format every other bcachefs choice-option sysfs file uses) and then comparing that whole string literally to `none` with `[[ $version_upgrade == none ]]`, which could never match regardless of which value was actually selected. Fixed to extract the bracketed selection first (`grep -oP '\[\K[^]]+'`, the same idiom already used elsewhere in this repo, e.g. `replication.ktest`'s SPOF-device parsing), matching the bracket-aware pattern `device-open-errors.ktest` also uses for its own choice-option sysfs read.

Reran in a VM against koverstreet/bcachefs-tools#635's exact current head (`3b2e1092d`, guest tools binary built from that commit, verified via `git -C $ktest_deps_dir/bcachefs-tools rev-parse HEAD`): `bcachefs update /mnt` runs for real (not a capability-probe skip -- `bcachefs update --help` does advertise the command), the sysfs read reports `version_upgrade after bcachefs update: compatible incompatible [none]`, the fixed assertion now correctly extracts `none` from the brackets and passes, and the test completes its post-update `fsck -ny` and `bcachefs_test_end_checks` cleanly. `TEST SUCCESS`.
