### PR TITLE
tests/bcachefs: test filesystem label mounts

### DIFF
--- a/tests/fs/bcachefs/single_device.ktest
+++ b/tests/fs/bcachefs/single_device.ktest
@@ -159,6 +159,29 @@ test_mount_options()
     bcachefs_test_end_checks $dev
 }
 
+test_mount_by_filesystem_label()
+{
+    local dev=${ktest_scratch_dev[0]}
+    local label=ktest_mount_by_label
+
+    set_watchdog 10
+
+    if ! bcachefs mount --help 2>&1 | grep -q 'LABEL='; then
+        echo "bcachefs mount LABEL= support not available, skipping"
+        return 0
+    fi
+
+    run_quiet "" bcachefs format -f -L "$label" $dev
+
+    echo "test: mount by filesystem label"
+    mount -t bcachefs "LABEL=$label" /mnt
+    touch /mnt/mounted-by-label
+    umount /mnt
+
+    bcachefs fsck -ny $dev
+    bcachefs_test_end_checks $dev
+}
+
 test_extent_merge2()
 {
     local p=/sys/module/bcachefs/parameters/debug_check_iterators


### PR DESCRIPTION
## Summary

Add a focused bcachefs regression for mounting a filesystem by `LABEL=<label>`.

The test formats a scratch filesystem with a filesystem label, mounts it through `mount -t bcachefs LABEL=<label> /mnt`, writes a marker file, unmounts, and runs the normal fsck/end checks.

The test self-skips when the installed `bcachefs mount --help` does not advertise `LABEL=` yet, so it can land alongside the tools-side implementation without breaking older test images.

Tools implementation: https://github.com/koverstreet/bcachefs-tools/pull/664
Fixes/coverage for: https://github.com/koverstreet/bcachefs/issues/551

## Testing

- `bash -n tests/fs/bcachefs/single_device.ktest`
- `git diff --check`
- `tests/fs/bcachefs/single_device.ktest list-tests | rg '^mount_by_filesystem_label$'`
- `cargo build --verbose`
- `codex review --base origin/master`
- GitHub Actions `build-and-format` is green on head `20c72d442b4e3265835c1f21146f1bdfb40d290d`.

## VM proof

VM run against master bcachefs-tools (kernel 7.2.0-rc4): `mount_by_filesystem_label` PASSED in 6s -- `mount -t bcachefs LABEL=<label>` resolves and mounts correctly, marker file round-trips, normal fsck/end checks pass.
