### PR TITLE
tests/bcachefs: test subvolume delete with loop holder

### DIFF
--- a/tests/fs/bcachefs/subvol.ktest
+++ b/tests/fs/bcachefs/subvol.ktest
@@ -369,6 +369,32 @@ test_subvol_delete()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_subvol_delete_loop_holder()
+{
+    local loopdev=
+
+    trap '[[ -n "$loopdev" ]] && losetup -d "$loopdev" || true' RETURN
+
+    run_quiet "" bcachefs format -f ${ktest_scratch_dev[0]}
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    bcachefs subvolume create /mnt/subvolume_1
+    truncate -s 64M /mnt/subvolume_1/loop.img
+    loopdev=$(losetup --find --show /mnt/subvolume_1/loop.img)
+
+    bcachefs subvolume delete /mnt/subvolume_1
+
+    losetup -d "$loopdev"
+    loopdev=
+    trap - RETURN
+
+    umount /mnt
+
+    bcachefs fsck -n ${ktest_scratch_dev[0]}
+
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_subvol_create_delete()
 {
     bcachefs_antagonist


### PR DESCRIPTION
## Summary

Add a bcachefs subvolume regression test for deleting a subvolume while an external loop-device holder still references a file inside it.


## Verification

- `bash -n tests/fs/bcachefs/subvol.ktest`
- `tests/fs/bcachefs/subvol.ktest list-tests | rg '^subvol_delete_loop_holder$'`
- `git diff --check`
- `cargo build --verbose`
- `codex review --base origin/master`

## Notes

This is a regression test, not the kernel-side fix. The intended kernel behavior still needs the non-blocking/revoke-on-delete design discussed in koverstreet/bcachefs#1091.

## VM proof

Update: the companion fix landed on koverstreet/bcachefs-tools#724 (two commits: non-blocking subvolume delete with the RCU-safe eviction scan, plus the create_lock/pagefault split). This test now passes in 5s against that branch in a VM, no sleeping-in-atomic or RCU splats.
