### PR TITLE
tests/bcachefs: cover cached foreground replicas

### DIFF
--- a/tests/fs/bcachefs/tier.ktest
+++ b/tests/fs/bcachefs/tier.ktest
@@ -238,6 +238,59 @@ test_tiering_replication()
     run_basic_tiering_test --replicas=2
 }
 
+test_tiering_cached_replicas()
+{
+    set_watchdog 240
+
+    run_quiet "" bcachefs format -f			\
+	--block_size=4k					\
+	--bucket_size=256k				\
+	--replicas=2					\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}	\
+	--label=ssd.ssd2 ${ktest_scratch_dev[1]}	\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}	\
+	--label=hdd.hdd2 ${ktest_scratch_dev[3]}	\
+	--foreground_target=ssd				\
+	--promote_target=ssd				\
+	--background_target=hdd
+
+    mount -t bcachefs "$(join_by : "${ktest_scratch_dev[@]}")" /mnt
+
+    dd if=/dev/zero of=/mnt/cached-replicas bs=16M count=16 oflag=direct
+    sync
+
+    bcachefs reconcile wait -t target /mnt
+
+    local usage=/tmp/tiering-cached-replicas-usage.txt
+    bcachefs fs usage -a -h /mnt > "$usage"
+
+    local dev cached
+    for dev in ssd.ssd1 ssd.ssd2; do
+	cached=$(awk -v dev="$dev" '
+	    $1 == dev && $2 == "(device" { in_dev = 1; next }
+	    in_dev && $1 == "cached:" { print $2; found = 1; exit }
+	    END { if (!found) exit 1 }
+	' "$usage") || {
+	    echo "No cached usage line found for $dev"
+	    cat "$usage"
+	    return 1
+	}
+
+	case "$cached" in
+	0|0B|0.00*)
+	    echo "$dev has no cached data"
+	    cat "$usage"
+	    return 1
+	    ;;
+	esac
+    done
+
+    umount /mnt
+
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_tiering_variable_buckets()
 {
     run_basic_fio_test					\


### PR DESCRIPTION
## Summary

Adds a bcachefs tiering regression for koverstreet/bcachefs-tools#574 and the companion fix in koverstreet/bcachefs-tools#687.

The test formats two foreground/promote devices and two background devices with `--replicas=2`, writes data through the foreground target, waits for target reconciliation, and then checks `bcachefs fs usage -a -h` for cached data on both foreground devices.

This covers the user-visible failure mode from koverstreet/bcachefs-tools#574 where background movement left only one foreground cached copy even though the foreground target had two devices and `data_replicas=2`.

## Validation

- `cargo build`
- `git diff --check`
- `bash -n tests/fs/bcachefs/tier.ktest`
- `tests/fs/bcachefs/tier.ktest list-tests`
- Reran in a VM against koverstreet/bcachefs-tools#687 at
  `308ea498766470bbefdce024b95fb783e7554726`: `tiering_cached_replicas` PASSED
  in 15s, `TEST SUCCESS`. `cached_ptrs_want`/`maybe_drop_cached_ptr` were
  compiled into the kernel, and the `fs usage -a -h` assertion confirmed
  cached replicas landed on both foreground devices.
