### PR TITLE
tests/bcachefs: add discard write throughput repro

### DIFF
--- a/tests/fs/bcachefs/bcachefs-test-libs.sh
+++ b/tests/fs/bcachefs/bcachefs-test-libs.sh
@@ -126,6 +126,12 @@ init_build_bcachefs_tools() {
     local jobs=$(( $(nproc) / 2 ))
     (( jobs < 1 )) && jobs=1
     local tools="$ktest_deps_dir/bcachefs-tools"
+    local module_cc="$ktest_compiler"
+
+    if ! command -v "$module_cc" >/dev/null 2>&1 &&
+       [[ -x /host/usr/bin/$module_cc ]]; then
+	module_cc="/host/usr/bin/$module_cc"
+    fi
 
     # bcachefs-tools build cache: building the bcachefs binary is a slow
     # Rust + C compile. The build is done once into a DESTDIR and tarred
@@ -192,7 +198,7 @@ init_build_bcachefs_tools() {
 		# Dev loop: fast incremental in-place build — no dkms, no cache.
 		# The build tree persists under /ktest-out across the fresh-every-
 		# run VM, so kbuild only recompiles what actually changed.
-		if ! make -j$jobs -C "$tools" dkms-reload-interactive; then
+		if ! make -j$jobs -C "$tools" CC="$module_cc" dkms-reload-interactive; then
 			echo "init_build_bcachefs_tools: interactive module build failed" >&2
 			return 1
 		fi
@@ -218,7 +224,7 @@ init_build_bcachefs_tools() {
 
 	# On DKMS build failure, surface the compiler output — otherwise the
 	# test log just shows "Bad return status" with no reason.
-	if ! make -j$jobs -C "$tools" PREFIX=/usr dkms-reload; then
+	if ! make -j$jobs -C "$tools" PREFIX=/usr CC="$module_cc" dkms-reload; then
 	    echo "init_build_bcachefs_tools: DKMS build failed; dumping make.log" >&2
 	    local log found=0
 	    while IFS= read -r log; do

--- a/tests/fs/bcachefs/perf-discard.ktest
+++ b/tests/fs/bcachefs/perf-discard.ktest
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+script_dir=$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")
+# shellcheck source=tests/fs/bcachefs/bcachefs-test-libs.sh
+. "$script_dir/bcachefs-test-libs.sh"
+
+require-kernel-config BCACHEFS_FS=y
+
+config-scratch-devs 8G
+config-timeout "$(stress_timeout)"
+
+discard_seq_write()
+{
+    local label=$1
+    local json=/root/fio-${label}.json
+
+    fio --eta=always				\
+	--output-format=json			\
+	--group_reporting			\
+	--exitall_on_error=1			\
+	--ioengine=libaio			\
+	--iodepth=32				\
+	--iodepth_batch=16			\
+	--direct=1				\
+	--numjobs=1				\
+	--refill_buffers=1			\
+	--buffer_compress_percentage=0		\
+	--filename=/mnt/discard-seq-write	\
+	--name="$label"			\
+	--rw=write				\
+	--bs=1M				\
+	--size=2G				\
+	>"$json"
+
+    sync
+
+    local bw_bytes
+    bw_bytes=$(jq -r '.jobs[0].write.bw_bytes // 0' "$json")
+    local bw_mib
+    bw_mib=$(awk -v bw="$bw_bytes" 'BEGIN { printf "%.2f", bw / 1048576 }')
+
+    echo "discard-seq-write $label bw_bytes=$bw_bytes bw_mib_s=$bw_mib"
+}
+
+log_need_discard()
+{
+    local label=$1
+
+    echo "=== fs usage: $label ==="
+    bcachefs fs usage -h --all /mnt || true
+}
+
+need_discard_bytes()
+{
+    bcachefs fs usage --all /mnt 2>/dev/null		|
+	awk '
+	    /need_discard/ {
+		for (i = 1; i <= NF; i++)
+		    if ($i ~ /^[0-9]+$/)
+			sum += $i
+	    }
+	    END { print sum + 0 }
+	'
+}
+
+wait_for_discard_drain()
+{
+    local timeout=120
+    local start
+    start=$(date +%s)
+
+    while true; do
+	local bytes
+	bytes=$(need_discard_bytes)
+	[[ $bytes = 0 ]] && return 0
+
+	local now
+	now=$(date +%s)
+	if [[ $((now - start)) -ge $timeout ]]; then
+	    echo "need_discard still nonzero after ${timeout}s: $bytes"
+	    return 0
+	fi
+
+	sleep 2
+    done
+}
+
+test_seq_write_during_discard()
+{
+    set_watchdog 900
+
+    # shellcheck disable=SC2154
+    blkdiscard "${ktest_scratch_dev[0]}" || true
+    run_quiet "" bcachefs format -f --discard --no_initialize "${ktest_scratch_dev[0]}"
+
+    mount -t bcachefs "${ktest_scratch_dev[0]}" /mnt
+
+    discard_seq_write baseline
+    rm -f /mnt/discard-seq-write
+    sync
+    log_need_discard after-delete-baseline
+
+    discard_seq_write during-discard
+    rm -f /mnt/discard-seq-write
+    sync
+    log_need_discard after-delete-during
+
+    wait_for_discard_drain
+    log_need_discard after-drain
+
+    discard_seq_write after-drain
+    log_need_discard final
+
+    umount /mnt
+    bcachefs fsck -ny "${ktest_scratch_dev[0]}"
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- add a bcachefs `perf-discard.ktest` reproducer for sequential writes while `need_discard` backlog exists
- log baseline, during-discard, and after-drain fio write bandwidth together with `bcachefs fs usage` snapshots
- pass ktest's selected compiler through the bcachefs module rebuild path, falling back to `/host/usr/bin/<compiler>` when the guest image does not have that compiler in `PATH`

References koverstreet/bcachefs#659.

## Testing

- `bash -n tests/fs/bcachefs/bcachefs-test-libs.sh`
- `bash -n tests/fs/bcachefs/perf-discard.ktest`
- `shellcheck -x tests/fs/bcachefs/perf-discard.ktest`
- `CC=gcc-16 PATH=/usr/libexec:$PATH ./build-test-kernel run -I -k <local path> -o <local path> -T <local path> tests/fs/bcachefs/perf-discard.ktest`
  - `TEST SUCCESS`
  - `PASSED seq_write_during_discard in 164s`
  - observed fio write samples: baseline `1184.50 MiB/s`, during-discard `4970.87 MiB/s`, after-drain `1553.87 MiB/s`


## VM proof (independent re-run)

VM run against master bcachefs-tools (kernel 7.2.0-rc4): `seq_write_during_discard` PASSED in 134s -- baseline, during-discard, and after-drain fio sequential-write bandwidth plus `bcachefs fs usage` snapshots were captured across a need_discard backlog without failure, corroborating the author's earlier local run above.
