### PR TITLE
tests/bcachefs: cover encrypted EC background reads

### DIFF
--- a/tests/fs/bcachefs/ec.ktest
+++ b/tests/fs/bcachefs/ec.ktest
@@ -131,6 +131,62 @@ test_ec_crypto_lz4()
     do_ec_test --encrypted --no_passphrase --compression=lz4
 }
 
+test_ec_crypto_background_target_scrub_before_remount()
+{
+    set_watchdog 360
+
+    run_quiet "" bcachefs format -f			\
+	--encrypted --no_passphrase			\
+	--erasure_code					\
+	--replicas=2					\
+	--bucket_size=256k				\
+	--label=ssd.ssd0 ${ktest_scratch_dev[0]}	\
+	--label=ssd.ssd1 ${ktest_scratch_dev[1]}	\
+	--label=hdd.hdd0 ${ktest_scratch_dev[2]}	\
+	--label=hdd.hdd1 ${ktest_scratch_dev[3]}	\
+	--label=hdd.hdd2 ${ktest_scratch_dev[4]}	\
+	--foreground_target=ssd				\
+	--promote_target=ssd				\
+	--background_target=hdd
+    devs="$(join_by : "${ktest_scratch_dev[@]}")"
+
+    mount -t bcachefs $devs /mnt
+
+    dd if=/dev/zero of=/mnt/ec-background-file bs=1M count=256 oflag=direct status=progress
+    md5sum /mnt/ec-background-file > /root/ec-background-file.md5
+
+    for i in $(seq 1 120); do
+	bcachefs list -b extents "${ktest_scratch_dev[@]}" > /tmp/ec-background-extents
+	if grep -q stripe_ptr /tmp/ec-background-extents; then
+	    break
+	fi
+	sleep 1
+    done
+
+    bcachefs fs usage -h /mnt
+
+    bcachefs list -b extents "${ktest_scratch_dev[@]}" > /tmp/ec-background-extents
+    if ! grep -q stripe_ptr /tmp/ec-background-extents; then
+	echo "expected extents to move to erasure-coded background target"
+	exit 1
+    fi
+
+    bcachefs scrub /mnt
+    echo 3 > /proc/sys/vm/drop_caches
+    md5sum -c /root/ec-background-file.md5
+
+    umount /mnt
+
+    mount -t bcachefs $devs /mnt
+    bcachefs scrub /mnt
+    echo 3 > /proc/sys/vm/drop_caches
+    md5sum -c /root/ec-background-file.md5
+    umount /mnt
+
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_ec_mixed_tiers()
 {
     set_watchdog 240


### PR DESCRIPTION
Adds a focused bcachefs ktest covering the encrypted erasure-coded background-target path discussed in koverstreet/bcachefs#1099.

The test formats five scratch devices with:

- `--encrypted --no_passphrase`
- erasure coding enabled
- SSD foreground/promote targets
- HDD background target

It writes a 256 MiB file, waits until extents have moved to striped EC storage, then runs scrub and verifies the file hash before and after remount. Finally it runs offline fsck and the standard bcachefs end checks.

Local validation:

- `bash -n tests/fs/bcachefs/ec.ktest`
- `git diff --check`
- `cargo build --verbose`
- Focused VM run with the current ktest 7.1 kernel reached:
  - `Erasure coded (data+parity): 2+1: 385M`
  - scrub before remount: `corrected 0B`, `uncorrected 0B`, `/mnt/ec-background-file: OK`
  - scrub after remount: `corrected 0B`, `uncorrected 0B`, `/mnt/ec-background-file: OK`
  - offline fsck completed cleanly
  - `========= PASSED ec_crypto_background_target_scrub_before_remount in 10s`

Note: on this local runner, after printing `TEST SUCCESS`, the host-side qemu/virtiofsd cleanup path lingered until I sent a foreground interrupt; the guest test itself reached the pass marker twice.

## VM proof

VM run against master bcachefs-tools (kernel 7.2.0-rc4): `ec_crypto_background_target_scrub_before_remount` PASSED in 15s -- an encrypted, erasure-coded fs with SSD foreground/HDD background targets survives a scrub before remount cleanly.
