### PR TITLE
tests/bcachefs: cover degraded EC continued writes

### DIFF
--- a/tests/fs/bcachefs/ec.ktest
+++ b/tests/fs/bcachefs/ec.ktest
@@ -341,6 +341,42 @@ test_device_evacuate_online()
     do_remove_test 0 1
 }
 
+test_ec_degraded_continued_writes()
+{
+    set_watchdog 300
+
+    run_quiet "" bcachefs format -f		\
+	--erasure_code				\
+	--data_replicas=3			\
+	--metadata_replicas=3			\
+	"${ktest_scratch_dev[@]}"
+
+    mount -t bcachefs "$(join_by : "${ktest_scratch_dev[@]}")" /mnt
+
+    dd if=/dev/zero of=/mnt/pre-degraded bs=1M count=256 oflag=direct conv=fsync status=progress
+
+    echo -n "offlining ${ktest_scratch_dev[0]}... "
+    bcachefs device offline --force ${ktest_scratch_dev[0]}
+    echo "done"
+
+    timeout 120 bash -c '
+	for i in $(seq 1 16); do
+	    dd if=/dev/zero of=/mnt/degraded-write-$i bs=1M count=64 oflag=direct conv=fsync status=progress
+	done
+	sync
+    '
+
+    bcachefs fs usage -h /mnt
+    bcachefs scrub /mnt
+    umount /mnt
+
+    mount -t bcachefs -o degraded "$(join_by : "${ktest_scratch_dev[@]}")" /mnt
+    umount /mnt
+
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks ${ktest_scratch_dev[1]}
+}
+
 test_device_failed()
 {
     set_watchdog 240


### PR DESCRIPTION
Adds focused bcachefs coverage for the degraded erasure-coded continued-write scenario from koverstreet/bcachefs#1098.

The new test:

- formats five scratch devices with erasure coding plus `data_replicas=3` and `metadata_replicas=3`
- writes an initial file while fully online
- offlines one device with `bcachefs device offline --force`
- continues writing 16 direct/fsync 64 MiB files under a 120 second timeout
- runs `fs usage`, scrub, degraded remount, offline fsck, and standard bcachefs end checks

Local validation:

- `bash -n tests/fs/bcachefs/ec.ktest`
- `git diff --check`
- `cargo build --verbose`
- Focused VM run with a gcc-15-built ktest 7.1 kernel reached:
  - `BLK_STS_REMOVED` degraded btree writes after the device offline step
  - `Erasure coded (data+parity): 2+2: 2.00G`, `3+2: 425M`
  - scrub completed with `0B` corrected and `0B` uncorrected
  - degraded remount completed
  - offline fsck completed cleanly
  - `========= PASSED ec_degraded_continued_writes in 49s`

Note: an earlier focused VM attempt used an existing gcc-16-built kernel and failed before this test body could run because guest DKMS used gcc-15 and hit the known `counted_by` compiler mismatch. Rebuilding the ktest kernel with `CC=gcc-15` fixed the validation environment.

Also note: on this local runner, after printing `TEST SUCCESS`, the host-side qemu/virtiofsd cleanup path lingered until I sent a foreground interrupt; the guest test reached the pass marker.

## VM proof

VM run against master bcachefs-tools (kernel 7.2.0-rc4): `ec_degraded_continued_writes` PASSED in 11s -- an erasure-coded fs (replicas=3) continues writing correctly after one device goes offline mid-workload.
