### PR TITLE
tests/bcachefs: cover filesystem label commands

### DIFF
--- a/tests/fs/bcachefs/single_device.ktest
+++ b/tests/fs/bcachefs/single_device.ktest
@@ -159,6 +159,40 @@ test_mount_options()
     bcachefs_test_end_checks $dev
 }
 
+test_filesystem_label_commands()
+{
+    local dev=${ktest_scratch_dev[0]}
+    set_watchdog 10
+
+    if ! bcachefs get-label --help >/dev/null 2>&1 ||
+       ! bcachefs set-label --help >/dev/null 2>&1; then
+	echo "bcachefs label commands not available, skipping"
+	return 0
+    fi
+
+    run_quiet "" bcachefs format -f "$dev"
+    mount -t bcachefs "$dev" /mnt
+
+    bcachefs set-label /mnt ktest_label_one
+    test "$(bcachefs get-label /mnt)" = ktest_label_one
+    test "$(bcachefs label /mnt)" = ktest_label_one
+
+    mkdir /mnt/subdir
+    bcachefs set-label /mnt/subdir ktest_label_two
+    test "$(bcachefs get-label /mnt/subdir)" = ktest_label_two
+
+    ! bcachefs set-label /mnt 12345678901234567890123456789012
+    test "$(bcachefs get-label /mnt)" = ktest_label_two
+
+    umount /mnt
+    mount -t bcachefs "$dev" /mnt
+    test "$(bcachefs get-label /mnt)" = ktest_label_two
+    umount /mnt
+
+    bcachefs fsck -ny "$dev"
+    bcachefs_test_end_checks "$dev"
+}
+
 test_extent_merge2()
 {
     local p=/sys/module/bcachefs/parameters/debug_check_iterators


### PR DESCRIPTION
## Summary

Add a focused bcachefs regression for the mounted-filesystem label commands from koverstreet/bcachefs-tools#649.

The test formats and mounts a scratch filesystem, then verifies:

- `bcachefs set-label <path> <label>` changes the filesystem label through a mount path
- `bcachefs get-label <path>` and the `bcachefs label <path>` alias report the new label
- a subdirectory path works as the command target
- an overlong 32-byte label is rejected without changing the existing label
- the final label survives unmount/remount and fsck/end checks

The test self-skips when the installed `bcachefs` binary does not yet expose `get-label` / `set-label`, so it can land alongside the tools implementation without breaking older test images.

Implementation: koverstreet/bcachefs-tools#649
Coverage for: koverstreet/bcachefs#617

## Testing

- `bash -n tests/fs/bcachefs/single_device.ktest`
- `tests/fs/bcachefs/single_device.ktest list-tests | rg '^filesystem_label_commands$'`
- `git diff --check`
- `cargo build --verbose`

## VM proof

VM run against master bcachefs-tools (kernel 7.2.0-rc4): `filesystem_label_commands` PASSED in <1s -- `bcachefs set-label`/`get-label` through a mounted-fs path work correctly.
