### PR TITLE
tests/bcachefs: cover format warning for shared parent disks

### DIFF
--- a/tests/fs/bcachefs/format.ktest
+++ b/tests/fs/bcachefs/format.ktest
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+test_format_warns_when_replicas_share_parent_disk()
+{
+    set_watchdog 120
+
+    modprobe -r scsi_debug 2>/dev/null || true
+    if ! modprobe scsi_debug dev_size_mb=256 num_parts=2; then
+	echo "scsi_debug not available, skipping"
+	return 0
+    fi
+    trap 'modprobe -r scsi_debug 2>/dev/null || true' RETURN
+
+    local disk="" d
+    for d in /sys/block/sd*; do
+	if grep -qi scsi_debug "$d/device/model" 2>/dev/null; then
+	    disk=/dev/$(basename "$d")
+	    break
+	fi
+    done
+    [[ -n $disk ]] || { echo "scsi_debug device not found"; return 1; }
+
+    local part1="${disk}1" part2="${disk}2" i
+    for i in $(seq 1 10); do
+	[[ -b $part1 && -b $part2 ]] && break
+	sleep 1
+    done
+    [[ -b $part1 && -b $part2 ]] || {
+	echo "scsi_debug partitions $part1/$part2 not found"
+	return 1
+    }
+
+    local out
+    out="$(bcachefs format -f --replicas=2 "$part1" "$part2" 2>&1)"
+    echo "$out"
+    grep -F "warning: requested 2 replicas" <<< "$out"
+    grep -F "warning: multiple format devices share a parent disk:" <<< "$out"
+    grep -F "$part1" <<< "$out"
+    grep -F "$part2" <<< "$out"
+
+    out="$(bcachefs format -f -q --replicas=2 "$part1" "$part2" 2>&1)"
+    echo "$out"
+    ! grep -F "warning: requested 2 replicas" <<< "$out"
+    ! grep -F "warning: multiple format devices share a parent disk:" <<< "$out"
+
+    modprobe -r scsi_debug 2>/dev/null || true
+    trap - RETURN
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add a bcachefs ktest regression for the format guardrail in https://github.com/koverstreet/bcachefs-tools/pull/666.

The test uses `scsi_debug` with two partitions from the same parent disk, then verifies that `bcachefs format --replicas=2` warns when both format devices resolve to that one physical parent disk. It also checks that `--quiet` suppresses the warning, preserving the warning-only behavior chosen for https://github.com/koverstreet/bcachefs/issues/144.

Companion tools fix: https://github.com/koverstreet/bcachefs-tools/pull/666
Related issue: https://github.com/koverstreet/bcachefs/issues/144

## Testing

- `bash -n tests/fs/bcachefs/format.ktest`
- `git diff --check`

## VM proof

VM run against master bcachefs-tools (kernel 7.2.0-rc4): `format_warns_when_replicas_share_parent_disk` PASSED in 2s -- `bcachefs format --replicas=2` against two scsi_debug partitions of the same parent disk emits the expected shared-parent warning.
