### PR TITLE
tests/bcachefs: cover nocow SRCU wait pressure

### DIFF
--- a/tests/fs/bcachefs/nocow_srcu_wait.ktest
+++ b/tests/fs/bcachefs/nocow_srcu_wait.ktest
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# shellcheck source=tests/fs/bcachefs/bcachefs-test-libs.sh
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/bcachefs-test-libs.sh"
+
+config-scratch-devs 4G
+config-timeout 180
+
+test_nocow_srcu_wait()
+{
+    # shellcheck disable=SC2154 # ktest_scratch_dev is provided by ktest.
+    local dev="${ktest_scratch_dev[0]}"
+    local runtime=45
+    local end
+    local pids=()
+    local i
+
+    set_watchdog 180
+
+    run_quiet "" bcachefs format -f --nocow --fs_size=1536M "$dev"
+    mount -t bcachefs "$dev" /mnt
+
+    for i in $(seq 0 7); do
+	xfs_io -f /mnt/nocow."$i" \
+	    -c "pwrite -S 0x55 0 64M" \
+	    -c fsync
+    done
+
+    dmesg -C
+    end=$((SECONDS + runtime))
+
+    for i in $(seq 0 7); do
+	(
+	    while (( SECONDS < end )); do
+		dd if=/dev/zero of=/mnt/nocow."$i" bs=4k count=256 \
+		    seek=$((RANDOM % 1024)) conv=notrunc oflag=direct status=none
+	    done
+	) &
+	pids+=("$!")
+    done
+
+    (
+	while (( SECONDS < end )); do
+	    for i in $(seq 0 7); do
+		truncate -s 64M /mnt/nocow."$i"
+	    done
+	    sync
+	done
+    ) &
+    pids+=("$!")
+
+    for i in "${pids[@]}"; do
+	wait "$i"
+    done
+
+    sync
+
+    if dmesg | grep -E 'btree trans held srcu lock|bch2_nocow_write.*blocked for more than'; then
+	echo "nocow write path held SRCU too long" >&2
+	return 1
+    fi
+
+    umount /mnt
+    bcachefs fsck -ny "$dev"
+    bcachefs_test_end_checks "$dev"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add a focused bcachefs nocow write pressure test for the SRCU-held wait path covered by koverstreet/bcachefs-tools#659.

The test:

- formats a small nocow bcachefs scratch filesystem;
- creates several initialized nocow files;
- runs concurrent direct overwrites while a truncation/sync loop keeps the nocow write path busy;
- fails if dmesg reports the specific `btree trans held srcu lock` warning or a blocked `bch2_nocow_write` task.

## Scope

This is paired coverage for koverstreet/bcachefs#680 and koverstreet/bcachefs-tools#659. It is a pressure/regression guard for the transaction-aware nocow lock wait path, not a claim that every hang signature in the long koverstreet/bcachefs#680 report is fixed.

## Validation

- `bash -n tests/fs/bcachefs/nocow_srcu_wait.ktest`
- `shellcheck -x -P tests/fs/bcachefs tests/fs/bcachefs/nocow_srcu_wait.ktest`
- `./tests/fs/bcachefs/nocow_srcu_wait.ktest list-tests`
- `git diff --check`

## VM proof

VM run with bcachefs-tools#730 (data-update-srcu-alloc, open) installed: `nocow_srcu_wait` PASSED in 67s -- concurrent direct overwrites against initialized nocow files under a 45s truncate+sync pressure loop produced no `btree trans held srcu lock` warning and no bch2_nocow_write task blocked >120s.
