### PR TITLE
tests/bcachefs: cover hardlink rename target reinherit

### DIFF
--- a/tests/fs/bcachefs/tier.ktest
+++ b/tests/fs/bcachefs/tier.ktest
@@ -681,6 +681,39 @@ test_mv_cross_subvol_io_opts()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_rename_hardlink_reinherit_reconcile()
+{
+    set_watchdog 60
+
+    run_quiet "" bcachefs format -f			\
+	--label=ssd ${ktest_scratch_dev[0]}		\
+	--label=hdd ${ktest_scratch_dev[2]}		\
+	--foreground_target=ssd				\
+	--background_target=ssd
+
+    mount -t bcachefs ${ktest_scratch_dev[0]}:${ktest_scratch_dev[2]} /mnt
+
+    mkdir /mnt/src /mnt/dst
+    bcachefs set-file-option --foreground_target=hdd /mnt/dst
+    bcachefs set-file-option --background_target=hdd /mnt/dst
+
+    dd if=/dev/urandom of=/mnt/src/testfile bs=1M count=10 oflag=direct
+    ln /mnt/src/testfile /mnt/src/testfile.link
+    local before_hash=$(md5sum /mnt/src/testfile | cut -d ' ' -f 1)
+
+    mv /mnt/src/testfile.link /mnt/dst/testfile
+    rm /mnt/src/testfile
+    local after_hash=$(md5sum /mnt/dst/testfile | cut -d ' ' -f 1)
+    test "$before_hash" = "$after_hash"
+
+    bcachefs reconcile wait -t target /mnt
+    umount /mnt
+
+    local devs=(${ktest_scratch_dev[0]} ${ktest_scratch_dev[2]})
+    bcachefs fsck -ny "${devs[@]}"
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 test_reflink_option_propagate()
 {
     set_watchdog 60


### PR DESCRIPTION
## Summary

Add a bcachefs tiering regression test for a hardlinked regular inode whose remaining link is renamed into a directory with different inherited target options.

The test:

- creates a file and a same-directory hard link;
- renames one link into a directory with `foreground_target=hdd` and `background_target=hdd`;
- removes the original link so only the destination-tree entry remains;
- waits for target reconcile and runs fsck.

## Validation

- `bash -n tests/fs/bcachefs/tier.ktest`
- `tests/fs/bcachefs/tier.ktest list-tests | rg -x 'rename_hardlink_reinherit_reconcile'`
- Reran in a VM against koverstreet/bcachefs-tools#746 at
  `186b4ee25dfaa601a8671a317f78f75a1e5acfde`:
  `rename_hardlink_reinherit_reconcile` PASSED in 3s, `TEST SUCCESS`, with
  `bch2_reinherit_attrs_reconcile` compiled into the kernel and the
  post-rename fsck reporting no `extent_io_opts_not_set` errors.

## Related

- Source issue: koverstreet/bcachefs#1173
- Fix PR: koverstreet/bcachefs-tools#746
