### PR TITLE
ktest: finalize direct VM run results

### DIFF
--- a/lib/libktest.sh
+++ b/lib/libktest.sh
@@ -28,6 +28,8 @@ ktest_nice=0
 ktest_no_kbuild=false
 ktest_no_vm=false
 
+. "$ktest_dir/lib/test-result.sh"
+
 # config files:
 [[ -f $ktest_dir/ktestrc ]]	&& . "$ktest_dir/ktestrc"
 [[ -f /etc/ktestrc ]]		&& . /etc/ktestrc
@@ -409,6 +411,11 @@ start_vm()
 
     get_tmpdir
 
+    # Default to failure before starting the guest. This makes failures before
+    # testrunner starts (or during crashdump/reboot handling) unambiguously
+    # fail instead of being mistaken for qemu's normal poweroff status.
+    ktest_write_result "TEST FAILED"
+
     rm -f "$ktest_out/core.*"
     rm -f "$ktest_out/vmcore"
     rm -f "$ktest_out/vm"
@@ -682,8 +689,12 @@ start_vm()
     # works unprivileged; the subshell keeps it off ktest's own process, and
     # exec means qemu keeps the same pid so the caller still sees its status.
     ( echo 800 > /proc/self/oom_score_adj 2>/dev/null; exec "${qemu_cmd[@]}" )
+    local qemu_ret=$?
 
-    kill "${virtiofsd_pids[@]}" 2>/dev/null
+    kill "${virtiofsd_pids[@]}" 2>/dev/null || true
+    wait "${virtiofsd_pids[@]}" 2>/dev/null || true
+
+    ktest_finish_vm "$qemu_ret"
 }
 
 map_clang_version() {

--- a/lib/test-result.sh
+++ b/lib/test-result.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Direct-run result protocol shared by the host launcher and guest runner.
+#
+# The status file is the durable verdict: qemu normally exits successfully for
+# both a guest poweroff after success and one after a test failure. Keep it
+# separate from console output so the host can distinguish those cases.
+
+: "${ktest_out:?ktest_out must be set before loading test-result.sh}"
+
+ktest_status_file()
+{
+    echo "$ktest_out/status"
+}
+
+ktest_write_result()
+{
+    local result=$1
+
+    case $result in
+        "TEST SUCCESS"|"TEST FAILED")
+            ;;
+        *)
+            echo "invalid ktest result: $result" >&2
+            return 1
+            ;;
+    esac
+
+    printf '%s\n' "$result" > "$(ktest_status_file)"
+}
+
+ktest_result_code()
+{
+    local result
+
+    [[ -r $(ktest_status_file) ]] || return 1
+    IFS= read -r result < "$(ktest_status_file)" || return 1
+
+    [[ $result = "TEST SUCCESS" ]]
+}
+
+ktest_finish_vm()
+{
+    local qemu_ret=$1
+
+    # Do not turn a qemu failure into success merely because a stale or
+    # partially-written guest status says success. Conversely, a normal guest
+    # poweroff is a test failure unless it explicitly recorded TEST SUCCESS.
+    [[ $qemu_ret = 0 ]] || return "$qemu_ret"
+    ktest_result_code
+}
+
+ktest_finish_guest()
+{
+    local ret=$1
+    local result="TEST FAILED"
+
+    [[ $ret = 0 ]] && result="TEST SUCCESS"
+
+    # The host polls this through virtiofs. Publish and flush the durable
+    # verdict before printing the terminal marker, then power off direct
+    # noninteractive runs. Interactive sessions retain the VM for ssh/kgdb.
+    ktest_write_result "$result"
+    sync
+    echo "$result"
+
+    if [[ ${ktest_interactive:-false} != true ]]; then
+        poweroff
+    fi
+
+    return "$ret"
+}

--- a/lib/testrunner
+++ b/lib/testrunner
@@ -16,6 +16,23 @@ export PATH=$PATH:/root/.cargo/bin
 ktest_dir="/host/$ktest_dir"
 ktest_tmp="/host/$ktest_tmp"
 ktest_out="/host/$ktest_out"
+. "$ktest_dir/lib/test-result.sh"
+
+ktest_finish()
+{
+    local ret=$?
+
+    trap - EXIT
+    pkill -P $$ >/dev/null || true
+    ktest_finish_guest "$ret"
+    exit "$ret"
+}
+
+# Every regular runner exit is terminal: the status is written before the
+# marker and noninteractive guests then power off. Intentional sysrq reboots
+# never execute this trap; their next boot keeps the same default failure
+# status until it reaches a real terminal verdict.
+trap ktest_finish EXIT
 # ktest_deps_dir comes through as a host-side path. CI workers set it
 # explicitly; interactive runs fall back to the host user's deps cache
 # so repo clones are shared with the host and persist across runs
@@ -120,6 +137,9 @@ if [[ -s /proc/vmcore ]]; then
     echo "Collecting crash dump..."
     cp --sparse=always /proc/vmcore "$ktest_out/vmcore" || true
     sync
+    # Crashdump collection is an intentional shutdown path, not a completed
+    # test. Leave start_vm's default failure status in place.
+    trap - EXIT
     poweroff
 fi
 
@@ -136,7 +156,6 @@ EXPECTED_REBOOT=0
 
 if [[ $NR_REBOOTS != $EXPECTED_REBOOT ]]; then
     echo "UNEXPECTED REBOOT: got $NR_REBOOTS expected $EXPECTED_REBOOT"
-    echo "TEST FAILED"
     exit 1
 fi
 
@@ -202,8 +221,7 @@ check_taint()
 
     if [[ $taint != 0 && ! $ktest_allow_taint ]]; then
 	echo "Failure because kernel tainted - check log for warnings"
-	echo "TEST FAILED"
-	exit 0
+	return 1
     fi
 }
 
@@ -221,7 +239,6 @@ uname -r
 
 if [[ -z $ktest_tests ]] && ! $ktest_tests_unknown; then
     echo "No tests found"
-    echo "TEST FAILED"
     exit 1
 fi
 
@@ -229,11 +246,9 @@ ktest_tests=$(echo $ktest_tests)
 
 if [[ $ktest_tests = "none" ]]; then
     echo "No tests to run"
-    echo "TEST FAILED"
-    exit 0
+    exit 1
 fi
 
-trap 'pkill -P $$ >/dev/null' EXIT
 cd /root
 
 # ktest_tmp here is testrunner's /host/-rewritten *host* tmpdir; the
@@ -272,8 +287,4 @@ check_taint
 echo -n "Kernel version: "
 uname -r
 
-if [[ $ret = 0 ]]; then
-    echo "TEST SUCCESS"
-else
-    echo "TEST FAILED"
-fi
+exit "$ret"

--- a/tests/direct-run-protocol.sh
+++ b/tests/direct-run-protocol.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ROOT=$(dirname "$(readlink -f "$0")")/..
+
+fail()
+{
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_status()
+{
+    local expected=$1
+    local actual
+
+    actual=$(<"$ktest_out/status")
+    [[ $actual = "$expected" ]] || fail "status is '$actual', expected '$expected'"
+}
+
+assert_trace()
+{
+    local expected=$1
+    local actual
+
+    actual=$(<"$trace")
+    [[ $actual = "$expected" ]] || fail "trace was: $actual"
+}
+
+run_guest()
+{
+    local mode=$1 ret=$2
+
+    ktest_interactive=$mode
+    trace="$ktest_out/trace"
+    : > "$trace"
+
+    # The test double records the guest-visible protocol in one ordered stream.
+    ktest_write_result()
+    {
+        printf '%s\n' "$1" > "$ktest_out/status"
+        printf 'status:%s\n' "$1" >> "$trace"
+    }
+    sync()
+    {
+        echo sync >> "$trace"
+    }
+    poweroff()
+    {
+        echo poweroff >> "$trace"
+    }
+
+    set +o errexit
+    ktest_finish_guest "$ret" >> "$trace"
+    local got=$?
+    set -o errexit
+    [[ $got = "$ret" ]] || fail "guest returned $got, expected $ret"
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+ktest_out="$tmp/out"
+mkdir -p "$ktest_out"
+
+. "$ROOT/lib/test-result.sh"
+
+# This is the value start_vm creates before qemu is launched, so any failure
+# before testrunner starts is a failure rather than qemu's normal shutdown.
+ktest_write_result "TEST FAILED"
+assert_status "TEST FAILED"
+
+# A noninteractive success is durable before the terminal marker and powers
+# off. This is the direct-run path; it deliberately does not use supervisor.
+run_guest false 0
+assert_status "TEST SUCCESS"
+assert_trace $'status:TEST SUCCESS\nsync\nTEST SUCCESS\npoweroff'
+
+# A test failure follows exactly the same shutdown protocol but returns failure.
+run_guest false 1
+assert_status "TEST FAILED"
+assert_trace $'status:TEST FAILED\nsync\nTEST FAILED\npoweroff'
+
+# Host-side initialization covers failures before the guest runner reaches its
+# exit trap (bad boot, failed setup, or crashdump collection).
+ktest_write_result "TEST FAILED"
+assert_status "TEST FAILED"
+if ktest_finish_vm 0; then
+    fail "early failure was reported as success"
+fi
+
+# Interactive runs retain their VM after publishing the result.
+run_guest true 0
+assert_status "TEST SUCCESS"
+assert_trace $'status:TEST SUCCESS\nsync\nTEST SUCCESS'
+ktest_finish_vm 0 || fail "guest success was not returned to the host"
+
+# A nonzero qemu exit remains nonzero even if an old/success status exists.
+if ktest_finish_vm 37; then
+    fail "qemu failure was discarded"
+else
+    got=$?
+    [[ $got = 37 ]] || fail "qemu failure became $got"
+fi
+
+# Intentional sysrq reboot and crashdump collection do not publish success:
+# both retain the pre-VM failure default until a later normal boot finishes.
+ktest_write_result "TEST FAILED"
+if ktest_finish_vm 0; then
+    fail "reboot/crashdump default failure was reported as success"
+fi
+
+# The intentional paths bypass the terminal trap: reboot stays a real sysrq
+# reboot, while crashdump collection powers off without publishing success.
+grep -F 'echo b > /proc/sysrq-trigger' "$ROOT/lib/testrunner" > /dev/null ||
+    fail "sysrq reboot path changed"
+crashdump_block=$(sed -n '/if \[\[ -s \/proc\/vmcore \]\]; then/,/^fi$/p' "$ROOT/lib/testrunner")
+case $crashdump_block in
+    *'trap - EXIT'*'poweroff'*)
+        ;;
+    *)
+        fail "crashdump no longer bypasses the terminal result trap"
+        ;;
+esac
+
+echo "direct-run protocol: PASS"


### PR DESCRIPTION
Direct `ktest run` now terminates its noninteractive VM and returns the guest
test verdict.

The guest runner previously printed `TEST SUCCESS` or `TEST FAILED` and exited,
but PID 1 kept running. The host launched QEMU directly, discarded QEMU's
status when cleaning up `virtiofsd`, and had no durable guest result. Interactive
runs therefore needed a manual interrupt even after a terminal marker, while a
normal QEMU poweroff could not distinguish test success from failure.

This adds a small host/guest result protocol:

- The host writes a default failure before boot.
- The guest writes and syncs its final result before printing the terminal
  marker.
- Noninteractive guests power off after either success or failure; interactive
  guests stay available for SSH/KGDB.
- The host preserves QEMU failures and accepts success only when the guest
  explicitly recorded it.
- Intentional SysRq reboot and crashdump collection retain the failure default
  until a later normal test completion.

Current head: `f4332231382b26242fdc89de319d9ef07822061e`.

Validation:

- `bash -n` on the changed shell files
- ShellCheck on the new protocol helper and test
- `tests/direct-run-protocol.sh` covers success, failure, early failure,
  interactive mode, QEMU failure propagation, reboot, and crashdump handling.
- `make -C lib supervisor`
- Full VM run of `offline_evacuating_device_schedules_scan`: the guest printed
  `TEST SUCCESS`, wrote `TEST SUCCESS` to the host-visible status file, powered
  off, and the direct host command returned 0 with no QEMU or `virtiofsd`
  process left behind.

## VM proof

Verified two ways: (1) the PR's own host-side unit test `tests/direct-run-protocol.sh` PASSED (mocks the guest/host status-file protocol end to end, including the reboot/crashdump-bypass paths). (2) Live VM run of `single_device.ktest wipe_btrfs` using this branch's own patched `build-test-kernel`/`libktest.sh` printed `TEST SUCCESS`, wrote the matching `$ktest_out/status` file, and -- unlike every other run in this session, which all leaked their qemu process even on a clean pass -- the qemu process and its wrapper exited on their own with nothing left to reap.
