### PR TITLE
tests/fs/bcachefs: snapshot space leak — keys dead in every child snapshot are never reclaimed

### DIFF
--- a/tests/fs/bcachefs/bcachefs-test-libs.sh
+++ b/tests/fs/bcachefs/bcachefs-test-libs.sh
@@ -266,6 +266,66 @@ export BCACHEFS_KERNEL_ONLY=1
 #Expensive:
 #require-kernel-config CLOSURE_DEBUG
 
+# ── disk space accounting ────────────────────────────────────────────────
+
+# Total user data on disk, in 512b sectors: bcachefs_used_sectors <dev>
+#
+# The accounting btree's `replicas` counters, which gc recomputes and fsck
+# verifies - ground truth, not a statfs estimate. Device must be unmounted.
+bcachefs_used_sectors()
+{
+    bcachefs list -b accounting $1 2>/dev/null |
+	sed -n 's/.*: replicas user: [^]]*\] //p' |
+	awk '{ s += $1 } END { print s + 0 }'
+}
+
+bcachefs_sectors_to_mb()
+{
+    echo $(( $1 / 2048 ))
+}
+
+# sysfs directory of the fs mounted at $1.
+#
+# Not always the UUID: fs/init/fs.c names the kobject "%pU" only when
+# c->sb.multi_device; a single-device fs is named after its block device
+# (prt_bdevname -> /sys/fs/bcachefs/vdb), so the UUID dir doesn't exist for it.
+# Resolve rather than glob /sys/fs/bcachefs/*/ - as a redirect target that
+# becomes an "ambiguous redirect" once a second bcachefs is mounted.
+bcachefs_sysfs_dir()
+{
+    local mnt=$1
+    local src=$(findmnt -no SOURCE "$mnt")
+    local uuid=$(findmnt -no UUID "$mnt")
+    local d
+
+    for d in "/sys/fs/bcachefs/${src##*/}" "/sys/fs/bcachefs/$uuid"; do
+	if [[ -d $d ]]; then
+	    echo "$d"
+	    return 0
+	fi
+    done
+
+    echo "bcachefs_sysfs_dir: no sysfs dir for $mnt (src='$src' uuid='$uuid')" >&2
+    return 1
+}
+
+# Run snapshot deletion to completion: bcachefs subvolume delete only queues it
+# (bch2_delete_dead_snapshots_async), so measuring space right after would race
+# the worker. Fails loudly - a settle that quietly doesn't happen just moves the
+# race somewhere harder to see.
+bcachefs_settle_snapshot_deletion()
+{
+    local mnt=$1
+
+    sync
+
+    local dir
+    dir=$(bcachefs_sysfs_dir "$mnt") || return 1
+
+    echo 1 > "$dir/internal/trigger_delete_dead_snapshots"
+    sync
+}
+
 bcachefs_mem_in_use()
 {
     echo 1 > /sys/module/rcutree/parameters/do_rcu_barrier

--- a/tests/fs/bcachefs/snapshot-space-leak.ktest
+++ b/tests/fs/bcachefs/snapshot-space-leak.ktest
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Data that no subvolume can see, that nothing ever reclaims.
+#
+# Snapshotting forks: bch2_snapshot_node_create() demotes the existing node to
+# an interior node and creates two fresh leaves, one for the source subvolume,
+# one for the snapshot. The data as of that moment lives at the interior node.
+# Delete the file in both leaves and those extents are invisible everywhere -
+# but still allocated. The interior node isn't dead (both children are live
+# subvolumes) and isn't redundant either: check_should_delete_snapshot() bails
+# at `if (nr_live_children == 2) return 0;`, and nothing looks for keys that
+# are overwritten in *every* leaf - __bch2_key_has_snapshot_overwrites()
+# answers "any descendant", a different question. See the "keys that have been
+# overwritten in all child snapshots ... (unimplemented?)" comment in
+# fs/snapshots/delete.c.
+#
+# Not a corruption: fsck passes clean and the fs is permanently short of
+# space. Both tests assert fsck IS clean as well as that the space came back,
+# so the leak can't hide behind a passing fsck.
+#
+# Space is read offline from the accounting btree's gc-verified `replicas`
+# counters. The per-snapshot numbers in the failure dump are
+# BCH_DISK_ACCOUNTING_snapshot, which gc never recomputes
+# (bch2_accounting_is_mem() excludes it) - diagnostic, not oracle.
+#
+# The controls live elsewhere, and pin these failures to snapshots and to the
+# two-live-children case specifically:
+#
+#   generic/015			no snapshots in play: space comes back
+#   subvol.ktest:snapshots_simple  interior node with ONE live child: reclaimed
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+config-scratch-devs 8G
+
+config-timeout $(stress_timeout)
+
+DEV=${ktest_scratch_dev[0]}
+
+DATA_MB=256
+SLOP_MB=32	# btree/journal noise between measurements
+
+used_sectors() { bcachefs_used_sectors $DEV; }
+mb()           { bcachefs_sectors_to_mb $1; }
+
+dump_state()
+{
+    echo "--- disk usage by snapshot id ---"
+    bcachefs list -b accounting $DEV 2>/dev/null |
+	sed -n 's/.*: snapshot id=\([0-9]*\) \([0-9]*\)$/\1 \2/p' |
+	while read -r id sectors; do
+	    printf '  snapshot %-12s %10s sectors  %6s MiB\n' \
+		   "$id" "$sectors" "$(mb $sectors)"
+	done
+
+    # Indirect extents show up as zero above however much they hold: reflink_v
+    # lives in the reflink btree at snapshot 0, and buckets.c only mods the
+    # snapshot counter for a nonzero k.k->p.snapshot. Count them separately.
+    echo "--- reflink btree (no snapshot accounting) ---"
+    bcachefs list -b reflink $DEV 2>/dev/null |
+	awk '/type reflink_v/ { for (i=1;i<=NF;i++) if ($i=="refcount:") rc[$(i+1)]++; n++; next }
+	     /c_size/        { for (i=1;i<=NF;i++) if ($i=="c_size")    { s += $(i+1); break } }
+	     END {
+		printf "  reflink_v keys: %d, on disk: %d sectors (%d MiB)\n", n, s, s/2048
+		for (r in rc)
+		    printf "  refcount %-4s : %d keys\n", r, rc[r]
+	     }'
+
+    echo "--- snapshots btree ---"
+    bcachefs list -b snapshots  $DEV 2>/dev/null | sed 's/^/  /'
+    echo "--- subvolumes btree ---"
+    bcachefs list -b subvolumes $DEV 2>/dev/null | sed 's/^/  /'
+}
+
+# After deleting the data everywhere it was visible the fs must be both
+# consistent and no fuller than it started.
+assert_reclaimed()
+{
+    local base=$1
+    local now=$(used_sectors)
+    local leaked=$(( now - base ))
+
+    echo "baseline ${base} sectors ($(mb $base) MiB), now ${now} sectors ($(mb $now) MiB)"
+
+    # If fsck ever does start catching this, fail here rather than pass quietly.
+    if ! bcachefs fsck -n $DEV; then
+	echo "TEST FAILED: fsck found errors (expected a clean, merely-leaky fs)"
+	dump_state
+	exit 1
+    fi
+
+    if (( leaked > SLOP_MB * 2048 )); then
+	echo "TEST FAILED: $(mb $leaked) MiB still allocated after deleting the data in every subvolume that could see it"
+	echo "             (fsck is clean - the fs is consistent and permanently short of space)"
+	dump_state
+	exit 1
+    fi
+
+    echo "OK: reclaimed to within $(mb $leaked) MiB of baseline"
+}
+
+# Formatted and mounted, baseline usage in $baseline.
+fresh_fs()
+{
+    run_quiet "" bcachefs format -f $DEV
+
+    baseline=$(used_sectors)
+
+    mount -t bcachefs $DEV /mnt
+}
+
+finish()
+{
+    bcachefs_settle_snapshot_deletion /mnt
+    umount /mnt
+}
+
+# Both leaves whiteout the file; the extents sit at the interior node,
+# reachable from nowhere. Both subvolumes still exist, so the interior node is
+# neither dead nor redundant and nothing comes back for those keys.
+test_delete_in_all_snapshots()
+{
+    fresh_fs
+
+    dd if=/dev/urandom of=/mnt/file bs=1M count=$DATA_MB oflag=direct
+
+    pushd /mnt
+    bcachefs subvolume snapshot snap
+    popd
+
+    [[ -f /mnt/snap/file ]]		# the snapshot really can see it
+
+    rm /mnt/file			# dead in the root subvol's leaf
+    rm /mnt/snap/file			# dead in the snapshot's leaf too
+
+    bcachefs subvolume list /mnt
+
+    finish
+    assert_reclaimed $baseline
+
+    bcachefs_test_end_checks $DEV
+}
+
+# Same mechanism, one level removed: the only surviving reflink_p keys are the
+# unreachable ones at the interior node, so every leaked reflink_v sits at
+# refcount 1 held by a key no subvolume can see.
+#
+# Separate test because a fix gets this for free - dropping a reflink_p runs
+# the trigger, the refcount hits zero - but only if the deletion goes through
+# the normal trigger path. This catches one that shortcuts around it.
+test_reflink_delete_in_all_snapshots()
+{
+    fresh_fs
+
+    dd if=/dev/urandom of=/mnt/file bs=1M count=$DATA_MB oflag=direct
+    cp --reflink=always /mnt/file /mnt/clone
+    rm /mnt/file			# only the indirect extents remain
+    sync
+
+    pushd /mnt
+    bcachefs subvolume snapshot snap
+    popd
+
+    [[ -f /mnt/snap/clone ]]
+
+    rm /mnt/clone
+    rm /mnt/snap/clone
+
+    finish
+    assert_reclaimed $baseline
+
+    bcachefs_test_end_checks $DEV
+}
+
+main "$@"

--- a/tests/fs/bcachefs/subvol.ktest
+++ b/tests/fs/bcachefs/subvol.ktest
@@ -5,18 +5,35 @@
 config-scratch-devs 16G
 config-scratch-devs 4G
 
+# Snapshots pin the data they were taken over; deleting them has to give it
+# back.
+#
+# Each generation overwrites the same file and snapshots the root subvolume,
+# so every snapshot pins its own version of foo. Repeated snapshotting builds
+# a chain of interior nodes, and deleting newest-first walks it back down:
+# each deletion leaves the node above with one live child - the redundant
+# case that bch2_delete_dead_snapshot_key() collapses.
+#
+# The pre-teardown check that the snapshots really were pinning their
+# generations matters as much as the reclaim check: without it the test passes
+# vacuously if they never held anything.
 test_snapshots_simple()
 {
-    NR_SNAPS=1
+    NR_SNAPS=8
+    GEN_MB=32
+    SLOP_MB=32		# btree/journal noise between measurements
 
     bcachefs_antagonist
 
     run_quiet "" bcachefs format -f ${ktest_scratch_dev[0]}
+
+    local baseline=$(bcachefs_used_sectors ${ktest_scratch_dev[0]})
+
     mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
 
     pushd /mnt
     for i in `seq 0 $NR_SNAPS`; do
-	dd if=/dev/zero of=/mnt/foo bs=1M count=1 oflag=direct
+	dd if=/dev/urandom of=/mnt/foo bs=1M count=$GEN_MB oflag=direct
 	bcachefs subvolume snapshot snap-$i
     done
     popd
@@ -24,21 +41,43 @@ test_snapshots_simple()
     umount /mnt
     sleep 0.2
     bcachefs fsck -n ${ktest_scratch_dev[0]}
-    exit
 
-    for i in `seq 0 $NR_SNAPS|sort -r`; do
-	umount /mnt
-	sleep 0.2
-	bcachefs fsck -n ${ktest_scratch_dev[0]}
+    local full=$(bcachefs_used_sectors ${ktest_scratch_dev[0]})
+    local pinned=$(( full - baseline ))
+    echo "with $((NR_SNAPS + 1)) snapshots: $(bcachefs_sectors_to_mb $pinned) MiB pinned"
+
+    if (( pinned < NR_SNAPS * GEN_MB * 2048 )); then
+	echo "TEST FAILED: expected at least $((NR_SNAPS * GEN_MB)) MiB pinned by $((NR_SNAPS + 1)) snapshots, got $(bcachefs_sectors_to_mb $pinned) MiB"
+	echo "             (snapshots aren't pinning their data - the reclaim check below would pass vacuously)"
+	exit 1
+    fi
+
+    for i in `seq 0 $NR_SNAPS|sort -rn`; do
 	mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
 
 	echo "deleting snap-$i"
 	bcachefs subvolume delete /mnt/snap-$i
-	df -h /mnt
+	bcachefs_settle_snapshot_deletion /mnt
+
+	umount /mnt
+	sleep 0.2
+	bcachefs fsck -n ${ktest_scratch_dev[0]}
+
+	local now=$(bcachefs_used_sectors ${ktest_scratch_dev[0]})
+	echo "  after deleting snap-$i: $(bcachefs_sectors_to_mb $((now - baseline))) MiB still in use"
     done
 
-    umount /mnt
-    sleep 0.2
+    # All snapshots gone: only the live copy of foo should be left.
+    local left=$(( $(bcachefs_used_sectors ${ktest_scratch_dev[0]}) - baseline ))
+
+    if (( left > (GEN_MB + SLOP_MB) * 2048 )); then
+	echo "TEST FAILED: $(bcachefs_sectors_to_mb $left) MiB still allocated after deleting every snapshot"
+	echo "             (only the live copy of foo should remain: ~$GEN_MB MiB)"
+	exit 1
+    fi
+
+    echo "reclaimed: $(bcachefs_sectors_to_mb $left) MiB left, live foo is $GEN_MB MiB"
+
     mount -t bcachefs -o fsck ${ktest_scratch_dev[0]} /mnt
     umount /mnt
 


### PR DESCRIPTION
Gosh, Claude really wants to be verbose on this one.

Summary: Make a snapshot, delete the same file in both the snapshot and the root, the data sticks around forever because it's in the *base* snapshot ID.

We wrote a test for it; that's the second commit. Claude really wanted a general "make sure snapshot reclamation works in the easy case" test; turned out there's *most* of one, it just had part of it truncated and unfinished for the last three years, so Claude fixed it up. That's the first commit.

Old tests pass, new tests fail.

As always, you are welcome to fix this up in whatever way makes you happier to check it in, I'm not wedded to it, I'm just providing you with a drop-in test case that you can easily use to fix the real problem :)

The rest of this is what Claude wrote.

-----

Snapshotting forks: `bch2_snapshot_node_create()` demotes the existing snapshot
node to an interior node and creates *two* fresh leaves — one the source
subvolume is re-pointed at, one for the new snapshot — leaving the data as of
that moment at the interior node, shared by both.

Delete a file in the source subvolume and in the snapshot, and those extents are
invisible from every subvolume in the tree — and still allocated, permanently.
The interior node isn't dead (both children are live subvolumes) and isn't
redundant either, so `check_should_delete_snapshot()` bails at
`if (nr_live_children == 2) return 0;`, and nothing looks for keys that are
overwritten in *every* leaf — `__bch2_key_has_snapshot_overwrites()` answers
"any descendant", which is a different question. The
"keys that have been overwritten in all child snapshots ... (unimplemented?)"
comment in `fs/snapshots/delete.c` is exactly this.

This is not corruption. **fsck passes clean and the filesystem is permanently
short of space** — which is why it goes unnoticed.

### What's here

No fix — these are the acceptance tests for one, plus the control that was
missing.

* **`snapshot-space-leak.ktest`** (new, both tests fail deliberately)
  * `delete_in_all_snapshots` — the bug: two live children.
  * `reflink_delete_in_all_snapshots` — the bug via reflink. Separate test
    because indirect extents leak one level removed: the only surviving
    `reflink_p` keys are the unreachable ones at the interior node, leaving
    every `reflink_v` at refcount 1 held by a key no subvolume can see. A fix
    that deletes the dead interior keys reclaims this for free through the
    `reflink_p` trigger — but only if the deletion goes through the normal
    trigger path, and this is what catches one that shortcuts around it.

  Both assert fsck is clean *as well as* that the space came back, so the leak
  can't hide behind a passing fsck.

* **`subvol.ktest: test_snapshots_simple`** — revived. Its teardown half has
  been dead since `fd48bd9` wrote it (a bare `exit` after the snapshot loop),
  and the unreachable code only ran `df -h` for a human to look at. It now
  deletes newest-first and asserts the space comes back — and asserts the
  snapshots were pinning it in the first place, without which the reclaim check
  passes vacuously.

  This is the control that pins the new failures to the two-live-children case
  rather than to snapshots in general. (`generic/015` covers the no-snapshot
  case and isn't expunged for bcachefs, so it isn't duplicated here.)

* **`bcachefs-test-libs.sh`** — `bcachefs_used_sectors` reads the accounting
  btree's gc-verified `replicas` counters offline instead of guessing from
  statfs; `bcachefs_settle_snapshot_deletion` forces the deletion worker to
  completion so a measurement isn't racing it; `bcachefs_sysfs_dir` resolves the
  fs's sysfs directory rather than globbing `/sys/fs/bcachefs/*/`, which as a
  redirect target becomes an "ambiguous redirect" the moment a second bcachefs
  is mounted. Note it is *not* always the UUID — `fs/init/fs.c` names the
  kobject `"%pU"` only when `c->sb.multi_device`, so a single-device filesystem
  (what every test formats) lives under its block device name.

### Results

```
snapshots_simple                  PASSED   288 MiB pinned -> 32 MiB left, live foo is 32 MiB
delete_in_all_snapshots           FAILED   256 MiB still allocated, fsck clean
                                           snapshot 4294967295: 524288 sectors
reflink_delete_in_all_snapshots   FAILED   256 MiB still allocated, fsck clean
                                           snapshot 4294967295: 0 sectors (!)
                                           reflink_v: 1024 keys, all refcount 1
```

The `0 sectors` on the reflink case is not a measurement error: `reflink_v` lives
in the reflink btree at snapshot 0 and `buckets.c` only mods the snapshot counter
for a nonzero `p.snapshot`, so indirect extents contribute *nothing* to
per-snapshot accounting however much they hold. `bcachefs subvolume list-snapshots`
cannot see this class of leak at all.

### Provenance

Found in a metadata dump from a user with unexplained space usage. On that
filesystem ~346 GiB — 41% of all user data — was unreachable from any
subvolume: 127 GiB of direct extents at the interior node whiteout'd in both
leaves, plus 219 GiB of `reflink_v` whose sole referrer was an unreachable
interior `reflink_p` (all at refcount 1). Accounting was *correct* throughout —
an independent recompute from the extents btree matched the per-snapshot
counters to within 1000 sectors out of 1.14 billion. The space really was gone.