### PR TITLE
Add shrink tests

### DIFF
--- a/tests/fs/bcachefs/bcachefs-test-libs.sh
+++ b/tests/fs/bcachefs/bcachefs-test-libs.sh
@@ -298,9 +298,12 @@ check_bcachefs_leaks()
 
 check_bcachefs_errors()
 {
+    local ignore=${ktest_expect_errors:-^$}
+
     for i in $@; do
 	if bcachefs show-super -f errors $i|
 	    sed -n '/^errors /,${/^errors /!p;}'|
+	    grep -vE "$ignore" |
 	    grep -E '[a-z]'; then
 	    return 1
 	fi

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -61,8 +61,8 @@ test_online_two_device_data_shrink()
 
     umount /mnt
 
-    bcachefs fsck -ny ${ktest_scratch_dev[0]}
-    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]}
 }
 
 main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -42,6 +42,7 @@ test_online_two_device_data_shrink()
     # format dev1 to 1G
     run_quiet "" bcachefs format -f		\
 	--fs_size=1G        				\
+	-l "bcachefs"				        \
 	${ktest_scratch_dev[0]}
 
     mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
@@ -61,8 +62,8 @@ test_online_two_device_data_shrink()
 
     umount /mnt
 
-    bcachefs fsck -ny ${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]}
-    bcachefs_test_end_checks ${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]}
+    bcachefs fsck -ny /dev/disk/by-label/bcachefs
+    bcachefs_test_end_checks /dev/disk/by-label/bcachefs
 }
 
 main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -42,7 +42,6 @@ test_online_two_device_data_shrink()
     # format dev1 to 1G
     run_quiet "" bcachefs format -f		\
 	--fs_size=1G        				\
-	-l "bcachefs"				        \
 	${ktest_scratch_dev[0]}
 
     mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
@@ -53,7 +52,7 @@ test_online_two_device_data_shrink()
     # add dev2
     bcachefs device add /mnt ${ktest_scratch_dev[1]}
 
-    # resize dev1 to 100M -> should evacuate most data to dev2
+    # resize dev1 to minimum size -> should evacuate most data to dev2
     df -h /mnt
     bcachefs device resize ${ktest_scratch_dev[0]} 256M
     df -h /mnt
@@ -62,8 +61,8 @@ test_online_two_device_data_shrink()
 
     umount /mnt
 
-    bcachefs fsck -ny /dev/disk/by-label/bcachefs
-    bcachefs_test_end_checks /dev/disk/by-label/bcachefs
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks "${ktest_scratch_dev[@]}"
 }
 
 main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -51,7 +51,7 @@ test_online_two_device_data_shrink()
     dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
 
     # add dev2
-    bcachefs device add /mnt ${ktest_scratch_dev[1]}
+    bcachefs device add -f /mnt ${ktest_scratch_dev[1]}
 
     # resize dev1 to minimum size -> should evacuate most data to dev2
     df -h /mnt
@@ -81,14 +81,12 @@ test_online_three_device_replicas_shrink()
     dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
 
     # add dev3
-    bcachefs device add /mnt ${ktest_scratch_dev[2]}
+    bcachefs device add -f /mnt ${ktest_scratch_dev[2]}
 
     # resize dev1 to minimum size -> should evacuate most data to dev3 to ensure replicas are met
     df -h /mnt
     bcachefs device resize ${ktest_scratch_dev[0]} 256M
     df -h /mnt
-
-    bcachefs fs usage -h /mnt --all
 
     umount /mnt
 

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -111,8 +111,6 @@ test_online_three_device_ec_shrink()
     # write 700M data
     dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
 
-    bcachefs reconcile wait -t erasure_code /mnt
-
     # add dev3
     bcachefs device add -f /mnt ${ktest_scratch_dev[2]}
 

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -11,6 +11,7 @@ require-kernel-config DM_FLAKEY
 
 config-scratch-devs 4G
 config-scratch-devs 4G
+config-scratch-devs 2G
 
 
 test_online_empty_shrink()
@@ -53,6 +54,38 @@ test_online_two_device_data_shrink()
     bcachefs device add /mnt ${ktest_scratch_dev[1]}
 
     # resize dev1 to minimum size -> should evacuate most data to dev2
+    df -h /mnt
+    bcachefs device resize ${ktest_scratch_dev[0]} 256M
+    df -h /mnt
+
+    umount /mnt
+
+    bcachefs fsck -ny "${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}"
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}"
+}
+
+test_online_three_device_replicas_shrink()
+{
+    set_watchdog 60
+    bcachefs_antagonist
+
+    # format dev1 and dev2 to 1G, with replicas=2
+    run_quiet "" bcachefs format -f		\
+	--replicas=2                        \
+	--data_replicas_required=2          \
+	--metadata_replicas_required=2      \
+	--fs_size=1G        				\
+	${ktest_scratch_dev[0]} --fs_size=1G ${ktest_scratch_dev[1]}
+
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    # write 700M data
+    dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
+
+    # add dev3
+    bcachefs device add /mnt ${ktest_scratch_dev[2]}
+
+    # resize dev1 to minimum size -> should evacuate most data to dev3 to ensure replicas are met
     df -h /mnt
     bcachefs device resize ${ktest_scratch_dev[0]} 256M
     df -h /mnt

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -72,8 +72,6 @@ test_online_three_device_replicas_shrink()
     # format dev1 and dev2 to 1G, with replicas=2
     run_quiet "" bcachefs format -f		\
 	--replicas=2                        \
-	--data_replicas_required=2          \
-	--metadata_replicas_required=2      \
 	--fs_size=1G        				\
 	${ktest_scratch_dev[0]} --fs_size=1G ${ktest_scratch_dev[1]}
 

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -94,4 +94,39 @@ test_online_three_device_replicas_shrink()
     bcachefs_test_end_checks "${ktest_scratch_dev[@]}"
 }
 
+test_online_three_device_ec_shrink()
+{
+    set_watchdog 60
+    bcachefs_antagonist
+
+    # format dev1 and dev2 to 1G, with replicas=2
+    run_quiet "" bcachefs format -f		\
+	--replicas=2                        \
+	--erasure_code                      \
+	--fs_size=1G        				\
+	${ktest_scratch_dev[0]} --fs_size=1G ${ktest_scratch_dev[1]}
+
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    # write 700M data
+    dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
+
+    bcachefs reconcile wait -t erasure_code /mnt
+
+    # add dev3
+    bcachefs device add -f /mnt ${ktest_scratch_dev[2]}
+
+    # resize dev1 to minimum size -> should evacuate most data to dev3 to ensure replicas are met
+    df -h /mnt
+    bcachefs device resize ${ktest_scratch_dev[0]} 256M
+    df -h /mnt
+
+    bcachefs fs usage -h --all /mnt
+
+    umount /mnt
+
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks "${ktest_scratch_dev[@]}"
+}
+
 main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -34,4 +34,35 @@ test_online_empty_shrink()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_online_two_device_data_shrink()
+{
+    set_watchdog 60
+    bcachefs_antagonist
+
+    # format dev1 to 1G
+    run_quiet "" bcachefs format -f		\
+	--fs_size=1G        				\
+	${ktest_scratch_dev[0]}
+
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    # write 700M data
+    dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
+
+    # add dev2
+    bcachefs device add /mnt ${ktest_scratch_dev[1]}
+
+    # resize dev1 to 100M -> should evacuate most data to dev2
+    df -h /mnt
+    bcachefs device resize ${ktest_scratch_dev[0]} 256M
+    df -h /mnt
+
+    bcachefs fs usage -h /mnt --all
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/bcachefs-test-libs.sh
+
+require-kernel-config BCACHEFS_TESTS
+require-kernel-config BCACHEFS_QUOTA
+
+require-kernel-config MD
+require-kernel-config BLK_DEV_DM
+require-kernel-config DM_FLAKEY
+
+config-scratch-devs 4G
+config-scratch-devs 4G
+
+
+test_online_empty_shrink()
+{
+    set_watchdog 60
+    bcachefs_antagonist
+
+    run_quiet "" bcachefs format -f		\
+	--fs_size=1G				\
+	${ktest_scratch_dev[0]}
+
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    df -h /mnt
+    bcachefs device resize ${ktest_scratch_dev[0]} 500M
+    df -h /mnt
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -91,6 +91,27 @@ shrink_run_fio_randrw()
 	"$@"
 }
 
+shrink_live_file_churn()
+{
+    local dir=$1
+    local iterations=$2
+    local size_mb=$3
+    local keep=$4
+
+    mkdir -p "$dir"
+
+    for i in $(seq 1 "$iterations"); do
+	local file="$dir/file.$i"
+
+	shrink_write_random_file "$file" "$size_mb"
+	mv "$file" "$file.done"
+
+	if (( i > keep )); then
+	    rm -f "$dir/file.$((i - keep)).done"
+	fi
+    done
+}
+
 shrink_verify_snapshots()
 {
     (
@@ -122,15 +143,51 @@ shrink_verify_checksums()
     )
 }
 
+shrink_populate_metadata_tree()
+{
+    local root=$1
+
+    mkdir -p "$root/a" "$root/b"
+
+    shrink_write_random_file "$root/a/regular.bin" 256
+    shrink_write_random_file "$root/a/evacuate.bin" 384
+    printf 'metadata survives shrink\n' > "$root/small.txt"
+
+    cp --reflink=always "$root/a/regular.bin" "$root/b/reflink.bin"
+    ln "$root/a/regular.bin" "$root/a/regular.hardlink"
+    ln "$root/small.txt" "$root/small.link"
+    ln -s small.txt "$root/link-to-small"
+
+    setfattr -n user.shrink_case -v metadata "$root"
+    setfattr -n user.shrink_payload -v primary "$root/a/regular.bin"
+
+    mv "$root/a/evacuate.bin" "$root/b/evacuate.bin"
+    mkdir "$root/b/renamed"
+    mv "$root/b/reflink.bin" "$root/b/renamed/reflink.bin"
+}
+
+shrink_verify_metadata_tree()
+{
+    local root=$1
+    local checksums=$2
+
+    shrink_verify_checksums "$checksums"
+
+    [[ $(stat -c '%h' "$root/a/regular.bin") = 2 ]]
+    [[ $(stat -c '%h' "$root/small.txt") = 2 ]]
+    [[ $(readlink "$root/link-to-small") = small.txt ]]
+    [[ $(getfattr --only-values -n user.shrink_case "$root" 2>/dev/null) = metadata ]]
+    [[ $(getfattr --only-values -n user.shrink_payload "$root/a/regular.bin" 2>/dev/null) = primary ]]
+}
+
 shrink_verify_xattrs_hardlinks()
 {
-    shrink_verify_checksums "$ktest_out/shrink-xattrs.md5"
+    shrink_verify_metadata_tree /mnt/tree "$ktest_out/shrink-xattrs.md5"
+}
 
-    [[ $(stat -c '%h' /mnt/tree/a/regular.bin) = 2 ]]
-    [[ $(stat -c '%h' /mnt/tree/small.txt) = 2 ]]
-    [[ $(readlink /mnt/tree/link-to-small) = small.txt ]]
-    [[ $(getfattr --only-values -n user.shrink_case /mnt/tree 2>/dev/null) = metadata ]]
-    [[ $(getfattr --only-values -n user.shrink_payload /mnt/tree/a/regular.bin 2>/dev/null) = primary ]]
+shrink_verify_replicas_metadata()
+{
+    shrink_verify_metadata_tree /mnt/tree "$ktest_out/shrink-replicas-metadata.md5"
 }
 
 shrink_verify_targeted_subdirs()
@@ -391,23 +448,7 @@ test_online_two_device_xattrs_hardlinks_shrink()
 
     shrink_mount "${devs[0]}"
 
-    mkdir -p /mnt/tree/a /mnt/tree/b
-
-    shrink_write_random_file /mnt/tree/a/regular.bin 256
-    shrink_write_random_file /mnt/tree/a/evacuate.bin 384
-    printf 'metadata survives shrink\n' > /mnt/tree/small.txt
-
-    cp --reflink=always /mnt/tree/a/regular.bin /mnt/tree/b/reflink.bin
-    ln /mnt/tree/a/regular.bin /mnt/tree/a/regular.hardlink
-    ln /mnt/tree/small.txt /mnt/tree/small.link
-    ln -s small.txt /mnt/tree/link-to-small
-
-    setfattr -n user.shrink_case -v metadata /mnt/tree
-    setfattr -n user.shrink_payload -v primary /mnt/tree/a/regular.bin
-
-    mv /mnt/tree/a/evacuate.bin /mnt/tree/b/evacuate.bin
-    mkdir /mnt/tree/b/renamed
-    mv /mnt/tree/b/reflink.bin /mnt/tree/b/renamed/reflink.bin
+    shrink_populate_metadata_tree /mnt/tree
 
     shrink_record_checksums "$ktest_out/shrink-xattrs.md5"	\
 	tree/a/regular.bin					\
@@ -468,6 +509,47 @@ test_online_three_device_targeted_subdirs_shrink()
     df -h /mnt
 
     shrink_finish shrink_verify_targeted_subdirs "${devs[@]}"
+}
+
+test_online_three_device_replicas_metadata_under_randrw_shrink()
+{
+    set_watchdog 240
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}" "${ktest_scratch_dev[2]}")
+
+    run_quiet "" bcachefs format -f		\
+	--replicas=2				\
+	--compression=lz4			\
+	--fs_size=1G				\
+	"${devs[0]}" --fs_size=1G "${devs[1]}"
+
+    shrink_mount "${devs[0]}"
+
+    shrink_populate_metadata_tree /mnt/tree
+    shrink_record_checksums "$ktest_out/shrink-replicas-metadata.md5"	\
+	tree/a/regular.bin						\
+	tree/b/evacuate.bin						\
+	tree/b/renamed/reflink.bin					\
+	tree/small.txt
+
+    bcachefs device add -f /mnt "${devs[2]}"
+
+    local liveout="$ktest_out/shrink-replicas-metadata-live.out"
+    shrink_live_file_churn /mnt/live 24 8 6 >"$liveout" 2>&1 &
+    local livepid=$!
+
+    sleep 2
+
+    df -h /mnt
+    bcachefs device resize "${devs[0]}" 512M
+    df -h /mnt
+
+    if ! wait $livepid; then
+	cat "$liveout"
+	return 1
+    fi
+
+    shrink_finish shrink_verify_replicas_metadata "${devs[@]}"
 }
 
 main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -917,6 +917,57 @@ test_online_three_device_replicas_metadata_under_randrw_shrink()
     finish verify_replicas_metadata "${devs[@]}"
 }
 
+test_online_shrink_cancel()
+{
+    set_watchdog 120
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
+    local resizeout="$ktest_out/shrink-cancel.out"
+    local initial_size_bytes
+
+    run_quiet "" bcachefs format -f		\
+	--fs_size=1G				\
+	"${devs[0]}"
+
+    mount_mnt "${devs[0]}"
+    initial_size_bytes=$(show_super_size_bytes "${devs[0]}")
+
+    dd if=/dev/urandom of=/mnt/payload bs=1M count=750 oflag=direct
+    bcachefs device add -f /mnt "${devs[1]}"
+
+    bcachefs device resize "${devs[0]}" 200M >"$resizeout" 2>&1 &
+    local resizepid=$!
+
+    wait_for_resize_to_start "$resizepid" "$resizeout"
+    bcachefs device resize "${devs[0]}" cancel
+    wait_for_canceled_resize "$resizepid" "$resizeout"
+
+    assert_member_size_bytes "${devs[0]}" $initial_size_bytes
+    assert_resize_target_inactive "${devs[0]}"
+    finish "" "${devs[@]}"
+}
+
+test_online_shrink_then_cancel()
+{
+    set_watchdog 60
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}")
+
+    run_quiet "" bcachefs format -f		\
+	--fs_size=1G				\
+	"${devs[0]}"
+
+    mount_mnt "${devs[0]}"
+
+    bcachefs device resize "${devs[0]}" 500M
+
+    bcachefs device resize "${devs[0]}" cancel
+
+    assert_member_size_bytes "${devs[0]}" $((500 * 1024 * 1024))
+    assert_resize_target_inactive "${devs[0]}"
+    finish "" "${devs[@]}"
+}
+
 _test_offline_empty_shrink()
 {
     set_watchdog 60

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -243,10 +243,7 @@ test_online_two_device_crypto_compression_shrink_under_randrw()
     shrink_finish "" "${devs[@]}"
 }
 
-# Mixed bucket sizes are a relevant shrink configuration, but this still trips
-# no_buckets_found during device reconcile today. Keep the reproducer around so
-# the scenario is easy to re-enable once the implementation is fixed.
-d_test_online_three_device_variable_buckets_shrink()
+test_online_three_device_variable_buckets_shrink()
 {
     set_watchdog 180
     bcachefs_antagonist

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -81,6 +81,108 @@ assert_resize_target_inactive()
     fi
 }
 
+# Shrink or grow a device via the bcachefs-tools library (offline path).
+# The filesystem must not be mounted by the kernel.
+offline_device_resize()
+{
+    local dev=$1
+    local size=$2
+
+    bcachefs device resize "$dev" "$size"
+    assert_member_size_bytes "$dev" "$size"
+    assert_resize_target_inactive "$dev"
+}
+
+_do_empty_shrink()
+{
+    local mode=$1
+    local devs=("${ktest_scratch_dev[0]}")
+
+    run_quiet "" bcachefs format -f		\
+	--fs_size=1G				\
+	"${devs[0]}"
+
+    mount_mnt "${devs[0]}"
+    df -h /mnt
+
+    if [[ $mode == offline ]]; then
+	umount /mnt
+	offline_device_resize "${devs[0]}" 500M
+	mount_mnt "${devs[0]}"
+    else
+	bcachefs device resize "${devs[0]}" 500M
+    fi
+
+    df -h /mnt
+    finish "" "${devs[@]}"
+}
+
+_do_two_device_data_shrink()
+{
+    local mode=$1
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
+
+    run_quiet "" bcachefs format -f		\
+	--fs_size=1G				\
+	"${devs[0]}"
+
+    mount_mnt "${devs[0]}"
+    dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
+    bcachefs device add -f /mnt "${devs[1]}"
+
+    record_checksums "$ktest_out/do-two-device-data.md5" foo
+    df -h /mnt
+
+    if [[ $mode == offline ]]; then
+	umount /mnt
+	offline_device_resize "${devs[0]}" 256M
+	mount_mnt "${devs[@]}"
+    else
+	bcachefs device resize "${devs[0]}" 256M
+    fi
+
+    verify_checksums "$ktest_out/do-two-device-data.md5"
+    df -h /mnt
+    finish "" "${devs[@]}"
+}
+
+_do_impossible_shrink()
+{
+    local mode=$1
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
+    local resizeout="$ktest_out/do-impossible-shrink.out"
+
+    run_quiet "" bcachefs format -f		\
+	--replicas=2				\
+	--fs_size=3G				\
+	"${devs[0]}" --fs_size=3G "${devs[1]}"
+
+    mount_mnt "${devs[0]}"
+    write_random_file /mnt/impossible.bin 768
+
+    impossible_shrink_md5="$ktest_out/do-impossible-shrink.md5"
+    impossible_shrink_dev="${devs[0]}"
+    record_checksums "$impossible_shrink_md5" impossible.bin
+
+    if [[ $mode == offline ]]; then
+	umount /mnt
+    fi
+
+    if bcachefs device resize "${devs[0]}" 256M >"$resizeout" 2>&1; then
+	echo "Impossible shrink unexpectedly succeeded"
+	cat "$resizeout"
+	return 1
+    fi
+
+    assert_resize_target_inactive "${devs[0]}"
+
+    if [[ $mode == offline ]]; then
+	mount_mnt "${devs[@]}"
+    fi
+
+    finish verify_impossible_shrink "${devs[@]}"
+}
+
 wait_for_resize_to_start()
 {
     local pid=$1
@@ -324,46 +426,14 @@ test_online_empty_shrink()
 {
     set_watchdog 60
     bcachefs_antagonist
-    local devs=("${ktest_scratch_dev[0]}")
-
-    run_quiet "" bcachefs format -f		\
-	--fs_size=1G				\
-	"${devs[0]}"
-
-    mount_mnt "${devs[0]}"
-
-    df -h /mnt
-    bcachefs device resize "${devs[0]}" 500M
-    df -h /mnt
-
-    finish "" "${devs[@]}"
+    _do_empty_shrink online
 }
 
 test_online_two_device_data_shrink()
 {
     set_watchdog 60
     bcachefs_antagonist
-    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
-
-    # format dev1 to 1G
-    run_quiet "" bcachefs format -f		\
-	--fs_size=1G        				\
-	"${devs[0]}"
-
-    mount_mnt "${devs[0]}"
-
-    # write 700M data
-    dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
-
-    # add dev2
-    bcachefs device add -f /mnt "${devs[1]}"
-
-    # resize dev1 to minimum size -> should evacuate most data to dev2
-    df -h /mnt
-    bcachefs device resize "${devs[0]}" 256M
-    df -h /mnt
-
-    finish "" "${devs[@]}"
+    _do_two_device_data_shrink online
 }
 
 test_online_three_device_replicas_shrink()
@@ -398,31 +468,7 @@ test_online_two_device_replicas_impossible_shrink()
 {
     set_watchdog 420
     bcachefs_antagonist
-    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
-    local resizeout="$ktest_out/shrink-replicas-impossible.out"
-
-    run_quiet "" bcachefs format -f		\
-	--replicas=2				\
-	--fs_size=3G				\
-	"${devs[0]}" --fs_size=3G "${devs[1]}"
-
-    mount_mnt "${devs[0]}"
-
-    write_random_file /mnt/impossible.bin 768
-
-    impossible_shrink_md5="$ktest_out/shrink-replicas-impossible.md5"
-    impossible_shrink_dev="${devs[0]}"
-    record_checksums "$impossible_shrink_md5" impossible.bin
-
-    if bcachefs device resize "${devs[0]}" 256M >"$resizeout" 2>&1; then
-	echo "Impossible shrink unexpectedly succeeded"
-	cat "$resizeout"
-	return 1
-    fi
-
-    assert_resize_target_inactive "${devs[0]}"
-
-    finish verify_impossible_shrink "${devs[@]}"
+    _do_impossible_shrink online
 }
 
 test_online_three_device_ec_shrink()
@@ -869,6 +915,27 @@ test_online_three_device_replicas_metadata_under_randrw_shrink()
     fi
 
     finish verify_replicas_metadata "${devs[@]}"
+}
+
+test_offline_empty_shrink()
+{
+    set_watchdog 60
+    bcachefs_antagonist
+    _do_empty_shrink offline
+}
+
+test_offline_two_device_data_shrink()
+{
+    set_watchdog 120
+    bcachefs_antagonist
+    _do_two_device_data_shrink offline
+}
+
+test_offline_impossible_shrink()
+{
+    set_watchdog 120
+    bcachefs_antagonist
+    _do_impossible_shrink offline
 }
 
 main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -85,14 +85,26 @@ wait_for_resize_to_start()
 {
     local pid=$1
     local output=$2
+    local i
 
-    sleep 5
-    if ! kill -0 "$pid" 2>/dev/null; then
+    # A long fixed sleep can miss the entire in-flight window once shrink gets
+    # faster. Give the ioctl only a brief head start, then act as soon as it is
+    # still alive so retarget/restart tests catch the live worker instead of a
+    # completed resize.
+    for i in $(seq 1 20); do
+	sleep 0.1
+
+	if kill -0 "$pid" 2>/dev/null; then
+	    return 0
+	fi
+
 	wait "$pid" || true
-	echo "Resize completed before retarget; test did not exercise in-flight target changes"
+	echo "Resize completed before the test observed persisted in-flight state"
 	cat "$output"
 	return 1
-    fi
+    done
+
+    return 0
 }
 
 wait_for_canceled_resize()
@@ -595,16 +607,9 @@ test_online_two_device_restart_resume_shrink()
     bcachefs device resize "${devs[0]}" 512M >"$resizeout" 2>&1 &
     local resizepid=$!
 
-    # target_nbuckets is committed near the start of shrink. Give the ioctl a
-    # short head start, then interrupt it so the restart path has to finish
-    # the persisted shrink on the next mount.
-    sleep 5
-    if ! kill -0 "$resizepid" 2>/dev/null; then
-	wait "$resizepid" || true
-	echo "Shrink completed before interruption; restart-resume test did not exercise resume"
-	cat "$resizeout"
-	return 1
-    fi
+    # Kill the ioctl after the target is safely persisted so the next mount
+    # has to resume the interrupted shrink.
+    wait_for_resize_to_start "$resizepid" "$resizeout"
 
     kill -TERM "$resizepid" 2>/dev/null || true
     wait "$resizepid" || true

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -100,6 +100,49 @@ shrink_verify_snapshots()
     )
 }
 
+shrink_record_checksums()
+{
+    local output=$1
+    shift
+
+    (
+	cd /mnt
+	: > "$output"
+	md5sum "$@" >> "$output"
+    )
+}
+
+shrink_verify_checksums()
+{
+    local output=$1
+
+    (
+	cd /mnt
+	md5sum -c "$output"
+    )
+}
+
+shrink_verify_xattrs_hardlinks()
+{
+    shrink_verify_checksums "$ktest_out/shrink-xattrs.md5"
+
+    [[ $(stat -c '%h' /mnt/tree/a/regular.bin) = 2 ]]
+    [[ $(stat -c '%h' /mnt/tree/small.txt) = 2 ]]
+    [[ $(readlink /mnt/tree/link-to-small) = small.txt ]]
+    [[ $(getfattr --only-values -n user.shrink_case /mnt/tree 2>/dev/null) = metadata ]]
+    [[ $(getfattr --only-values -n user.shrink_payload /mnt/tree/a/regular.bin 2>/dev/null) = primary ]]
+}
+
+shrink_verify_targeted_subdirs()
+{
+    shrink_verify_checksums "$ktest_out/shrink-targets.md5"
+
+    [[ $(getfattr --only-values -n user.shrink_target /mnt/fast/fast.bin 2>/dev/null) = fast ]]
+    [[ $(getfattr --only-values -n user.shrink_target /mnt/bulk/bulk.bin 2>/dev/null) = bulk ]]
+    [[ $(readlink /mnt/bulk/link-to-fast) = ../fast/fast.bin ]]
+    [[ $(stat -c '%h' /mnt/root.meta) = 2 ]]
+}
+
 
 test_online_empty_shrink()
 {
@@ -333,6 +376,98 @@ test_online_three_device_replicas_snapshot_shrink()
     df -h /mnt
 
     shrink_finish shrink_verify_snapshots "${devs[@]}"
+}
+
+test_online_two_device_xattrs_hardlinks_shrink()
+{
+    set_watchdog 180
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
+
+    run_quiet "" bcachefs format -f		\
+	--compression=lz4			\
+	--fs_size=1G				\
+	"${devs[0]}"
+
+    shrink_mount "${devs[0]}"
+
+    mkdir -p /mnt/tree/a /mnt/tree/b
+
+    shrink_write_random_file /mnt/tree/a/regular.bin 256
+    shrink_write_random_file /mnt/tree/a/evacuate.bin 384
+    printf 'metadata survives shrink\n' > /mnt/tree/small.txt
+
+    cp --reflink=always /mnt/tree/a/regular.bin /mnt/tree/b/reflink.bin
+    ln /mnt/tree/a/regular.bin /mnt/tree/a/regular.hardlink
+    ln /mnt/tree/small.txt /mnt/tree/small.link
+    ln -s small.txt /mnt/tree/link-to-small
+
+    setfattr -n user.shrink_case -v metadata /mnt/tree
+    setfattr -n user.shrink_payload -v primary /mnt/tree/a/regular.bin
+
+    mv /mnt/tree/a/evacuate.bin /mnt/tree/b/evacuate.bin
+    mkdir /mnt/tree/b/renamed
+    mv /mnt/tree/b/reflink.bin /mnt/tree/b/renamed/reflink.bin
+
+    shrink_record_checksums "$ktest_out/shrink-xattrs.md5"	\
+	tree/a/regular.bin					\
+	tree/b/evacuate.bin					\
+	tree/b/renamed/reflink.bin				\
+	tree/small.txt
+
+    bcachefs device add -f /mnt "${devs[1]}"
+
+    df -h /mnt
+    bcachefs device resize "${devs[0]}" 256M
+    df -h /mnt
+
+    shrink_finish shrink_verify_xattrs_hardlinks "${devs[@]}"
+}
+
+test_online_three_device_targeted_subdirs_shrink()
+{
+    set_watchdog 180
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}" "${ktest_scratch_dev[2]}")
+
+    run_quiet "" bcachefs format -f				\
+	--label=fast "${devs[0]}"				\
+	--label=bulk "${devs[2]}"				\
+	--foreground_target=fast				\
+	--promote_target=fast					\
+	--background_target=bulk
+
+    shrink_mount "${devs[0]}" "${devs[2]}"
+
+    mkdir /mnt/fast
+    mkdir /mnt/bulk
+
+    bcachefs set-file-option --foreground_target=fast /mnt/fast
+    bcachefs set-file-option --promote_target=fast /mnt/fast
+    bcachefs set-file-option --foreground_target=bulk /mnt/bulk
+    bcachefs set-file-option --background_target=bulk /mnt/bulk
+
+    shrink_write_random_file /mnt/fast/fast.bin 512
+    shrink_write_random_file /mnt/bulk/bulk.bin 256
+    printf 'targeted metadata\n' > /mnt/root.meta
+    ln /mnt/root.meta /mnt/root.meta.link
+    ln -s ../fast/fast.bin /mnt/bulk/link-to-fast
+
+    setfattr -n user.shrink_target -v fast /mnt/fast/fast.bin
+    setfattr -n user.shrink_target -v bulk /mnt/bulk/bulk.bin
+
+    shrink_record_checksums "$ktest_out/shrink-targets.md5"	\
+	fast/fast.bin						\
+	bulk/bulk.bin						\
+	root.meta
+
+    bcachefs device add -f --label=fast /mnt "${devs[1]}"
+
+    df -h /mnt
+    bcachefs device resize "${devs[0]}" 512M
+    df -h /mnt
+
+    shrink_finish shrink_verify_targeted_subdirs "${devs[@]}"
 }
 
 main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -18,6 +18,95 @@ mount_mnt()
     mount -t bcachefs "$(join_by : "$@")" /mnt
 }
 
+show_super_field()
+{
+    local dev=$1
+    local field=$2
+
+    bcachefs show-super "$dev" | awk -v field="$field" '
+	{
+	    line = $0
+	    sub(/^[[:space:]]+/, "", line)
+	}
+
+	index(line, field ":") == 1 {
+	    sub(/^[^:]+:[[:space:]]*/, "", line)
+	    gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+	    print line
+	    exit
+	}
+    '
+}
+
+show_super_size_bytes()
+{
+    local dev=$1
+
+    show_super_field "$dev" "Size" | tr -d ' ' | numfmt --from=iec
+}
+
+show_super_bucket_size_bytes()
+{
+    local dev=$1
+
+    show_super_field "$dev" "Bucket size" | tr -d ' ' | numfmt --from=iec
+}
+
+show_super_buckets()
+{
+    local dev=$1
+
+    show_super_field "$dev" "Buckets"
+}
+
+assert_member_size_bytes()
+{
+    local dev=$1
+    local expected_bytes=$2
+    local bucket_size_bytes=$(show_super_bucket_size_bytes "$dev")
+    local expected_buckets=$((expected_bytes / bucket_size_bytes))
+
+    [[ $(show_super_buckets "$dev") -eq $expected_buckets ]]
+}
+
+assert_resize_target_inactive()
+{
+    local dev=$1
+
+    local target=$(show_super_field "$dev" "Target buckets")
+
+    if [[ -n $target && $target != Inactive ]]; then
+	bcachefs show-super "$dev"
+	return 1
+    fi
+}
+
+wait_for_resize_to_start()
+{
+    local pid=$1
+    local output=$2
+
+    sleep 5
+    if ! kill -0 "$pid" 2>/dev/null; then
+	wait "$pid" || true
+	echo "Resize completed before retarget; test did not exercise in-flight target changes"
+	cat "$output"
+	return 1
+    fi
+}
+
+wait_for_canceled_resize()
+{
+    local pid=$1
+    local output=$2
+
+    if wait "$pid"; then
+	echo "Superseded resize unexpectedly succeeded"
+	cat "$output"
+	return 1
+    fi
+}
+
 finish()
 {
     local verify_fn=$1
@@ -193,6 +282,13 @@ verify_replicas_metadata()
 verify_restart_resume()
 {
     verify_metadata_tree /mnt/tree "$ktest_out/shrink-restart-resume.md5"
+}
+
+verify_retarget_resize()
+{
+    verify_metadata_tree /mnt/tree "$retarget_resize_md5"
+    assert_resize_target_inactive "$retarget_resize_dev"
+    assert_member_size_bytes "$retarget_resize_dev" "$retarget_resize_size_bytes"
 }
 
 verify_targeted_subdirs()
@@ -522,6 +618,128 @@ test_online_two_device_restart_resume_shrink()
     bcachefs device resize "${devs[0]}" 512M
 
     finish verify_restart_resume "${devs[@]}"
+}
+
+test_online_two_device_shrink_retarget_larger()
+{
+    set_watchdog 420
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
+    local resizeout="$ktest_out/shrink-retarget-larger-first.out"
+
+    run_quiet "" bcachefs format -f		\
+	--compression=lz4			\
+	--fs_size=3G				\
+	"${devs[0]}"
+
+    mount_mnt "${devs[0]}"
+
+    populate_metadata_tree /mnt/tree
+    write_random_file /mnt/big.bin 2048
+
+    retarget_resize_md5="$ktest_out/shrink-retarget-larger.md5"
+    retarget_resize_dev="${devs[0]}"
+    retarget_resize_size_bytes=$((1024 * 1024 * 1024))
+
+    record_checksums "$retarget_resize_md5"		\
+	big.bin						\
+	tree/a/regular.bin				\
+	tree/b/evacuate.bin				\
+	tree/b/renamed/reflink.bin			\
+	tree/small.txt
+
+    bcachefs device add -f /mnt "${devs[1]}"
+
+    bcachefs device resize "${devs[0]}" 512M >"$resizeout" 2>&1 &
+    local resizepid=$!
+
+    wait_for_resize_to_start "$resizepid" "$resizeout"
+    bcachefs device resize "${devs[0]}" 1G
+    wait_for_canceled_resize "$resizepid" "$resizeout"
+
+    finish verify_retarget_resize "${devs[@]}"
+}
+
+test_online_two_device_shrink_retarget_cancel()
+{
+    set_watchdog 420
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
+    local resizeout="$ktest_out/shrink-retarget-cancel-first.out"
+    local initial_size_bytes
+
+    run_quiet "" bcachefs format -f		\
+	--compression=lz4			\
+	--fs_size=3G				\
+	"${devs[0]}"
+
+    mount_mnt "${devs[0]}"
+    initial_size_bytes=$(show_super_size_bytes "${devs[0]}")
+
+    populate_metadata_tree /mnt/tree
+    write_random_file /mnt/big.bin 2048
+
+    retarget_resize_md5="$ktest_out/shrink-retarget-cancel.md5"
+    retarget_resize_dev="${devs[0]}"
+    retarget_resize_size_bytes=$initial_size_bytes
+
+    record_checksums "$retarget_resize_md5"		\
+	big.bin						\
+	tree/a/regular.bin				\
+	tree/b/evacuate.bin				\
+	tree/b/renamed/reflink.bin			\
+	tree/small.txt
+
+    bcachefs device add -f /mnt "${devs[1]}"
+
+    bcachefs device resize "${devs[0]}" 512M >"$resizeout" 2>&1 &
+    local resizepid=$!
+
+    wait_for_resize_to_start "$resizepid" "$resizeout"
+    bcachefs device resize "${devs[0]}" 3G
+    wait_for_canceled_resize "$resizepid" "$resizeout"
+
+    finish verify_retarget_resize "${devs[@]}"
+}
+
+test_online_two_device_shrink_retarget_grow()
+{
+    set_watchdog 420
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
+    local resizeout="$ktest_out/shrink-retarget-grow-first.out"
+
+    run_quiet "" bcachefs format -f		\
+	--compression=lz4			\
+	--fs_size=3G				\
+	"${devs[0]}"
+
+    mount_mnt "${devs[0]}"
+
+    populate_metadata_tree /mnt/tree
+    write_random_file /mnt/big.bin 2048
+
+    retarget_resize_md5="$ktest_out/shrink-retarget-grow.md5"
+    retarget_resize_dev="${devs[0]}"
+    retarget_resize_size_bytes=$((3584 * 1024 * 1024))
+
+    record_checksums "$retarget_resize_md5"		\
+	big.bin						\
+	tree/a/regular.bin				\
+	tree/b/evacuate.bin				\
+	tree/b/renamed/reflink.bin			\
+	tree/small.txt
+
+    bcachefs device add -f /mnt "${devs[1]}"
+
+    bcachefs device resize "${devs[0]}" 512M >"$resizeout" 2>&1 &
+    local resizepid=$!
+
+    wait_for_resize_to_start "$resizepid" "$resizeout"
+    bcachefs device resize "${devs[0]}" 3584M
+    wait_for_canceled_resize "$resizepid" "$resizeout"
+
+    finish verify_retarget_resize "${devs[@]}"
 }
 
 test_online_three_device_targeted_subdirs_shrink()

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -303,6 +303,12 @@ verify_retarget_resize()
     assert_member_size_bytes "$retarget_resize_dev" "$retarget_resize_size_bytes"
 }
 
+verify_impossible_shrink()
+{
+    verify_checksums "$impossible_shrink_md5"
+    assert_resize_target_inactive "$impossible_shrink_dev"
+}
+
 verify_targeted_subdirs()
 {
     verify_checksums "$ktest_out/shrink-targets.md5"
@@ -386,6 +392,37 @@ test_online_three_device_replicas_shrink()
     df -h /mnt
 
     finish "" "${devs[@]}"
+}
+
+test_online_two_device_replicas_impossible_shrink()
+{
+    set_watchdog 420
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
+    local resizeout="$ktest_out/shrink-replicas-impossible.out"
+
+    run_quiet "" bcachefs format -f		\
+	--replicas=2				\
+	--fs_size=3G				\
+	"${devs[0]}" --fs_size=3G "${devs[1]}"
+
+    mount_mnt "${devs[0]}"
+
+    write_random_file /mnt/impossible.bin 768
+
+    impossible_shrink_md5="$ktest_out/shrink-replicas-impossible.md5"
+    impossible_shrink_dev="${devs[0]}"
+    record_checksums "$impossible_shrink_md5" impossible.bin
+
+    if bcachefs device resize "${devs[0]}" 256M >"$resizeout" 2>&1; then
+	echo "Impossible shrink unexpectedly succeeded"
+	cat "$resizeout"
+	return 1
+    fi
+
+    assert_resize_target_inactive "${devs[0]}"
+
+    finish verify_impossible_shrink "${devs[@]}"
 }
 
 test_online_three_device_ec_shrink()

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -12,6 +12,7 @@ require-kernel-config DM_FLAKEY
 config-scratch-devs 4G
 config-scratch-devs 4G
 config-scratch-devs 2G
+config-scratch-devs 1G
 
 mount_mnt()
 {
@@ -475,24 +476,31 @@ test_online_three_device_ec_shrink()
 {
     set_watchdog 60
     bcachefs_antagonist
-    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}" "${ktest_scratch_dev[2]}")
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}" "${ktest_scratch_dev[2]}" "${ktest_scratch_dev[3]}")
 
     # format dev1 and dev2 to 1G, with replicas=2
     run_quiet "" bcachefs format -f		\
 	--replicas=2                        \
 	--erasure_code                      \
 	--fs_size=1G        				\
-	"${devs[0]}" --fs_size=1G "${devs[1]}"
+	--bucket_size=512k                  \
+	"${devs[0]}"                        \
+	--fs_size=1G        				\
+	--bucket_size=512k                  \
+	"${devs[1]}"                        \
+	--fs_size=1G        				\
+	--bucket_size=512k                  \
+	"${devs[2]}"
 
     mount_mnt "${devs[0]}"
 
-    # write 700M data
     dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
 
-    # add dev3
-    bcachefs device add -f /mnt "${devs[2]}"
+    bcachefs reconcile wait -t erasure_code /mnt
 
-    # resize dev1 to minimum size -> should evacuate most data to dev3 to ensure replicas are met
+    bcachefs device add -f /mnt --bucket_size=512k "${devs[3]}"
+
+    # resize dev1 to minimum size -> should evacuate most data to dev4 to ensure replicas are met
     df -h /mnt
     bcachefs device resize "${devs[0]}" 256M
     df -h /mnt

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -190,6 +190,11 @@ verify_replicas_metadata()
     verify_metadata_tree /mnt/tree "$ktest_out/shrink-replicas-metadata.md5"
 }
 
+verify_restart_resume()
+{
+    verify_metadata_tree /mnt/tree "$ktest_out/shrink-restart-resume.md5"
+}
+
 verify_targeted_subdirs()
 {
     verify_checksums "$ktest_out/shrink-targets.md5"
@@ -463,6 +468,60 @@ test_online_two_device_xattrs_hardlinks_shrink()
     df -h /mnt
 
     finish verify_xattrs_hardlinks "${devs[@]}"
+}
+
+test_online_two_device_restart_resume_shrink()
+{
+    set_watchdog 420
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
+    local resizeout="$ktest_out/shrink-restart-resume.out"
+
+    run_quiet "" bcachefs format -f		\
+	--compression=lz4			\
+	--fs_size=3G				\
+	"${devs[0]}"
+
+    mount_mnt "${devs[0]}"
+
+    populate_metadata_tree /mnt/tree
+    write_random_file /mnt/big.bin 2048
+
+    record_checksums "$ktest_out/shrink-restart-resume.md5"	\
+	big.bin							\
+	tree/a/regular.bin					\
+	tree/b/evacuate.bin					\
+	tree/b/renamed/reflink.bin				\
+	tree/small.txt
+
+    bcachefs device add -f /mnt "${devs[1]}"
+
+    bcachefs device resize "${devs[0]}" 512M >"$resizeout" 2>&1 &
+    local resizepid=$!
+
+    # target_nbuckets is committed near the start of shrink. Give the ioctl a
+    # short head start, then interrupt it so the restart path has to finish
+    # the persisted shrink on the next mount.
+    sleep 5
+    if ! kill -0 "$resizepid" 2>/dev/null; then
+	wait "$resizepid" || true
+	echo "Shrink completed before interruption; restart-resume test did not exercise resume"
+	cat "$resizeout"
+	return 1
+    fi
+
+    kill -TERM "$resizepid" 2>/dev/null || true
+    wait "$resizepid" || true
+
+    umount /mnt
+
+    mount_mnt "${devs[@]}"
+
+    # Resume should have finished before mount returns; reissuing the same
+    # shrink must now be a no-op instead of "device already resizing".
+    bcachefs device resize "${devs[0]}" 512M
+
+    finish verify_restart_resume "${devs[@]}"
 }
 
 test_online_three_device_targeted_subdirs_shrink()

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -989,4 +989,28 @@ _test_offline_impossible_shrink()
     _do_impossible_shrink offline
 }
 
+test_online_resize_to_zero_buckets_rejected()
+{
+	set_watchdog 60
+	bcachefs_antagonist
+	local devs=("${ktest_scratch_dev[0]}")
+	local resizeout="$ktest_out/resize-to-zero-buckets.out"
+
+	run_quiet "" bcachefs format -f		\
+		--fs_size=1G			\
+		"${devs[0]}"
+
+	mount_mnt "${devs[0]}"
+
+	if bcachefs device resize "${devs[0]}" 0 >"$resizeout" 2>&1; then
+		echo "Resize to 0 buckets unexpectedly succeeded"
+		cat "$resizeout"
+		return 1
+	fi
+
+	assert_resize_target_inactive "${devs[0]}"
+
+	finish "" "${devs[@]}"
+}
+
 main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -13,12 +13,12 @@ config-scratch-devs 4G
 config-scratch-devs 4G
 config-scratch-devs 2G
 
-shrink_mount()
+mount_mnt()
 {
     mount -t bcachefs "$(join_by : "$@")" /mnt
 }
 
-shrink_finish()
+finish()
 {
     local verify_fn=$1
     shift
@@ -29,7 +29,7 @@ shrink_finish()
 
     bcachefs fsck -ny "${devs[@]}"
 
-    shrink_mount "${devs[@]}"
+    mount_mnt "${devs[@]}"
     if [[ -n $verify_fn ]]; then
 	"$verify_fn"
     fi
@@ -38,7 +38,7 @@ shrink_finish()
     bcachefs_test_end_checks "${devs[@]}"
 }
 
-shrink_write_random_file()
+write_random_file()
 {
     local path=$1
     local size_mb=$2
@@ -51,7 +51,7 @@ shrink_write_random_file()
 	status=none
 }
 
-shrink_overwrite_random_file()
+overwrite_random_file()
 {
     local path=$1
     local seek_mb=$2
@@ -67,7 +67,7 @@ shrink_overwrite_random_file()
 	status=none
 }
 
-shrink_run_fio_randrw()
+run_fio_randrw()
 {
     local filename=$1
     shift
@@ -91,7 +91,7 @@ shrink_run_fio_randrw()
 	"$@"
 }
 
-shrink_live_file_churn()
+live_file_churn()
 {
     local dir=$1
     local iterations=$2
@@ -103,7 +103,7 @@ shrink_live_file_churn()
     for i in $(seq 1 "$iterations"); do
 	local file="$dir/file.$i"
 
-	shrink_write_random_file "$file" "$size_mb"
+	write_random_file "$file" "$size_mb"
 	mv "$file" "$file.done"
 
 	if (( i > keep )); then
@@ -112,7 +112,7 @@ shrink_live_file_churn()
     done
 }
 
-shrink_verify_snapshots()
+verify_snapshots()
 {
     (
 	cd /mnt
@@ -121,7 +121,7 @@ shrink_verify_snapshots()
     )
 }
 
-shrink_record_checksums()
+record_checksums()
 {
     local output=$1
     shift
@@ -133,7 +133,7 @@ shrink_record_checksums()
     )
 }
 
-shrink_verify_checksums()
+verify_checksums()
 {
     local output=$1
 
@@ -143,14 +143,14 @@ shrink_verify_checksums()
     )
 }
 
-shrink_populate_metadata_tree()
+populate_metadata_tree()
 {
     local root=$1
 
     mkdir -p "$root/a" "$root/b"
 
-    shrink_write_random_file "$root/a/regular.bin" 256
-    shrink_write_random_file "$root/a/evacuate.bin" 384
+    write_random_file "$root/a/regular.bin" 256
+    write_random_file "$root/a/evacuate.bin" 384
     printf 'metadata survives shrink\n' > "$root/small.txt"
 
     cp --reflink=always "$root/a/regular.bin" "$root/b/reflink.bin"
@@ -166,12 +166,12 @@ shrink_populate_metadata_tree()
     mv "$root/b/reflink.bin" "$root/b/renamed/reflink.bin"
 }
 
-shrink_verify_metadata_tree()
+verify_metadata_tree()
 {
     local root=$1
     local checksums=$2
 
-    shrink_verify_checksums "$checksums"
+    verify_checksums "$checksums"
 
     [[ $(stat -c '%h' "$root/a/regular.bin") = 2 ]]
     [[ $(stat -c '%h' "$root/small.txt") = 2 ]]
@@ -180,19 +180,19 @@ shrink_verify_metadata_tree()
     [[ $(getfattr --only-values -n user.shrink_payload "$root/a/regular.bin" 2>/dev/null) = primary ]]
 }
 
-shrink_verify_xattrs_hardlinks()
+verify_xattrs_hardlinks()
 {
-    shrink_verify_metadata_tree /mnt/tree "$ktest_out/shrink-xattrs.md5"
+    verify_metadata_tree /mnt/tree "$ktest_out/shrink-xattrs.md5"
 }
 
-shrink_verify_replicas_metadata()
+verify_replicas_metadata()
 {
-    shrink_verify_metadata_tree /mnt/tree "$ktest_out/shrink-replicas-metadata.md5"
+    verify_metadata_tree /mnt/tree "$ktest_out/shrink-replicas-metadata.md5"
 }
 
-shrink_verify_targeted_subdirs()
+verify_targeted_subdirs()
 {
-    shrink_verify_checksums "$ktest_out/shrink-targets.md5"
+    verify_checksums "$ktest_out/shrink-targets.md5"
 
     [[ $(getfattr --only-values -n user.shrink_target /mnt/fast/fast.bin 2>/dev/null) = fast ]]
     [[ $(getfattr --only-values -n user.shrink_target /mnt/bulk/bulk.bin 2>/dev/null) = bulk ]]
@@ -211,13 +211,13 @@ test_online_empty_shrink()
 	--fs_size=1G				\
 	"${devs[0]}"
 
-    shrink_mount "${devs[0]}"
+    mount_mnt "${devs[0]}"
 
     df -h /mnt
     bcachefs device resize "${devs[0]}" 500M
     df -h /mnt
 
-    shrink_finish "" "${devs[@]}"
+    finish "" "${devs[@]}"
 }
 
 test_online_two_device_data_shrink()
@@ -231,7 +231,7 @@ test_online_two_device_data_shrink()
 	--fs_size=1G        				\
 	"${devs[0]}"
 
-    shrink_mount "${devs[0]}"
+    mount_mnt "${devs[0]}"
 
     # write 700M data
     dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
@@ -244,7 +244,7 @@ test_online_two_device_data_shrink()
     bcachefs device resize "${devs[0]}" 256M
     df -h /mnt
 
-    shrink_finish "" "${devs[@]}"
+    finish "" "${devs[@]}"
 }
 
 test_online_three_device_replicas_shrink()
@@ -259,7 +259,7 @@ test_online_three_device_replicas_shrink()
 	--fs_size=1G        				\
 	"${devs[0]}" --fs_size=1G "${devs[1]}"
 
-    shrink_mount "${devs[0]}"
+    mount_mnt "${devs[0]}"
 
     # write 700M data
     dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
@@ -272,7 +272,7 @@ test_online_three_device_replicas_shrink()
     bcachefs device resize "${devs[0]}" 256M
     df -h /mnt
 
-    shrink_finish "" "${devs[@]}"
+    finish "" "${devs[@]}"
 }
 
 test_online_three_device_ec_shrink()
@@ -288,7 +288,7 @@ test_online_three_device_ec_shrink()
 	--fs_size=1G        				\
 	"${devs[0]}" --fs_size=1G "${devs[1]}"
 
-    shrink_mount "${devs[0]}"
+    mount_mnt "${devs[0]}"
 
     # write 700M data
     dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
@@ -301,7 +301,7 @@ test_online_three_device_ec_shrink()
     bcachefs device resize "${devs[0]}" 256M
     df -h /mnt
 
-    shrink_finish "" "${devs[@]}"
+    finish "" "${devs[@]}"
 }
 
 test_online_two_device_crypto_compression_shrink_under_randrw()
@@ -316,14 +316,14 @@ test_online_two_device_crypto_compression_shrink_under_randrw()
 	--fs_size=1G				\
 	"${devs[0]}"
 
-    shrink_mount "${devs[0]}"
+    mount_mnt "${devs[0]}"
 
-    shrink_write_random_file /mnt/preseed 384
+    write_random_file /mnt/preseed 384
 
     bcachefs device add -f /mnt "${devs[1]}"
 
     local fioout="$ktest_out/shrink-randrw.out"
-    shrink_run_fio_randrw /mnt/live-randrw	\
+    run_fio_randrw /mnt/live-randrw	\
 	--size=1024M				\
 	--time_based				\
 	--runtime=20 >"$fioout" 2>&1 &
@@ -340,7 +340,7 @@ test_online_two_device_crypto_compression_shrink_under_randrw()
 	return 1
     fi
 
-    shrink_finish "" "${devs[@]}"
+    finish "" "${devs[@]}"
 }
 
 test_online_three_device_variable_buckets_shrink()
@@ -357,12 +357,12 @@ test_online_three_device_variable_buckets_shrink()
 	--promote_target=fast				\
 	--background_target=bulk
 
-    shrink_mount "${devs[@]}"
+    mount_mnt "${devs[@]}"
 
     # Different bucket sizes force shrink to translate per-device cutoffs while
     # relocating foreground extents off the device being reduced.
-    shrink_write_random_file /mnt/variable-buckets 768
-    shrink_run_fio_randrw /mnt/variable-buckets-randrw	\
+    write_random_file /mnt/variable-buckets 768
+    run_fio_randrw /mnt/variable-buckets-randrw	\
 	--size=384M				\
 	--loops=1
 
@@ -370,7 +370,7 @@ test_online_three_device_variable_buckets_shrink()
     bcachefs device resize "${devs[0]}" 768M
     df -h /mnt
 
-    shrink_finish "" "${devs[@]}"
+    finish "" "${devs[@]}"
 }
 
 test_online_three_device_replicas_snapshot_shrink()
@@ -386,12 +386,12 @@ test_online_three_device_replicas_snapshot_shrink()
 	--fs_size=1G				\
 	"${devs[0]}" --fs_size=1G "${devs[1]}"
 
-    shrink_mount "${devs[0]}"
+    mount_mnt "${devs[0]}"
 
     bcachefs subvolume create /mnt/work
 
     for i in $(seq 0 5); do
-	shrink_write_random_file "/mnt/work/file.$i" 48
+	write_random_file "/mnt/work/file.$i" 48
     done
 
     bcachefs subvolume snapshot -r /mnt/work /mnt/snap-before
@@ -412,7 +412,7 @@ test_online_three_device_replicas_snapshot_shrink()
     )
 
     for i in $(seq 0 3); do
-	shrink_overwrite_random_file "/mnt/work/file.$i" $((i * 4 + 2)) 12
+	overwrite_random_file "/mnt/work/file.$i" $((i * 4 + 2)) 12
     done
 
     mkdir /mnt/work/meta
@@ -432,7 +432,7 @@ test_online_three_device_replicas_snapshot_shrink()
     bcachefs device resize "${devs[0]}" 256M
     df -h /mnt
 
-    shrink_finish shrink_verify_snapshots "${devs[@]}"
+    finish verify_snapshots "${devs[@]}"
 }
 
 test_online_two_device_xattrs_hardlinks_shrink()
@@ -446,11 +446,11 @@ test_online_two_device_xattrs_hardlinks_shrink()
 	--fs_size=1G				\
 	"${devs[0]}"
 
-    shrink_mount "${devs[0]}"
+    mount_mnt "${devs[0]}"
 
-    shrink_populate_metadata_tree /mnt/tree
+    populate_metadata_tree /mnt/tree
 
-    shrink_record_checksums "$ktest_out/shrink-xattrs.md5"	\
+    record_checksums "$ktest_out/shrink-xattrs.md5"	\
 	tree/a/regular.bin					\
 	tree/b/evacuate.bin					\
 	tree/b/renamed/reflink.bin				\
@@ -462,7 +462,7 @@ test_online_two_device_xattrs_hardlinks_shrink()
     bcachefs device resize "${devs[0]}" 256M
     df -h /mnt
 
-    shrink_finish shrink_verify_xattrs_hardlinks "${devs[@]}"
+    finish verify_xattrs_hardlinks "${devs[@]}"
 }
 
 test_online_three_device_targeted_subdirs_shrink()
@@ -478,7 +478,7 @@ test_online_three_device_targeted_subdirs_shrink()
 	--promote_target=fast					\
 	--background_target=bulk
 
-    shrink_mount "${devs[0]}" "${devs[2]}"
+    mount_mnt "${devs[0]}" "${devs[2]}"
 
     mkdir /mnt/fast
     mkdir /mnt/bulk
@@ -488,8 +488,8 @@ test_online_three_device_targeted_subdirs_shrink()
     bcachefs set-file-option --foreground_target=bulk /mnt/bulk
     bcachefs set-file-option --background_target=bulk /mnt/bulk
 
-    shrink_write_random_file /mnt/fast/fast.bin 512
-    shrink_write_random_file /mnt/bulk/bulk.bin 256
+    write_random_file /mnt/fast/fast.bin 512
+    write_random_file /mnt/bulk/bulk.bin 256
     printf 'targeted metadata\n' > /mnt/root.meta
     ln /mnt/root.meta /mnt/root.meta.link
     ln -s ../fast/fast.bin /mnt/bulk/link-to-fast
@@ -497,7 +497,7 @@ test_online_three_device_targeted_subdirs_shrink()
     setfattr -n user.shrink_target -v fast /mnt/fast/fast.bin
     setfattr -n user.shrink_target -v bulk /mnt/bulk/bulk.bin
 
-    shrink_record_checksums "$ktest_out/shrink-targets.md5"	\
+    record_checksums "$ktest_out/shrink-targets.md5"	\
 	fast/fast.bin						\
 	bulk/bulk.bin						\
 	root.meta
@@ -508,7 +508,7 @@ test_online_three_device_targeted_subdirs_shrink()
     bcachefs device resize "${devs[0]}" 512M
     df -h /mnt
 
-    shrink_finish shrink_verify_targeted_subdirs "${devs[@]}"
+    finish verify_targeted_subdirs "${devs[@]}"
 }
 
 test_online_three_device_replicas_metadata_under_randrw_shrink()
@@ -523,10 +523,10 @@ test_online_three_device_replicas_metadata_under_randrw_shrink()
 	--fs_size=1G				\
 	"${devs[0]}" --fs_size=1G "${devs[1]}"
 
-    shrink_mount "${devs[0]}"
+    mount_mnt "${devs[0]}"
 
-    shrink_populate_metadata_tree /mnt/tree
-    shrink_record_checksums "$ktest_out/shrink-replicas-metadata.md5"	\
+    populate_metadata_tree /mnt/tree
+    record_checksums "$ktest_out/shrink-replicas-metadata.md5"	\
 	tree/a/regular.bin						\
 	tree/b/evacuate.bin						\
 	tree/b/renamed/reflink.bin					\
@@ -535,7 +535,7 @@ test_online_three_device_replicas_metadata_under_randrw_shrink()
     bcachefs device add -f /mnt "${devs[2]}"
 
     local liveout="$ktest_out/shrink-replicas-metadata-live.out"
-    shrink_live_file_churn /mnt/live 24 8 6 >"$liveout" 2>&1 &
+    live_file_churn /mnt/live 24 8 6 >"$liveout" 2>&1 &
     local livepid=$!
 
     sleep 2
@@ -549,7 +549,7 @@ test_online_three_device_replicas_metadata_under_randrw_shrink()
 	return 1
     fi
 
-    shrink_finish shrink_verify_replicas_metadata "${devs[@]}"
+    finish verify_replicas_metadata "${devs[@]}"
 }
 
 main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -13,118 +13,329 @@ config-scratch-devs 4G
 config-scratch-devs 4G
 config-scratch-devs 2G
 
+shrink_mount()
+{
+    mount -t bcachefs "$(join_by : "$@")" /mnt
+}
+
+shrink_finish()
+{
+    local verify_fn=$1
+    shift
+    local devs=("$@")
+
+    bcachefs fs usage -h --all /mnt
+    umount /mnt
+
+    bcachefs fsck -ny "${devs[@]}"
+
+    shrink_mount "${devs[@]}"
+    if [[ -n $verify_fn ]]; then
+	"$verify_fn"
+    fi
+    umount /mnt
+
+    bcachefs_test_end_checks "${devs[@]}"
+}
+
+shrink_write_random_file()
+{
+    local path=$1
+    local size_mb=$2
+
+    dd if=/dev/urandom of="$path"			\
+	bs=1M					\
+	count="$size_mb"				\
+	iflag=fullblock				\
+	oflag=direct				\
+	status=none
+}
+
+shrink_overwrite_random_file()
+{
+    local path=$1
+    local seek_mb=$2
+    local size_mb=$3
+
+    dd if=/dev/urandom of="$path"			\
+	bs=1M					\
+	count="$size_mb"				\
+	seek="$seek_mb"				\
+	conv=notrunc				\
+	iflag=fullblock				\
+	oflag=direct				\
+	status=none
+}
+
+shrink_run_fio_randrw()
+{
+    local filename=$1
+    shift
+
+    fio						\
+	--eta=always				\
+	--exitall_on_error=1			\
+	--randrepeat=0				\
+	--ioengine=libaio			\
+	--iodepth=64				\
+	--iodepth_batch=16			\
+	--direct=1				\
+	--numjobs=1				\
+	--verify=sha1				\
+	--verify_fatal=1			\
+	--buffer_compress_percentage=30		\
+	--filename="$filename"			\
+	--name=randrw				\
+	--rw=randrw				\
+	--bsrange=4k-512k			\
+	"$@"
+}
+
+shrink_verify_snapshots()
+{
+    (
+	cd /mnt
+	md5sum -c "$ktest_out/shrink-snapshot.md5"
+	md5sum -c "$ktest_out/shrink-reflink.md5"
+    )
+}
+
 
 test_online_empty_shrink()
 {
     set_watchdog 60
     bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}")
 
     run_quiet "" bcachefs format -f		\
 	--fs_size=1G				\
-	${ktest_scratch_dev[0]}
+	"${devs[0]}"
 
-    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+    shrink_mount "${devs[0]}"
 
     df -h /mnt
-    bcachefs device resize ${ktest_scratch_dev[0]} 500M
+    bcachefs device resize "${devs[0]}" 500M
     df -h /mnt
 
-    umount /mnt
-
-    bcachefs fsck -ny ${ktest_scratch_dev[0]}
-    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+    shrink_finish "" "${devs[@]}"
 }
 
 test_online_two_device_data_shrink()
 {
     set_watchdog 60
     bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
 
     # format dev1 to 1G
     run_quiet "" bcachefs format -f		\
 	--fs_size=1G        				\
-	${ktest_scratch_dev[0]}
+	"${devs[0]}"
 
-    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+    shrink_mount "${devs[0]}"
 
     # write 700M data
     dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
 
     # add dev2
-    bcachefs device add -f /mnt ${ktest_scratch_dev[1]}
+    bcachefs device add -f /mnt "${devs[1]}"
 
     # resize dev1 to minimum size -> should evacuate most data to dev2
     df -h /mnt
-    bcachefs device resize ${ktest_scratch_dev[0]} 256M
+    bcachefs device resize "${devs[0]}" 256M
     df -h /mnt
 
-    umount /mnt
-
-    bcachefs fsck -ny "${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}"
-    bcachefs_test_end_checks "${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}"
+    shrink_finish "" "${devs[@]}"
 }
 
 test_online_three_device_replicas_shrink()
 {
     set_watchdog 60
     bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}" "${ktest_scratch_dev[2]}")
 
     # format dev1 and dev2 to 1G, with replicas=2
     run_quiet "" bcachefs format -f		\
 	--replicas=2                        \
 	--fs_size=1G        				\
-	${ktest_scratch_dev[0]} --fs_size=1G ${ktest_scratch_dev[1]}
+	"${devs[0]}" --fs_size=1G "${devs[1]}"
 
-    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+    shrink_mount "${devs[0]}"
 
     # write 700M data
     dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
 
     # add dev3
-    bcachefs device add -f /mnt ${ktest_scratch_dev[2]}
+    bcachefs device add -f /mnt "${devs[2]}"
 
     # resize dev1 to minimum size -> should evacuate most data to dev3 to ensure replicas are met
     df -h /mnt
-    bcachefs device resize ${ktest_scratch_dev[0]} 256M
+    bcachefs device resize "${devs[0]}" 256M
     df -h /mnt
 
-    umount /mnt
-
-    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
-    bcachefs_test_end_checks "${ktest_scratch_dev[@]}"
+    shrink_finish "" "${devs[@]}"
 }
 
 test_online_three_device_ec_shrink()
 {
     set_watchdog 60
     bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}" "${ktest_scratch_dev[2]}")
 
     # format dev1 and dev2 to 1G, with replicas=2
     run_quiet "" bcachefs format -f		\
 	--replicas=2                        \
 	--erasure_code                      \
 	--fs_size=1G        				\
-	${ktest_scratch_dev[0]} --fs_size=1G ${ktest_scratch_dev[1]}
+	"${devs[0]}" --fs_size=1G "${devs[1]}"
 
-    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+    shrink_mount "${devs[0]}"
 
     # write 700M data
     dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
 
     # add dev3
-    bcachefs device add -f /mnt ${ktest_scratch_dev[2]}
+    bcachefs device add -f /mnt "${devs[2]}"
 
     # resize dev1 to minimum size -> should evacuate most data to dev3 to ensure replicas are met
     df -h /mnt
-    bcachefs device resize ${ktest_scratch_dev[0]} 256M
+    bcachefs device resize "${devs[0]}" 256M
     df -h /mnt
 
-    bcachefs fs usage -h --all /mnt
+    shrink_finish "" "${devs[@]}"
+}
 
-    umount /mnt
+test_online_two_device_crypto_compression_shrink_under_randrw()
+{
+    set_watchdog 180
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}")
 
-    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
-    bcachefs_test_end_checks "${ktest_scratch_dev[@]}"
+    run_quiet "" bcachefs format -f		\
+	--encrypted --no_passphrase		\
+	--compression=lz4			\
+	--fs_size=1G				\
+	"${devs[0]}"
+
+    shrink_mount "${devs[0]}"
+
+    shrink_write_random_file /mnt/preseed 384
+
+    bcachefs device add -f /mnt "${devs[1]}"
+
+    local fioout="$ktest_out/shrink-randrw.out"
+    shrink_run_fio_randrw /mnt/live-randrw	\
+	--size=1024M				\
+	--time_based				\
+	--runtime=20 >"$fioout" 2>&1 &
+    local fiopid=$!
+
+    sleep 5
+
+    df -h /mnt
+    bcachefs device resize "${devs[0]}" 256M
+    df -h /mnt
+
+    if ! wait $fiopid; then
+	cat "$fioout"
+	return 1
+    fi
+
+    shrink_finish "" "${devs[@]}"
+}
+
+# Mixed bucket sizes are a relevant shrink configuration, but this still trips
+# no_buckets_found during device reconcile today. Keep the reproducer around so
+# the scenario is easy to re-enable once the implementation is fixed.
+d_test_online_three_device_variable_buckets_shrink()
+{
+    set_watchdog 180
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}" "${ktest_scratch_dev[2]}")
+
+    run_quiet "" bcachefs format -f			\
+	--label=fast --bucket_size=32k	"${devs[0]}"	\
+	--label=bulk --bucket_size=64k	"${devs[1]}"	\
+	--label=bulk --bucket_size=128k	"${devs[2]}"	\
+	--foreground_target=fast				\
+	--promote_target=fast				\
+	--background_target=bulk
+
+    shrink_mount "${devs[@]}"
+
+    # Different bucket sizes force shrink to translate per-device cutoffs while
+    # relocating foreground extents off the device being reduced.
+    shrink_write_random_file /mnt/variable-buckets 768
+    shrink_run_fio_randrw /mnt/variable-buckets-randrw	\
+	--size=384M				\
+	--loops=1
+
+    df -h /mnt
+    bcachefs device resize "${devs[0]}" 768M
+    df -h /mnt
+
+    shrink_finish "" "${devs[@]}"
+}
+
+test_online_three_device_replicas_snapshot_shrink()
+{
+    set_watchdog 180
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}" "${ktest_scratch_dev[2]}")
+
+    run_quiet "" bcachefs format -f		\
+	--replicas=2				\
+	--encrypted --no_passphrase		\
+	--compression=lz4			\
+	--fs_size=1G				\
+	"${devs[0]}" --fs_size=1G "${devs[1]}"
+
+    shrink_mount "${devs[0]}"
+
+    bcachefs subvolume create /mnt/work
+
+    for i in $(seq 0 5); do
+	shrink_write_random_file "/mnt/work/file.$i" 48
+    done
+
+    bcachefs subvolume snapshot -r /mnt/work /mnt/snap-before
+
+    for i in $(seq 0 3); do
+	cp --reflink=always "/mnt/snap-before/file.$i" "/mnt/reflink.$i"
+    done
+
+    (
+	cd /mnt
+	: > "$ktest_out/shrink-snapshot.md5"
+	: > "$ktest_out/shrink-reflink.md5"
+
+	for i in $(seq 0 3); do
+	    md5sum "snap-before/file.$i" >> "$ktest_out/shrink-snapshot.md5"
+	    md5sum "reflink.$i" >> "$ktest_out/shrink-reflink.md5"
+	done
+    )
+
+    for i in $(seq 0 3); do
+	shrink_overwrite_random_file "/mnt/work/file.$i" $((i * 4 + 2)) 12
+    done
+
+    mkdir /mnt/work/meta
+    for dir in $(seq 0 15); do
+	mkdir "/mnt/work/meta/dir.$dir"
+	for file in $(seq 0 15); do
+	    printf 'snapshot-%02d-%02d\n' "$dir" "$file" \
+		> "/mnt/work/meta/dir.$dir/file.$file"
+	done
+    done
+    mv /mnt/work/meta/dir.0/file.0 /mnt/work/meta/dir.0/file.0.renamed
+    ln /mnt/work/meta/dir.1/file.1 /mnt/work/meta/dir.1/file.1.link
+
+    bcachefs device add -f /mnt "${devs[2]}"
+
+    df -h /mnt
+    bcachefs device resize "${devs[0]}" 256M
+    df -h /mnt
+
+    shrink_finish shrink_verify_snapshots "${devs[@]}"
 }
 
 main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -917,21 +917,21 @@ test_online_three_device_replicas_metadata_under_randrw_shrink()
     finish verify_replicas_metadata "${devs[@]}"
 }
 
-test_offline_empty_shrink()
+_test_offline_empty_shrink()
 {
     set_watchdog 60
     bcachefs_antagonist
     _do_empty_shrink offline
 }
 
-test_offline_two_device_data_shrink()
+_test_offline_two_device_data_shrink()
 {
     set_watchdog 120
     bcachefs_antagonist
     _do_two_device_data_shrink offline
 }
 
-test_offline_impossible_shrink()
+_test_offline_impossible_shrink()
 {
     set_watchdog 120
     bcachefs_antagonist

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -1070,4 +1070,46 @@ test_online_resize_to_zero_buckets_rejected()
 	finish "" "${devs[@]}"
 }
 
+# TODO: remove once shrinking is stabilized / no --shrink flag is needed anymore
+_no_shrink_without_flag()
+{
+
+	local mode=$1
+	local devs=("${ktest_scratch_dev[0]}")
+
+	run_quiet "" bcachefs format -f		\
+		--fs_size=1G			\
+		"${devs[0]}"
+
+	if [[ $mode != offline ]]; then
+	    mount_mnt "${devs[0]}"
+	fi
+
+	if bcachefs device resize "${devs[0]}" 512M 2>&1; then
+		echo "Shrink without '--shrink' flag succeeded"
+		cat "$resizeout"
+		return 1
+	fi
+
+	if [[ $mode == offline ]]; then
+	    mount_mnt "${devs[0]}"
+	fi
+
+	finish "" "${devs[@]}"
+}
+test_online_no_shrink_without_flag()
+{
+
+	set_watchdog 60
+	bcachefs_antagonist
+	_no_shrink_without_flag online
+}
+test_offline_no_shrink_without_flag()
+{
+
+	set_watchdog 60
+	bcachefs_antagonist
+	_no_shrink_without_flag offline
+}
+
 main "$@"

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -63,7 +63,7 @@ show_super_buckets()
 assert_member_size_bytes()
 {
     local dev=$1
-    local expected_bytes=$2
+    local expected_bytes=$(numfmt --from=iec "$2")
     local bucket_size_bytes=$(show_super_bucket_size_bytes "$dev")
     local expected_buckets=$((expected_bytes / bucket_size_bytes))
 

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -496,6 +496,8 @@ test_online_four_device_ec_shrink()
 
     dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
 
+    record_checksums "$ktest_out/online-four-device-ec.md5" foo
+
     bcachefs reconcile wait -t erasure_code /mnt
 
     # at this points all three devs should have ~365M
@@ -507,6 +509,8 @@ test_online_four_device_ec_shrink()
     # unmount & remount to trigger scheduled recovery passes. TODO: remove once no longer neccessary
     umount /mnt
     mount_mnt "${devs[0]}"
+
+    verify_checksums "$ktest_out/online-four-device-ec.md5"
 
     finish "" "${devs[@]}"
 }

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -506,9 +506,10 @@ test_online_four_device_ec_shrink()
 
     bcachefs device resize "${devs[0]}" 256M # (should) shrink only ~5M away
 
-    # unmount & remount to trigger scheduled recovery passes. TODO: remove once no longer neccessary
+    # unmount & remount to trigger scheduled accounting recovery pass, and expect accounting_mismatch. TODO: remove once no longer neccessary
     umount /mnt
     mount_mnt "${devs[0]}"
+    ktest_expect_errors=accounting_mismatch
 
     verify_checksums "$ktest_out/online-four-device-ec.md5"
 
@@ -548,9 +549,10 @@ test_online_minimal_ec_shrink()
 
     bcachefs device resize "${devs[0]}" 362M # (should) shrink only ~2M away
 
-    # unmount & remount to trigger scheduled recovery passes. TODO: remove once no longer neccessary
+    # unmount & remount to trigger scheduled accounting recovery pass, and expect accounting_mismatch. TODO: remove once no longer neccessary
     umount /mnt
     mount_mnt "${devs[0]}"
+    ktest_expect_errors=accounting_mismatch
 
     finish "" "${devs[@]}"
 }

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -1025,21 +1025,21 @@ test_online_shrink_then_cancel()
     finish "" "${devs[@]}"
 }
 
-_test_offline_empty_shrink()
+test_offline_empty_shrink()
 {
     set_watchdog 60
     bcachefs_antagonist
     _do_empty_shrink offline
 }
 
-_test_offline_two_device_data_shrink()
+test_offline_two_device_data_shrink()
 {
     set_watchdog 120
     bcachefs_antagonist
     _do_two_device_data_shrink offline
 }
 
-_test_offline_impossible_shrink()
+test_offline_impossible_shrink()
 {
     set_watchdog 120
     bcachefs_antagonist

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -89,7 +89,7 @@ offline_device_resize()
     local dev=$1
     local size=$2
 
-    bcachefs device resize "$dev" "$size"
+    bcachefs device resize --shrink "$dev" "$size"
     assert_member_size_bytes "$dev" "$size"
     assert_resize_target_inactive "$dev"
 }
@@ -111,7 +111,7 @@ _do_empty_shrink()
 	offline_device_resize "${devs[0]}" 500M
 	mount_mnt "${devs[0]}"
     else
-	bcachefs device resize "${devs[0]}" 500M
+	bcachefs device resize --shrink "${devs[0]}" 500M
     fi
 
     df -h /mnt
@@ -139,7 +139,7 @@ _do_two_device_data_shrink()
 	offline_device_resize "${devs[0]}" 256M
 	mount_mnt "${devs[@]}"
     else
-	bcachefs device resize "${devs[0]}" 256M
+	bcachefs device resize --shrink "${devs[0]}" 256M
     fi
 
     verify_checksums "$ktest_out/do-two-device-data.md5"
@@ -169,7 +169,7 @@ _do_impossible_shrink()
 	umount /mnt
     fi
 
-    if bcachefs device resize "${devs[0]}" 256M >"$resizeout" 2>&1; then
+    if bcachefs device resize --shrink "${devs[0]}" 256M >"$resizeout" 2>&1; then
 	echo "Impossible shrink unexpectedly succeeded"
 	cat "$resizeout"
 	return 1
@@ -459,7 +459,7 @@ test_online_three_device_replicas_shrink()
 
     # resize dev1 to minimum size -> should evacuate most data to dev3 to ensure replicas are met
     df -h /mnt
-    bcachefs device resize "${devs[0]}" 256M
+    bcachefs device resize --shrink "${devs[0]}" 256M
     df -h /mnt
 
     finish "" "${devs[@]}"
@@ -504,7 +504,7 @@ test_online_four_device_ec_shrink()
 
     bcachefs device add -f /mnt --bucket_size=512k "${devs[3]}"
 
-    bcachefs device resize "${devs[0]}" 256M # (should) shrink only ~5M away
+    bcachefs device resize --shrink "${devs[0]}" 256M # (should) shrink only ~5M away
 
     # unmount & remount to trigger scheduled accounting recovery pass, and expect accounting_mismatch. TODO: remove once no longer neccessary
     umount /mnt
@@ -547,7 +547,7 @@ test_online_minimal_ec_shrink()
 
     bcachefs device add -f /mnt --bucket_size=512k "${devs[3]}"
 
-    bcachefs device resize "${devs[0]}" 362M # (should) shrink only ~2M away
+    bcachefs device resize --shrink "${devs[0]}" 362M # (should) shrink only ~2M away
 
     # unmount & remount to trigger scheduled accounting recovery pass, and expect accounting_mismatch. TODO: remove once no longer neccessary
     umount /mnt
@@ -585,7 +585,7 @@ test_online_two_device_crypto_compression_shrink_under_randrw()
     sleep 5
 
     df -h /mnt
-    bcachefs device resize "${devs[0]}" 256M
+    bcachefs device resize --shrink "${devs[0]}" 256M
     df -h /mnt
 
     if ! wait $fiopid; then
@@ -620,7 +620,7 @@ test_online_three_device_variable_buckets_shrink()
 	--loops=1
 
     df -h /mnt
-    bcachefs device resize "${devs[0]}" 768M
+    bcachefs device resize --shrink "${devs[0]}" 768M
     df -h /mnt
 
     finish "" "${devs[@]}"
@@ -682,7 +682,7 @@ test_online_three_device_replicas_snapshot_shrink()
     bcachefs device add -f /mnt "${devs[2]}"
 
     df -h /mnt
-    bcachefs device resize "${devs[0]}" 256M
+    bcachefs device resize --shrink "${devs[0]}" 256M
     df -h /mnt
 
     finish verify_snapshots "${devs[@]}"
@@ -712,7 +712,7 @@ test_online_two_device_xattrs_hardlinks_shrink()
     bcachefs device add -f /mnt "${devs[1]}"
 
     df -h /mnt
-    bcachefs device resize "${devs[0]}" 256M
+    bcachefs device resize --shrink "${devs[0]}" 256M
     df -h /mnt
 
     finish verify_xattrs_hardlinks "${devs[@]}"
@@ -744,7 +744,7 @@ test_online_two_device_restart_resume_shrink()
 
     bcachefs device add -f /mnt "${devs[1]}"
 
-    bcachefs device resize "${devs[0]}" 512M >"$resizeout" 2>&1 &
+    bcachefs device resize --shrink "${devs[0]}" 512M >"$resizeout" 2>&1 &
     local resizepid=$!
 
     # Kill the ioctl after the target is safely persisted so the next mount
@@ -760,7 +760,7 @@ test_online_two_device_restart_resume_shrink()
 
     # Resume should have finished before mount returns; reissuing the same
     # shrink must now be a no-op instead of "device already resizing".
-    bcachefs device resize "${devs[0]}" 512M
+    bcachefs device resize --shrink "${devs[0]}" 512M
 
     finish verify_restart_resume "${devs[@]}"
 }
@@ -795,11 +795,11 @@ test_online_two_device_shrink_retarget_larger()
 
     bcachefs device add -f /mnt "${devs[1]}"
 
-    bcachefs device resize "${devs[0]}" 512M >"$resizeout" 2>&1 &
+    bcachefs device resize --shrink "${devs[0]}" 512M >"$resizeout" 2>&1 &
     local resizepid=$!
 
     wait_for_resize_to_start "$resizepid" "$resizeout"
-    bcachefs device resize "${devs[0]}" 1G
+    bcachefs device resize --shrink "${devs[0]}" 1G
     wait_for_canceled_resize "$resizepid" "$resizeout"
 
     finish verify_retarget_resize "${devs[@]}"
@@ -837,11 +837,11 @@ test_online_two_device_shrink_retarget_cancel()
 
     bcachefs device add -f /mnt "${devs[1]}"
 
-    bcachefs device resize "${devs[0]}" 512M >"$resizeout" 2>&1 &
+    bcachefs device resize --shrink "${devs[0]}" 512M >"$resizeout" 2>&1 &
     local resizepid=$!
 
     wait_for_resize_to_start "$resizepid" "$resizeout"
-    bcachefs device resize "${devs[0]}" 3G
+    bcachefs device resize --shrink "${devs[0]}" 3G
     wait_for_canceled_resize "$resizepid" "$resizeout"
 
     finish verify_retarget_resize "${devs[@]}"
@@ -877,11 +877,11 @@ test_online_two_device_shrink_retarget_grow()
 
     bcachefs device add -f /mnt "${devs[1]}"
 
-    bcachefs device resize "${devs[0]}" 512M >"$resizeout" 2>&1 &
+    bcachefs device resize --shrink "${devs[0]}" 512M >"$resizeout" 2>&1 &
     local resizepid=$!
 
     wait_for_resize_to_start "$resizepid" "$resizeout"
-    bcachefs device resize "${devs[0]}" 3584M
+    bcachefs device resize --shrink "${devs[0]}" 3584M
     wait_for_canceled_resize "$resizepid" "$resizeout"
 
     finish verify_retarget_resize "${devs[@]}"
@@ -927,7 +927,7 @@ test_online_three_device_targeted_subdirs_shrink()
     bcachefs device add -f --label=fast /mnt "${devs[1]}"
 
     df -h /mnt
-    bcachefs device resize "${devs[0]}" 512M
+    bcachefs device resize --shrink "${devs[0]}" 512M
     df -h /mnt
 
     finish verify_targeted_subdirs "${devs[@]}"
@@ -963,7 +963,7 @@ test_online_three_device_replicas_metadata_under_randrw_shrink()
     sleep 2
 
     df -h /mnt
-    bcachefs device resize "${devs[0]}" 512M
+    bcachefs device resize --shrink "${devs[0]}" 512M
     df -h /mnt
 
     if ! wait $livepid; then
@@ -992,11 +992,11 @@ test_online_shrink_cancel()
     dd if=/dev/urandom of=/mnt/payload bs=1M count=750 oflag=direct
     bcachefs device add -f /mnt "${devs[1]}"
 
-    bcachefs device resize "${devs[0]}" 200M >"$resizeout" 2>&1 &
+    bcachefs device resize --shrink "${devs[0]}" 200M >"$resizeout" 2>&1 &
     local resizepid=$!
 
     wait_for_resize_to_start "$resizepid" "$resizeout"
-    bcachefs device resize "${devs[0]}" cancel
+    bcachefs device resize --shrink "${devs[0]}" cancel
     wait_for_canceled_resize "$resizepid" "$resizeout"
 
     assert_member_size_bytes "${devs[0]}" $initial_size_bytes
@@ -1016,9 +1016,9 @@ test_online_shrink_then_cancel()
 
     mount_mnt "${devs[0]}"
 
-    bcachefs device resize "${devs[0]}" 500M
+    bcachefs device resize --shrink "${devs[0]}" 500M
 
-    bcachefs device resize "${devs[0]}" cancel
+    bcachefs device resize --shrink "${devs[0]}" cancel
 
     assert_member_size_bytes "${devs[0]}" $((500 * 1024 * 1024))
     assert_resize_target_inactive "${devs[0]}"
@@ -1059,7 +1059,7 @@ test_online_resize_to_zero_buckets_rejected()
 
 	mount_mnt "${devs[0]}"
 
-	if bcachefs device resize "${devs[0]}" 0 >"$resizeout" 2>&1; then
+	if bcachefs device resize --shrink "${devs[0]}" 0 >"$resizeout" 2>&1; then
 		echo "Resize to 0 buckets unexpectedly succeeded"
 		cat "$resizeout"
 		return 1

--- a/tests/fs/bcachefs/shrink.ktest
+++ b/tests/fs/bcachefs/shrink.ktest
@@ -472,7 +472,7 @@ test_online_two_device_replicas_impossible_shrink()
     _do_impossible_shrink online
 }
 
-test_online_three_device_ec_shrink()
+test_online_four_device_ec_shrink()
 {
     set_watchdog 60
     bcachefs_antagonist
@@ -498,12 +498,55 @@ test_online_three_device_ec_shrink()
 
     bcachefs reconcile wait -t erasure_code /mnt
 
+    # at this points all three devs should have ~365M
+
     bcachefs device add -f /mnt --bucket_size=512k "${devs[3]}"
 
-    # resize dev1 to minimum size -> should evacuate most data to dev4 to ensure replicas are met
-    df -h /mnt
-    bcachefs device resize "${devs[0]}" 256M
-    df -h /mnt
+    bcachefs device resize "${devs[0]}" 256M # (should) shrink only ~5M away
+
+    # unmount & remount to trigger scheduled recovery passes. TODO: remove once no longer neccessary
+    umount /mnt
+    mount_mnt "${devs[0]}"
+
+    finish "" "${devs[@]}"
+}
+
+
+test_online_minimal_ec_shrink()
+{
+    set_watchdog 60
+    bcachefs_antagonist
+    local devs=("${ktest_scratch_dev[0]}" "${ktest_scratch_dev[1]}" "${ktest_scratch_dev[2]}" "${ktest_scratch_dev[3]}")
+
+    # format dev1 and dev2 to 1G, with replicas=2
+    run_quiet "" bcachefs format -f		\
+	--replicas=2                        \
+	--erasure_code                      \
+	--fs_size=1G        				\
+	--bucket_size=512k                  \
+	"${devs[0]}"                        \
+	--fs_size=1G        				\
+	--bucket_size=512k                  \
+	"${devs[1]}"                        \
+	--fs_size=1G        				\
+	--bucket_size=512k                  \
+	"${devs[2]}"
+
+    mount_mnt "${devs[0]}"
+
+    dd if=/dev/urandom of=/mnt/foo bs=1M count=700 oflag=direct
+
+    bcachefs reconcile wait -t erasure_code /mnt
+
+    # at this points all three devs should have ~365M
+
+    bcachefs device add -f /mnt --bucket_size=512k "${devs[3]}"
+
+    bcachefs device resize "${devs[0]}" 362M # (should) shrink only ~2M away
+
+    # unmount & remount to trigger scheduled recovery passes. TODO: remove once no longer neccessary
+    umount /mnt
+    mount_mnt "${devs[0]}"
 
     finish "" "${devs[@]}"
 }

--- a/tests/fs/bcachefs/single_device.ktest
+++ b/tests/fs/bcachefs/single_device.ktest
@@ -1161,27 +1161,6 @@ test_online_grow()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
-test_online_empty_shrink()
-{
-    set_watchdog 60
-    bcachefs_antagonist
-
-    run_quiet "" bcachefs format -f		\
-	--fs_size=1G				\
-	${ktest_scratch_dev[0]}
-
-    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
-
-    df -h /mnt
-    bcachefs device resize ${ktest_scratch_dev[0]} 500M
-    df -h /mnt
-
-    umount /mnt
-
-    bcachefs fsck -ny ${ktest_scratch_dev[0]}
-    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
-}
-
 test_offline_grow()
 {
     set_watchdog 60

--- a/tests/fs/bcachefs/single_device.ktest
+++ b/tests/fs/bcachefs/single_device.ktest
@@ -755,7 +755,7 @@ test_lz4_buffered()
     echo starting copy
     cp -rx /usr /mnt/foo || true
 
-    echo starting sync 
+    echo starting sync
     sync
 
     echo starting rm
@@ -1140,7 +1140,7 @@ test_journal_torture()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
-test_online_resize()
+test_online_grow()
 {
     set_watchdog 60
     bcachefs_antagonist
@@ -1161,7 +1161,28 @@ test_online_resize()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
-test_offline_resize()
+test_online_empty_shrink()
+{
+    set_watchdog 60
+    bcachefs_antagonist
+
+    run_quiet "" bcachefs format -f		\
+	--fs_size=1G				\
+	${ktest_scratch_dev[0]}
+
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    df -h /mnt
+    bcachefs device resize ${ktest_scratch_dev[0]} 500M
+    df -h /mnt
+
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+test_offline_grow()
 {
     set_watchdog 60
     bcachefs_antagonist

--- a/tests/fs/bcachefs/single_device.ktest
+++ b/tests/fs/bcachefs/single_device.ktest
@@ -1186,6 +1186,31 @@ test_offline_grow()
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
 }
 
+test_offline_grow_to_size()
+{
+    set_watchdog 60
+    bcachefs_antagonist
+
+    run_quiet "" bcachefs format -f		\
+	--fs_size=1G				\
+	${ktest_scratch_dev[0]}
+
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+    dd if=/dev/urandom of=/mnt/grow.bin bs=1M count=256 oflag=direct
+    umount /mnt
+
+    bcachefs device resize ${ktest_scratch_dev[0]} $((2 * 1024 * 1024 * 1024))
+    bcachefs show-super ${ktest_scratch_dev[0]}
+
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+    df -h /mnt
+    dd if=/mnt/grow.bin of=/dev/null bs=1M count=256 iflag=direct
+    umount /mnt
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
 require-kernel-config BLK_DEV_DM
 
 test_offline_resize_lv()


### PR DESCRIPTION
Add tests for [shrinking](https://github.com/koverstreet/bcachefs/pull/1073). These need to be executed with both a compatible [bcachefs-tools and kernel](https://github.com/koverstreet/bcachefs-tools/pull/796).