### PR TITLE
Memory-pressure stress tests for swap-on-bcachefs; supervisor timeout escalation

### DIFF
--- a/lib/supervisor.c
+++ b/lib/supervisor.c
@@ -73,18 +73,51 @@ static void child_handler(int sig)
 	exit(EXIT_FAILURE);
 }
 
+/*
+ * Timeout handling escalates: the first alarm injects the FAILED TIMEOUT
+ * marker into the guest console — a live guest echoes it back through the
+ * output stream, landing it in the logs in order, where the -S/-F exit
+ * logic sees it.  But a wedged guest (e.g. a reclaim-deadlocked kernel:
+ * console spewing workqueue lockups, nothing reading stdin) echoes
+ * nothing, and the supervisor would previously wait on it forever.  So
+ * give the echo a grace period, then SIGTERM the child (the preemptively
+ * written "TEST FAILED" status stands and SIGCHLD ends the supervisor),
+ * then SIGKILL if even that doesn't stick.
+ */
+static volatile sig_atomic_t timeout_stage;
+
 static void alarm_handler(int sig)
 {
 	char *msg = mprintf("========= FAILED TIMEOUT %s in %lus\n",
 			    current_test ?: "(no test)", timeout);
 
-	if (write(childfd, msg, strlen(msg)) != strlen(msg))
-		die("write error in alarm handler");
+	switch (timeout_stage++) {
+	case 0:
+		if (write(childfd, msg, strlen(msg)) == (ssize_t) strlen(msg)) {
+			alarm(30);
+			break;
+		}
+		/* Console not even accepting input: skip straight to kill. */
+		timeout_stage++;
+		/* fallthrough */
+	case 1:
+		fputs(msg, stderr);
+		fputs("guest did not echo timeout marker, killing it\n", stderr);
+		kill(child, SIGTERM);
+		alarm(10);
+		break;
+	default:
+		fputs("child ignored SIGTERM, sending SIGKILL\n", stderr);
+		kill(child, SIGKILL);
+		alarm(10);
+		break;
+	}
 	free(msg);
 }
 
 static void set_timeout(unsigned long new_timeout)
 {
+	timeout_stage = 0;
 	timeout = new_timeout;
 	alarm(new_timeout);
 }
@@ -185,6 +218,11 @@ static FILE *popen_with_pid(char *argv[], pid_t *child)
 	}
 
 	childfd = pipefd[1];
+	/* The alarm handler writes to this from signal context; a wedged
+	 * guest can leave the console pipe full, and a blocking write would
+	 * hang the handler before it can escalate to killing the child. */
+	if (fcntl(childfd, F_SETFL, O_NONBLOCK))
+		die("fcntl error: %m");
 
 	FILE *childf = fdopen(pipefd[0], "r");
 	if (!childf)

--- a/root_image_noloop
+++ b/root_image_noloop
@@ -1,0 +1,439 @@
+#!/usr/bin/env bash
+#
+# Create a VM image suitable for running automated tests
+# Output: vm_image
+
+set -o nounset
+set -o errexit
+set -o errtrace
+
+ktest_dir=$(dirname "$(readlink -f "$0")")
+debootstrap=$ktest_dir/debootstrap/debootstrap
+
+. "$ktest_dir/lib/util.sh"
+. "$ktest_dir/lib/common.sh"
+
+if [[ $(id -u) != 0 && "$1" != "sync" ]] ; then
+    echo this script must be run as root
+    exit 1
+fi
+
+checkdep fallocate util-linux
+checkdep mkfs.ext4 e2fsprogs
+checkdep curl 
+
+IMAGE_SIZE="16G"
+MIRROR=https://deb.debian.org/debian/
+RELEASE=sid
+
+usage()
+{
+    echo "root_image: create/update virtual machine root images for ktest"
+    echo "Usage: root_image cmd [options]"
+    echo "  create		Create a new image"
+    echo "  update		Update an existing image"
+    echo "  sync		Copy directory to an existing image"
+    echo
+    echo "options:"
+    echo "  -h			Display this help and exit"
+    echo "  -a <arch>		Architecture for vm image"
+    echo "  -m <mirror>		Debian mirror"
+    echo '  -i <image>		Image to create/update, defaults to /var/lib/ktest/root.$arch'
+}
+
+if [[ $# = 0 ]]; then
+    usage
+    exit 1
+fi
+
+ktest_image=""
+CMD="cmd_$1"
+shift
+
+while getopts "ha:m:i:" arg; do
+    case $arg in
+	h)
+	    usage
+	    exit 0
+	    ;;
+	a)
+	    ktest_arch=$OPTARG
+	    ;;
+	m)
+	    MIRROR=$OPTARG
+	    ;;
+	i)
+	    ktest_image=$OPTARG
+	    ;;
+    esac
+done
+shift $(( OPTIND - 1 ))
+
+parse_arch "$ktest_arch"
+
+[[ -z $ktest_image ]] && ktest_image=/var/lib/ktest/root.$DEBIAN_ARCH
+
+mkdir -p "$(dirname "$ktest_image")"
+
+PACKAGES=(kexec-tools less psmisc openssh-server curl		\
+    pciutils							\
+    pkg-config libtool-bin					\
+    gdb strace linux-perf trace-cmd blktrace sysstat iotop htop	\
+    bpfcc-tools bpftrace					\
+    hdparm mdadm lvm2						\
+    btrfs-progs jfsutils nilfs-tools f2fs-tools			\
+    bc attr gawk acl rsync git python3-docutils			\
+    stress-ng lsof xxd zstd ripgrep bpfcc-tools)
+
+# build tools:
+PACKAGES+=(build-essential make gcc g++ clang lld)
+PACKAGES+=(autoconf automake autopoint bison flex pahole)
+PACKAGES+=(cargo mold)
+PACKAGES+=(rustc rust-src rust-analyzer librust-bindgen-dev bindgen)
+PACKAGES+=(devscripts debhelper sbuild dh-sequence-dkms dkms)
+
+# stress testing:
+PACKAGES+=(fio dbench bonnie++ fsmark)
+
+# bcachefs-tools build dependencies:
+PACKAGES+=(libblkid-dev uuid-dev libscrypt-dev libsodium-dev)
+PACKAGES+=(libkeyutils-dev liburcu-dev libudev-dev zlib1g-dev libattr1-dev systemd-dev)
+PACKAGES+=(libaio-dev libzstd-dev liblz4-dev libfuse3-dev valgrind)
+PACKAGES+=(llvm libclang-dev libunwind-dev)
+
+# quota tools:
+PACKAGES+=(libudev-dev libldap2-dev)
+
+# xfstests:
+PACKAGES+=(acct bsdextrautils xfsprogs xfslibs-dev quota libcap2-bin)
+PACKAGES+=(libattr1-dev libaio-dev libgdbm-dev libacl1-dev gettext)
+PACKAGES+=(libssl-dev libgdbm-dev libgdbm-compat-dev liburing-dev)
+PACKAGES+=(duperemove fsverity)
+
+# xfsprogs:
+PACKAGES+=(libinih-dev)
+
+# bcachefs:
+# Not currently packaged by debian:
+#PACKAGES+=(bcachefs-tools)
+
+# nfs testing:
+PACKAGES+=(nfs-kernel-server)
+
+# ocfs2 testing:
+PACKAGES+=(ocfs2-tools)
+
+# afs
+PACKAGES+=(openafs-dbserver openafs-fileserver)
+
+# nbd testing
+PACKAGES+=(nbd-client nbd-server)
+
+# dm testing:
+PACKAGES+=(cryptsetup)
+
+# weird block layer crap
+PACKAGES+=(multipath-tools sg3-utils srptools)
+
+# PuzzleFS support
+PACKAGES+=(capnproto jq)
+
+PACKAGES+=(erofs-utils squashfs-tools-ng)
+
+# ZFS support
+#PACKAGES+=("linux-headers-generic" dkms zfsutils-linux zfs-dkms)
+
+# Lustre support
+PACKAGES+=(libyaml-0-2 libyaml-dev)
+
+# suspend testing:
+# [[ $KERNEL_ARCH = x86 ]] && PACKAGES+=(uswsusp)
+
+EXCLUDE=(dmidecode nano rsyslog logrotate cron		\
+    iptables nfacct					\
+    debconf-i18n info gnupg libpam-systemd)
+
+SYSTEMD_MASK=(dev-hvc0.device				\
+    getty.target					\
+    getty-static.service				\
+    avahi-daemon.service				\
+    crond.service					\
+    exim4.service					\
+    kdump.service					\
+    hdparm.service					\
+    cdrom.mount						\
+    mdadm-raid.service					\
+    lvm2-activation-early.service			\
+    aoetools.service					\
+    sysstat.service					\
+    kexec-load.service					\
+    kexec.service					\
+    systemd-ask-password-console.path			\
+    systemd-ask-password-wall.path			\
+    systemd-update-utmp-runlevel.service		\
+    systemd-update-utmp.service				\
+    time-sync.target					\
+    multipathd.service)
+
+export DEBIAN_FRONTEND=noninteractive
+export DEBCONF_NONINTERACTIVE_SEEN=true
+export LC_ALL=C
+export LANGUAGE=C
+export LANG=C
+# We compute it here to avoid on hosts systems (e.g. NixOS)
+# that does not possess `chroot` in the isolated `PATH`
+# to fail miserably.
+export CHROOT=$(command -v chroot)
+
+_chroot()
+{
+    PATH=/usr/sbin:/usr/bin:/sbin:/bin "$CHROOT" "$@"
+}
+
+update_files()
+{
+    install -m0644 "$ktest_dir/lib/fstab" "$MNT/etc/fstab"
+    install -m0755 "$ktest_dir/lib/testrunner.wrapper" "$MNT/sbin/testrunner.wrapper"
+    install -m0644 "$ktest_dir/lib/testrunner.service" "$MNT/lib/systemd/system/testrunner.service"
+
+    ln -sf /lib/systemd/system/testrunner.service "$MNT/etc/systemd/system/multi-user.target.wants/testrunner.service"
+
+    touch "$MNT/etc/resolv.conf"
+    chmod 644 "$MNT/etc/resolv.conf"
+
+    mkdir -p "$MNT/root/"
+    install -m0644 "$MNT/etc/skel/.bashrc" "$MNT/root/"
+    install -m0644 "$MNT/etc/skel/.profile" "$MNT/root/"
+
+    cat >> "$MNT/root/.bashrc" <<-ZZ
+    export PROMPT_COMMAND="history -a; \$PROMPT_COMMAND"
+ZZ
+
+    mkdir -p "$MNT/var/log/core"
+    chmod 777 "$MNT/var/log/core"
+
+    # Disable systemd/udev stuff we don't need:
+
+    # systemctl mask doesn't work for foreign archs
+    #_chroot "$MNT" systemctl mask "${SYSTEMD_MASK[@]}"
+
+    for i in "${SYSTEMD_MASK[@]}"; do
+	(cd "$MNT/etc/systemd/system"; ln -sf /dev/null "$i")
+    done
+
+    cat > "$MNT/etc/systemd/journald.conf" <<-ZZ
+[Journal]
+Storage=none
+ForwardToConsole=no
+MaxLevelConsole=emerg
+ZZ
+
+    mkdir -p "$MNT/etc/network"
+    cat > "$MNT/etc/network/interfaces" <<-ZZ
+auto lo
+iface lo inet loopback
+
+auto eth0
+iface eth0 inet dhcp
+ZZ
+
+    # disable network interface renaming - it's unreliable
+    mkdir -p "$MNT/etc/udev/rules.d/"
+    ln -sf /dev/null "$MNT/etc/udev/rules.d/80-net-setup-link.rules"
+
+    rm -f "$MNT/lib/udev/rules.d/*persistent*"
+    rm -f "$MNT/lib/udev/rules.d/*lvm*"
+    rm -f "$MNT/lib/udev/rules.d/*dm*"
+    rm -f "$MNT/lib/udev/rules.d/*md-raid*"
+    rm -f "$MNT/lib/udev/rules.d/*btrfs*"
+    rm -f "$MNT/lib/udev/rules.d/*hdparm*"
+
+    echo $(hostname)-kvm > "$MNT/etc/hostname"
+
+    ln -sf /ktest-out/.bash_history "$MNT/root/.bash_history"
+}
+
+update_packages()
+{
+    # systemd... !?
+    mkdir -p "$MNT"/run/user/0
+    cp /etc/resolv.conf "$MNT/etc/resolv.conf"
+
+    mkdir -p "$MNT"/etc/dpkg/dpkg.cfg.d/
+    echo force-unsafe-io > "$MNT"/etc/dpkg/dpkg.cfg.d/dpkg-unsafe
+
+    _chroot "$MNT" mount -t proc none /proc
+    _chroot "$MNT" apt-get -qq update
+    _chroot "$MNT" apt-get -qq upgrade
+    _chroot "$MNT" apt-get -qq install --no-install-recommends "${PACKAGES[@]}"
+    rm -f "$MNT/var/cache/apt/archives/*.deb"
+}
+
+_umount_image()
+{
+    umount --recursive "$MNT"
+    rmdir "$MNT"
+    trap '' EXIT
+}
+
+umount_image()
+{
+    _umount_image
+
+    e2fsck -y -f "$ktest_image".new
+    resize2fs -M "$ktest_image".new		# shrinks the file
+    resize2fs "$ktest_image".new "$IMAGE_SIZE"	# re-grows as sparse
+    mv "$ktest_image".new "$ktest_image"
+}
+
+mount_image()
+{
+    MNT=$(mktemp --tmpdir -d $(basename "$0")-XXXXXXXXXX)
+    trap '_umount_image; rm -f "$ktest_image".new' EXIT
+
+    cp "$ktest_image" "$ktest_image".new
+    mount "$ktest_image".new "$MNT"
+}
+
+cmd_update()
+{
+    if [[ ! -e $ktest_image ]]; then
+	echo "$ktest_image does not exist"
+	exit 1
+    fi
+
+    mount_image
+    update_packages
+    update_files
+    umount_image
+}
+
+cmd_update_files()
+{
+    if [[ ! -e $ktest_image ]]; then
+	echo "$ktest_image does not exist"
+	exit 1
+    fi
+
+    mount_image
+    update_files
+    umount_image
+}
+
+cmd_sync() {
+    local source="${1:-$(pwd)/}"
+    local source_dir="$(basename "$source")"
+    local new_img="/tmp/ktest-out/$(basename $ktest_image).new"
+
+    cp "$ktest_image" "$new_img"
+
+    # Remove old directory
+    guestfish -a "$new_img" -m /dev/sda:/ rm-rf "/workspace/"
+    guestfish -a "$new_img" -m /dev/sda:/ mkdir-p "/workspace/lustre-release"
+
+    # Copy new directory in
+    virt-copy-in -a "$new_img" "$source/." /workspace/lustre-release
+}
+
+cmd_init()
+{
+    (cd "$ktest_dir"; git submodule update --init debootstrap)
+}
+
+cmd_create()
+{
+    if ! [[ -f $debootstrap ]]; then
+	echo "Run root_image init to prep debootstrap"
+	exit 1
+    fi
+
+    if [[ -e $ktest_image ]]; then
+	echo "$ktest_image already exists"
+	exit 1
+    fi
+
+    MNT=$(mktemp --tmpdir -d $(basename "$0")-XXXXXXXXXX)
+    trap '_umount_image; rm -f "$ktest_image".new' EXIT
+
+    fallocate -l "$IMAGE_SIZE" "$ktest_image".new
+    chmod 644 "$ktest_image".new
+    mkfs.ext4 -F "$ktest_image".new
+    mount "$ktest_image".new "$MNT"
+
+    mkdir -p "$MNT"/etc/dpkg/dpkg.cfg.d/
+    echo force-unsafe-io > "$MNT"/etc/dpkg/dpkg.cfg.d/dpkg-unsafe
+
+    DEBOOTSTRAP_DIR=$ktest_dir/debootstrap $debootstrap	\
+	--no-check-gpg					\
+	--arch="$DEBIAN_ARCH"				\
+	--exclude=$(join_by , "${EXCLUDE[@]}")		\
+	--no-merged-usr					\
+	--foreign					\
+	$RELEASE "$MNT" "$MIRROR"
+    mkdir -p "$MNT"/etc/dpkg/dpkg.cfg.d/
+    echo force-unsafe-io > "$MNT"/etc/dpkg/dpkg.cfg.d/dpkg-unsafe
+
+    _chroot "$MNT" /debootstrap/debootstrap --second-stage
+    _chroot "$MNT" dpkg --configure -a
+
+    update_packages
+    update_files
+    umount_image
+}
+
+
+cmd_create_noloop()
+{
+    if ! [[ -f $debootstrap ]]; then
+	echo "Run root_image init to prep debootstrap"
+	exit 1
+    fi
+
+    if [[ -e $ktest_image ]]; then
+	echo "$ktest_image already exists"
+	exit 1
+    fi
+
+    MNT=$(mktemp --tmpdir=/var/lib/ktest -d rootdir-build-XXXXXXXXXX)
+    trap 'umount --recursive "$MNT" 2>/dev/null || true; rm -rf "$MNT" "$ktest_image".new' EXIT
+
+    mkdir -p "$MNT"/etc/dpkg/dpkg.cfg.d/
+    echo force-unsafe-io > "$MNT"/etc/dpkg/dpkg.cfg.d/dpkg-unsafe
+
+    DEBOOTSTRAP_DIR=$ktest_dir/debootstrap $debootstrap	\
+	--no-check-gpg					\
+	--arch="$DEBIAN_ARCH"				\
+	--exclude=$(join_by , "${EXCLUDE[@]}")		\
+	--no-merged-usr					\
+	--foreign					\
+	$RELEASE "$MNT" "$MIRROR"
+    mkdir -p "$MNT"/etc/dpkg/dpkg.cfg.d/
+    echo force-unsafe-io > "$MNT"/etc/dpkg/dpkg.cfg.d/dpkg-unsafe
+
+    _chroot "$MNT" /debootstrap/debootstrap --second-stage
+    _chroot "$MNT" dpkg --configure -a
+
+    update_packages
+    update_files
+
+    umount "$MNT/proc" 2>/dev/null || true
+    umount --recursive "$MNT" 2>/dev/null || true
+
+    fallocate -l "$IMAGE_SIZE" "$ktest_image".new
+    chmod 644 "$ktest_image".new
+    mke2fs -F -t ext4 -d "$MNT" "$ktest_image".new
+    e2fsck -y -f "$ktest_image".new
+    resize2fs -M "$ktest_image".new
+    resize2fs "$ktest_image".new "$IMAGE_SIZE"
+    mv "$ktest_image".new "$ktest_image"
+
+    rm -rf "$MNT"
+    trap '' EXIT
+}
+
+if [[ $(type -t "$CMD") != function ]]; then
+    usage
+    exit 1
+fi
+
+$CMD "$@"

--- a/tests/fs/bcachefs/bcachefs-journal-wedge-detect.sh
+++ b/tests/fs/bcachefs/bcachefs-journal-wedge-detect.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+# Journal-wedge detector for bcachefs ktests.
+#
+# The failure this catches (seen twice on a production desktop, 2026-07-25 and
+# 2026-07-26, both fatal):
+#
+#   bch2_journal_do_writes_locked() only starts the write for a seq once
+#   journal_state_seq_count() for that seq reaches zero.  So a single journal
+#   reservation held indefinitely on an already-closed buffer pins
+#   j->seq_write_started forever.  Once
+#
+#       atomic64_read(&j->seq) - j->seq_write_started == JOURNAL_STATE_BUF_NR
+#
+#   (which is 4), every journal_entry_open() returns journal_max_open and the
+#   filesystem is finished — no IO error, no device fault, reclaim never even
+#   kicked.  The box stays up, but nothing that needs the journal completes.
+#
+# Why the existing detectors miss it:
+#   - livelock-detect keys on trans_restart climbing; here nothing restarts,
+#     everything just blocks, and the journal seq goes flat rather than the
+#     restart counters going wild.
+#   - hung_task does fire eventually, but only after 120s, and it names an
+#     arbitrary victim rather than the reservation holder.
+#
+# The signal, from journal_debug:
+#
+#     depth = <head seq> - <oldest unwritten seq>
+#
+# IMPORTANT: a nonzero refcount on the oldest unwritten entry is NORMAL when
+# that entry is also the head — that is just the open buffer taking
+# reservations.  Verified on a healthy filesystem: head == oldest unwritten,
+# refcount 1, depth 0.  Keying on "refcount != 0" alone fires constantly.
+# The anomaly is a CLOSED buffer still pinned, i.e. depth >= 1 persisting.
+# depth 4 is fatal, so sustained depth >= 2 is the early warning — this fires
+# while the filesystem is still healthy, which is the whole point: we do not
+# want to have to reproduce a full wedge to get the evidence.
+#
+# On detection it dumps what actually identifies the culprit:
+# debugfs/btree_transactions, which walks every live btree_trans printing a
+# full backtrace for each.  With the companion two-line kernel patch teaching
+# bch2_btree_trans_to_text() to print trans->journal_res, the holder is named
+# outright, and its backtrace answers the question that matters:
+#
+#   - a real stack   => the reservation is HELD BY A BLOCKED TASK
+#   - no live trans holding one => the reservation was LEAKED
+#
+# Controls (env):
+#   BCACHEFS_JWEDGE_DISABLE=1      turn the detector off
+#   BCACHEFS_JWEDGE_MINDEPTH=2     depth that counts as anomalous
+#   BCACHEFS_JWEDGE_STALL=20       seconds at >= MINDEPTH before declaring
+#   BCACHEFS_JWEDGE_ACTION=panic   panic (default) | warn (dump + continue)
+
+# Echo "<head> <oldest_unwritten> <refcount> <depth>" for the first mounted
+# bcachefs that has an unwritten entry, or nothing.
+#
+# journal_debug layout:
+#     seq:                       319405175      <- head (first bare "seq:")
+#     seq_ondisk:                319405171      <- "^seq:" does not match this
+#     ...
+#     unwritten entries:
+#     seq:                       319405172      <- oldest unwritten
+#       refcount:                1
+bch2_jwedge_sample()
+{
+    local base
+    for base in /sys/fs/bcachefs/*; do
+	[[ -d $base/internal ]] || continue
+	awk '
+	    !inu && /^seq:/       { head = $2; next }
+	    /^unwritten entries:/ { inu = 1; next }
+	    inu && /^seq:/        { if (!got) s = $2; next }
+	    inu && /^ *refcount:/ { if (!got) { r = $2; got = 1 } ; next }
+	    END { if (got) print head, s, r, (head - s) }
+	' "$base"/internal/journal_debug 2>/dev/null
+	return 0
+    done
+}
+
+bch2_jwedge_dump_and_act()
+{
+    local head=$1 seq=$2 ref=$3 depth=$4 stall_secs=$5
+
+    echo "BCACHEFS JOURNAL WEDGE: seq $seq pinned at depth $depth (head $head, refcount $ref) for ${stall_secs}s"
+
+    echo 1 > /proc/sys/kernel/sysrq 2>/dev/null || true
+
+    local base
+    for base in /sys/fs/bcachefs/*; do
+	[[ -d $base/internal ]] || continue
+	local uuid=$(basename "$base")
+	echo "=== $uuid: journal_debug ==="
+	cat "$base"/internal/journal_debug 2>/dev/null
+
+	# THE artefact: every live btree_trans, each with a backtrace.  With the
+	# journal_res line patched into bch2_btree_trans_to_text(), grep this for
+	# "journal res: seq $seq" to name the holder directly.
+	local dbg=/sys/kernel/debug/bcachefs/$uuid
+	if [[ -r $dbg/btree_transactions ]]; then
+	    echo "=== $uuid: btree_transactions (holder + backtrace) ==="
+	    cat "$dbg"/btree_transactions 2>/dev/null
+	else
+	    echo "=== $uuid: debugfs unavailable; falling back to sysrq-w only ==="
+	fi
+	[[ -r $dbg/btree_deadlock ]] && {
+	    echo "=== $uuid: btree_deadlock ==="
+	    cat "$dbg"/btree_deadlock 2>/dev/null
+	}
+
+	echo "=== $uuid: journal_reclaim ==="
+	cat "$base"/internal/journal_reclaim 2>/dev/null
+	echo "=== $uuid: btree_write_buffer ==="
+	cat "$base"/internal/btree_write_buffer 2>/dev/null
+	echo "=== $uuid: moving_ctxts ==="
+	cat "$base"/internal/moving_ctxts 2>/dev/null
+    done
+
+    # Blocked-task stacks: if the holder is blocked rather than leaked, it is here.
+    echo w > /proc/sysrq-trigger 2>/dev/null || true
+
+    if [[ ${BCACHEFS_JWEDGE_ACTION:-panic} = panic ]]; then
+	sync
+	echo c > /proc/sysrq-trigger
+    fi
+}
+
+bch2_journal_wedge_watchdog_start()
+{
+    [[ ${BCACHEFS_JWEDGE_DISABLE:-} ]] && return 0
+
+    local stall_secs=${BCACHEFS_JWEDGE_STALL:-20}
+    local mindepth=${BCACHEFS_JWEDGE_MINDEPTH:-2}
+    local poll=2
+    echo "journal-wedge watchdog: armed (mindepth=$mindepth, stall=${stall_secs}s, action=${BCACHEFS_JWEDGE_ACTION:-panic})"
+    (
+	# Match livelock-detect: the prelude's set -eE ERR trap is inherited by
+	# subshells, and a transient read hiccup must not kill the loop.
+	trap - ERR
+	set +e
+	local need=$(( (stall_secs + poll - 1) / poll ))
+	local stalls=0 prev_seq=""
+	while true; do
+	    sleep $poll
+	    local sample head seq ref depth
+	    sample=$(bch2_jwedge_sample)
+	    if [[ -z $sample ]]; then
+		stalls=0; prev_seq=""; continue
+	    fi
+	    set -- $sample
+	    head=$1 seq=$2 ref=$3 depth=$4
+
+	    [[ ${BCACHEFS_JWEDGE_DEBUG:-} ]] && \
+		echo "jwedge-watch: head=$head oldest=$seq ref=$ref depth=$depth stalls=$stalls"
+
+	    # Only a *stuck* seq counts: if the oldest unwritten seq advances,
+	    # the journal is draining normally however deep it momentarily got.
+	    if (( depth >= mindepth )) && (( ref != 0 )) && [[ $seq = "$prev_seq" ]]; then
+		stalls=$((stalls + 1))
+	    else
+		stalls=0
+	    fi
+	    prev_seq=$seq
+
+	    if (( stalls >= need )); then
+		bch2_jwedge_dump_and_act "$head" "$seq" "$ref" "$depth" "$stall_secs"
+		stalls=0		  # in warn mode, keep watching
+	    fi
+	done
+    ) &
+    bch2_journal_wedge_watchdog_pid=$!
+}
+
+bch2_journal_wedge_watchdog_stop()
+{
+    [[ -n ${bch2_journal_wedge_watchdog_pid:-} ]] || return 0
+    kill "$bch2_journal_wedge_watchdog_pid" 2>/dev/null || true
+    wait "$bch2_journal_wedge_watchdog_pid" 2>/dev/null || true
+    bch2_journal_wedge_watchdog_pid=
+}
+
+# bcachefs-livelock-detect.sh (sourced by bcachefs-test-libs.sh) already owns
+# these hooks; chain onto it rather than clobbering it, so a test that sources
+# this file gets both detectors.
+ktest_test_setup()
+{
+    bch2_livelock_watchdog_start
+    bch2_journal_wedge_watchdog_start
+}
+
+ktest_test_teardown()
+{
+    bch2_journal_wedge_watchdog_stop
+    bch2_livelock_watchdog_stop
+}

--- a/tests/fs/bcachefs/bcachefs-livelock-detect.sh
+++ b/tests/fs/bcachefs/bcachefs-livelock-detect.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+#
+# Automatic livelock detector for bcachefs ktests.
+#
+# Livelocks — tasks busy-looping without making progress, e.g. an
+# unbounded btree-transaction restart loop — slip past every built-in
+# kernel detector:
+#   - hung_task (CONFIG_DETECT_HUNG_TASK) only fires on TASK_UNINTERRUPTIBLE
+#     (D-state) sleep; a restart loop stays runnable.
+#   - softlockup / RCU stall only fire on a CPU that stops scheduling; a
+#     restart loop reschedules on every iteration.
+# So a livelocked bcachefs only fails a ktest via the coarse wall-clock
+# watchdog, minutes later, with no diagnosis of where it was stuck.
+#
+# This detects it directly from bcachefs's own counters.  A *completing*
+# transaction advances the journal sequence number; a *restarting* one
+# bumps a trans_restart_* counter without completing.  So:
+#
+#     trans_restart_* climbing  +  journal seq and data I/O flat  =  livelock
+#
+# because no transaction is finishing.  The journal-seq signal is what
+# keeps this robust against tests that deliberately inject restarts
+# (BCACHEFS_INJECT_TRANSACTION_RESTARTS): an injected restart still
+# retries and completes, so seq keeps advancing — only a real livelock
+# holds it flat.
+#
+# On detection it dumps the evidence the kernel detectors can't — an
+# all-CPU backtrace (sysrq-l shows the *runnable* tasks hung_task never
+# sees), the blocked-task list (sysrq-w), and the dominant restart
+# reasons (which trans_restart_* counter is spinning tells you where) —
+# then, by default, panics (sysrq-c) so the harness fails in seconds with
+# that evidence in the log instead of eating the watchdog.
+#
+# Controls (env):
+#   BCACHEFS_LIVELOCK_DISABLE=1     turn the detector off
+#   BCACHEFS_LIVELOCK_STALL=60      seconds of no-progress-but-restarting
+#                                   before declaring a livelock
+#   BCACHEFS_LIVELOCK_ACTION=panic  panic (default) | warn (dump + continue)
+
+# Restart signal vs forward-progress signal, summed across every mounted
+# bcachefs.  Echoes "<restarts> <progress>", or nothing if no fs is
+# mounted yet.
+#
+# Restarts: sum of the trans_restart_* counters (all TYPE_COUNTER, so
+# plain integers).  Progress: the journal sequence number — a *completing*
+# transaction advances it, so it is the cleanest liveness signal and,
+# being an integer, avoids the human-readable "75.6 MiB" formatting that
+# the TYPE_SECTORS data_read/data_write counters carry.
+bch2_livelock_sample()
+{
+    local base found=0 restarts=0 progress=0
+    for base in /sys/fs/bcachefs/*; do
+	[[ -d $base/counters ]] || continue
+	found=1
+	local r seq
+	r=$(awk '/since mount/ {s += $NF} END {print s + 0}' \
+	    "$base"/counters/trans_restart_* 2>/dev/null)
+	seq=$(awk -F'\t' '/^seq:/ {print $2 + 0; exit}' \
+	    "$base"/internal/journal_debug 2>/dev/null)
+	restarts=$((restarts + ${r:-0}))
+	progress=$((progress + ${seq:-0}))
+    done
+    (( found )) && echo "$restarts $progress"
+}
+
+bch2_livelock_dump_and_act()
+{
+    local stall_secs=$1
+    echo "BCACHEFS LIVELOCK: ${stall_secs}s of climbing trans_restart with no journal/data progress" | to_kmsg 2>/dev/null || \
+	echo "BCACHEFS LIVELOCK: ${stall_secs}s of climbing trans_restart with no journal/data progress"
+
+    echo 1 > /proc/sys/kernel/sysrq 2>/dev/null || true
+    # All-CPU backtrace: the runnable, spinning tasks hung_task can't show.
+    echo l > /proc/sysrq-trigger 2>/dev/null || true
+    # Blocked-task list, for anything that IS in D-state alongside.
+    echo w > /proc/sysrq-trigger 2>/dev/null || true
+
+    local base
+    for base in /sys/fs/bcachefs/*; do
+	[[ -d $base/counters ]] || continue
+	echo "=== $base: nonzero trans_restart counters ==="
+	local f
+	for f in "$base"/counters/trans_restart_*; do
+	    [[ -e $f ]] || continue
+	    local v
+	    v=$(awk '/since mount/ {print $NF; exit}' "$f" 2>/dev/null)
+	    (( ${v:-0} > 0 )) && echo "  $(basename "$f"): $v"
+	done
+    done
+
+    if [[ ${BCACHEFS_LIVELOCK_ACTION:-panic} = panic ]]; then
+	sync
+	# Panic so the supervisor's panic post-mortem fails the test fast,
+	# with the backtrace above already in the console log.
+	echo c > /proc/sysrq-trigger
+    fi
+}
+
+bch2_livelock_watchdog_start()
+{
+    [[ ${BCACHEFS_LIVELOCK_DISABLE:-} ]] && return 0
+
+    local stall_secs=${BCACHEFS_LIVELOCK_STALL:-60}
+    local poll=3
+    echo "livelock watchdog: armed (stall=${stall_secs}s, action=${BCACHEFS_LIVELOCK_ACTION:-panic})"
+    # A livelocked transaction restarts far more often than the fs
+    # completes work.  Per poll interval we flag a "stall" when both:
+    #   - restarts climbed by at least MIN_RESTARTS (filters idle/light
+    #     periods — a spinning restart loop does tens of thousands/sec,
+    #     so even a few seconds clears this easily), and
+    #   - restarts dwarf completions: delta_restarts > RATIO * delta_seq
+    #     (a completing transaction advances the journal seq; healthy
+    #     work restarts far less than it completes, a livelock far more).
+    # This catches whole-fs livelocks (journal frozen -> delta_seq 0 ->
+    # ratio infinite) AND partial ones (one task spinning while the
+    # journal only trickles).  stall_secs of sustained stalls = livelock.
+    local min_restarts=${BCACHEFS_LIVELOCK_MIN_RESTARTS:-20000}
+    local ratio=${BCACHEFS_LIVELOCK_RATIO:-1000}
+    (
+	# The prelude runs set -eE with an ERR trap that subshells inherit;
+	# drop it so a transient counter-read hiccup can't kill the loop.
+	trap - ERR
+	set +e
+	local need=$(( (stall_secs + poll - 1) / poll ))
+	local stalls=0 prev_r=-1 prev_p=-1
+	while true; do
+	    sleep $poll
+	    local sample r p
+	    sample=$(bch2_livelock_sample)
+	    if [[ -z $sample ]]; then
+		stalls=0; prev_r=-1; continue   # no fs mounted yet
+	    fi
+	    r=${sample% *}
+	    p=${sample#* }
+	    if (( prev_r >= 0 )); then
+		local dr=$(( r - prev_r ))
+		local dp=$(( p - prev_p ))
+		(( dp < 0 )) && dp=0
+		[[ ${BCACHEFS_LIVELOCK_DEBUG:-} ]] && \
+		    echo "livelock-watch: d_restarts=$dr d_seq=$dp stalls=$stalls"
+		if (( dr >= min_restarts )) && (( dr > ratio * dp )); then
+		    stalls=$((stalls + 1))
+		else
+		    stalls=0
+		fi
+	    fi
+	    prev_r=$r; prev_p=$p
+	    if (( stalls >= need )); then
+		bch2_livelock_dump_and_act "$stall_secs"
+		stalls=0                  # in warn mode, keep watching
+	    fi
+	done
+    ) &
+    bch2_livelock_watchdog_pid=$!
+}
+
+bch2_livelock_watchdog_stop()
+{
+    [[ -n ${bch2_livelock_watchdog_pid:-} ]] || return 0
+    kill "$bch2_livelock_watchdog_pid" 2>/dev/null || true
+    wait "$bch2_livelock_watchdog_pid" 2>/dev/null || true
+    bch2_livelock_watchdog_pid=
+}
+
+# Per-test hooks: prelude's run_test calls ktest_test_setup/teardown around
+# each test_* function if they are defined (with an EXIT trap so teardown
+# runs even when a test fails under set -e).  Every bcachefs test that
+# sources bcachefs-test-libs.sh thus gets livelock detection for free.
+ktest_test_setup()    { bch2_livelock_watchdog_start; }
+ktest_test_teardown() { bch2_livelock_watchdog_stop; }

--- a/tests/fs/bcachefs/bcachefs-mount-opt-noval.ktest
+++ b/tests/fs/bcachefs/bcachefs-mount-opt-noval.ktest
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Verify whether a valueless mount option whose parser is BCH_OPT_FN
+# dereferences NULL.
+#
+# gcc -fanalyzer flagged bch2_opt_val_synonym_lookup() being reached with a
+# NULL value, ending in strcmp(NULL, i->v1). Reading the code, every link
+# holds:
+#
+#  - bch2_parse_one_mount_opt() looks the synonym up BEFORE calling
+#    bch2_opt_parse(), so the parser never gets a chance to handle NULL first.
+#  - The guard that would skip a valueless option deliberately exempts
+#    BCH_OPT_FN options, because their parsers are allowed to accept NULL.
+#  - fix_errors is OPT_FS|OPT_MOUNT with OPT_FN, and
+#    bch2_opt_fix_errors_parse() indeed opens with `if (!val)`.
+#
+# So the intent is clearly "valueless fix_errors means FSCK_FIX_yes", and the
+# synonym lookup runs first and does not expect NULL.
+#
+# What the reading CANNOT settle is whether the option reaches bcachefs as NULL
+# at all: the VFS may normalise a valueless -o option to an empty string before
+# bcachefs sees it, in which case strcmp("" , ...) is harmless and this is a
+# false positive. That is a runtime question, hence this test.
+#
+# Blames to Kent, ef8dd631f788, 2025-04-06.
+#
+# Pass  = mount succeeds or fails cleanly (no oops)  -> analyzer FP, retract.
+# Fail  = kernel oops in bch2_opt_val_synonym_lookup -> real bug, report.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+config-scratch-devs 1G
+config-timeout 300
+
+test_mount_opt_no_value()
+{
+    set_watchdog 120
+
+    run_quiet "" bcachefs format -f ${ktest_scratch_dev[0]}
+
+    # Control: the same option WITH a value must work, so a failure below is
+    # attributable to the missing value and not to the option being rejected.
+    echo "=== control: fix_errors=yes ==="
+    mount -t bcachefs -o fix_errors=yes ${ktest_scratch_dev[0]} /mnt
+    umount /mnt
+    echo "control ok"
+
+    # The candidate. If the analyzer is right this oopses inside
+    # bch2_opt_val_synonym_lookup() -> strcmp(NULL, ...) and never returns.
+    echo "=== candidate: bare fix_errors ==="
+    if mount -t bcachefs -o fix_errors ${ktest_scratch_dev[0]} /mnt; then
+	echo "mounted with bare fix_errors"
+	umount /mnt
+    else
+	echo "mount refused bare fix_errors (rc=$?) -- clean failure, no oops"
+    fi
+
+    # A couple of neighbours, in case the reachable one is a different OPT_FN.
+    local opt
+    for opt in verbose degraded norecovery; do
+	echo "=== neighbour: bare $opt ==="
+	if mount -t bcachefs -o $opt ${ktest_scratch_dev[0]} /mnt; then
+	    umount /mnt
+	    echo "  mounted"
+	else
+	    echo "  refused (rc=$?)"
+	fi
+    done
+
+    echo "SURVIVED: no oops from any valueless option"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/bcachefs-test-libs.sh
+++ b/tests/fs/bcachefs/bcachefs-test-libs.sh
@@ -6,6 +6,10 @@
 
 . $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/../../test-libs.sh
 
+# Automatic livelock detection for every bcachefs test (defines the
+# ktest_test_setup/teardown hooks that prelude's run_test calls).
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-livelock-detect.sh
+
 # nodebug test variant: the harness passes ktest_bcachefs_no_debug (it
 # rides testrunner's ktest_* passthrough). Translate it once to the
 # internal NO_BCACHEFS_DEBUG that the checks below — and bcachefs_antagonist

--- a/tests/fs/bcachefs/commit_lazy.ktest
+++ b/tests/fs/bcachefs/commit_lazy.ktest
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# In-kernel unit test for bch2_trans_commit_lazy() (bcachefs-tools#780):
+# the lazy commit must be a no-op on an empty transaction and a regular
+# commit otherwise.  With the empty-check inverted it returns success
+# while silently dropping every queued update — test_commit_lazy queues
+# one update through it and then verifies the key actually persisted.
+#
+# Requires the module built with BCACHEFS_TESTS=1 (and Rust support:
+# BCACHEFS_RUST=1 for dkms builds, since the test harness lives in
+# fs/debug/tests.rs).
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+require-kernel-config BCACHEFS_DEBUG
+require-kernel-config BCACHEFS_TESTS
+
+# The unit-test harness (fs/debug/tests.rs) is Rust; a C-only module has
+# no perf_test attribute at all.  For dkms runs, force the Rust module
+# build (fs/Makefile reads the unprefixed var; sourced env vars are not
+# exported, so re-export here the way test-libs does for BCACHEFS_TESTS).
+export BCACHEFS_RUST=1
+
+config-mem 4G
+config-scratch-devs 2G
+config-timeout 1800
+
+[[ -n ${KTEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+test_commit_lazy_unit()
+{
+    set_watchdog 300
+
+    run_quiet "" bcachefs format -f "${ktest_scratch_dev[0]}"
+    mount -t bcachefs "${ktest_scratch_dev[0]}" /mnt
+
+    # Fails the write (and the test) if the lazy commit dropped the update.
+    echo "test_commit_lazy 1 1" > /sys/fs/bcachefs/*/perf_test
+
+    umount /mnt
+
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/dedup_mismatch.ktest
+++ b/tests/fs/bcachefs/dedup_mismatch.ktest
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Dedup byte-verify mismatch: regression test for the relock bug
+# (swap-files commit e10edaec8293).
+#
+# bch2_dedup_extent() drops btree locks (bch2_trans_unlock_long) for the
+# byte-verify reads.  The byte-verify-MISMATCH path (checksum collision,
+# data differs) used to return without relocking; the caller then panicked
+# "trans should be locked, unlocked by read_extent__rbio_alloc".
+#
+# The dedup_force_byte_verify_mismatch debug option makes the verify report
+# a mismatch as if the checksums had collided on differing data, so two
+# identical files (which collide in the dedup index naturally) drive the
+# mismatch path deterministically.
+#
+# Red/green: on a kernel without the relock fix this test panics the VM;
+# on a fixed kernel the extent is skipped, the counter increments, and
+# fsck comes back clean.
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/bcachefs-test-libs.sh
+
+config-mem 4G   # the in-VM bcachefs-tools + dkms build needs ~4G
+config-scratch-devs 4G
+config-timeout $(stress_timeout)
+
+# Reuse a prebuilt (bcachefs-less, for dkms runs) kernel — ktest's config
+# regeneration would re-enable built-in bcachefs otherwise.
+[[ -n ${KTEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+counter_since_mount()
+{
+    awk '/^since mount:/ { print $NF }' "$1"
+}
+
+test_dedup_force_mismatch()
+{
+    set_watchdog 300
+
+    # Requires the VM's bcachefs-tools to be the dedup-capable branch
+    # (run via dkms-dedup_mismatch.ktest with the deps checkout on
+    # port/on-testing or another dedup branch).
+    run_quiet "" bcachefs format -f --background_dedup=1 ${ktest_scratch_dev[0]}
+
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    # Force the mismatch BEFORE writing, so the very first dedup attempt
+    # takes the collision path.
+    echo 1 > /sys/fs/bcachefs/*/options/dedup_force_byte_verify_mismatch
+
+    # Two identical files: same checksum, natural dedup-index collision.
+    dd if=/dev/urandom of=/mnt/a bs=64k count=1 status=none
+    cp /mnt/a /mnt/b
+    cp /mnt/a /tmp/reference
+    sync
+
+    # Reconcile is driven by the io_clock, which advances on writes — the
+    # tiny 128k above may not move it enough to schedule a pass.  Advance
+    # it with bulk junk, then kick both the full and pending reconcile
+    # triggers (indexing happens on the full pass; dedup on re-process).
+    dd if=/dev/zero of=/mnt/clock bs=1M count=64 status=none
+    sync
+    rm -f /mnt/clock
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_pending_wakeup
+
+    # On the buggy kernel the panic fires here.
+    local mismatches=0
+    for i in $(seq 1 60); do
+	mismatches=$(counter_since_mount \
+	    /sys/fs/bcachefs/*/counters/dedup_byte_verify_mismatch)
+	(( mismatches > 0 )) && break
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_pending_wakeup
+	sleep 1
+    done
+
+    # Quiesce reconcile before verifying: with the force knob on it re-hits
+    # the collision path every pass, and even off it churns the dedup
+    # backlog — either way it holds btree locks and, on a 2-CPU debug VM,
+    # starves the foreground verification reads (they spin in
+    # six_lock_increment / bch2_btree_iter_peek).  Turn dedup off and clear
+    # the force so reconcile settles.  The counters already captured the
+    # verdict (mismatch path ran, no panic).
+    echo 0 > /sys/fs/bcachefs/*/options/dedup_force_byte_verify_mismatch
+    echo 0 > /sys/fs/bcachefs/*/options/background_dedup
+    sleep 3
+
+    if (( mismatches == 0 )); then
+	echo "FAIL: mismatch path never ran (counter still 0). Diagnostics:"
+	for c in dedup_extent_indexed dedup_extent_deduped \
+		 dedup_byte_verify_mismatch dedup_sectors_saved \
+		 dedup_stale_entry; do
+	    echo "  $c = $(counter_since_mount /sys/fs/bcachefs/*/counters/$c 2>/dev/null)"
+	done
+	cat /sys/fs/bcachefs/*/options/dedup_force_byte_verify_mismatch 2>/dev/null
+	cat /sys/fs/bcachefs/*/options/background_dedup 2>/dev/null
+	cat /sys/fs/bcachefs/*/options/data_checksum 2>/dev/null
+	return 1
+    fi
+    echo "mismatch path taken ${mismatches}x, no panic"
+
+    # Forced mismatch means nothing may be deduped and data must be intact.
+    cmp /mnt/a /tmp/reference || { echo "FAIL: file a corrupted"; return 1; }
+    cmp /mnt/b /tmp/reference || { echo "FAIL: file b corrupted"; return 1; }
+
+    local deduped=$(counter_since_mount \
+	/sys/fs/bcachefs/*/counters/dedup_extent_deduped)
+    (( deduped == 0 )) ||
+	{ echo "FAIL: $deduped extents deduped despite forced mismatch"; return 1; }
+
+    # Clear the force knob so reconcile stops re-hitting the mismatch path
+    # on every pass — otherwise it never quiesces and umount hangs.
+    echo 0 > /sys/fs/bcachefs/*/options/dedup_force_byte_verify_mismatch
+
+    umount /mnt
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+main "$@"

--- a/tests/fs/bcachefs/dedup_pending_terminal.ktest
+++ b/tests/fs/bcachefs/dedup_pending_terminal.ktest
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# Dedup pending-terminal: regression test for the dedup_pending
+# never-cleared livelock (crafted-collision local DoS).
+#
+# On a byte-verify MISMATCH the dedup worker used to leave dedup_pending
+# set, so every subsequent reconcile pass re-attempted the same doomed
+# dedup forever (fs-wide journal freeze / read livelock; triggerable by an
+# unprivileged writer via a checksum collision).  The fix routes the
+# terminal paths through dedup_skip_terminal(), which clears pending.
+#
+# The dedup_force_byte_verify_mismatch debug knob makes the byte-verify
+# report a mismatch deterministically, so two identical files drive the
+# mismatch path on every dedup attempt.  Verdict by counter slope:
+#   RED  (unfixed): dedup_byte_verify_mismatch keeps climbing every pass
+#   GREEN (fixed):  bumps once, then stays flat while reconcile keeps
+#                   running (pending cleared, nothing left to reprocess)
+#
+# In-tree variant of dedup_mismatch.ktest: no dkms, no userspace dedup
+# dependency (options are set via sysfs after mount).  Run THROUGH
+# lib/supervisor.
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/bcachefs-test-libs.sh
+
+config-mem 1G
+config-cpus 2
+config-scratch-devs 4G
+config-timeout 600
+
+# Reuse a prebuilt kernel for matrix runs.
+[[ -n ${DEDUP_TEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+# Give the slope window time to complete before the livelock detector
+# considers panicking the VM (red kernels are SUPPOSED to livelock here,
+# but we want the counter evidence first).
+export BCACHEFS_LIVELOCK_STALL=180
+
+counter_since_mount()
+{
+    awk '/^since mount:/ { print $NF }' "$1"
+}
+
+test_dedup_pending_terminal()
+{
+    set_watchdog 300
+
+    run_quiet "" bcachefs format -f ${ktest_scratch_dev[0]}
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    # No userspace dedup support needed: enable at runtime via sysfs.
+    echo 1 > /sys/fs/bcachefs/*/options/background_dedup
+    echo 1 > /sys/fs/bcachefs/*/options/dedup_force_byte_verify_mismatch
+
+    # File a first, ALONE: its index entry must be visible before the
+    # twin is written.  Index inserts land via the write buffer, so two
+    # identical extents processed in the same reconcile batch BOTH get
+    # indexed (neither lookup sees the other's insert) and nothing ever
+    # collides.  Sequencing a's indexing before b's write makes b's
+    # dedup attempt hit the entry deterministically.
+    dd if=/dev/urandom of=/mnt/a bs=64k count=1 status=none
+    cp /mnt/a /tmp/reference
+    sync
+
+    # Advance the io_clock so reconcile schedules a pass at all (tiny
+    # writes don't move it enough), then kick both triggers.  MUST be
+    # unique content: identical (e.g. zero) extents all collide in the
+    # dedup index and each bumps the mismatch counter once even on a
+    # fixed kernel, drowning the a/b signal in ~128 legitimate bumps.
+    dd if=/dev/urandom of=/mnt/clock bs=1M count=64 status=none
+    sync
+    rm -f /mnt/clock
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_pending_wakeup
+
+    # Wait for indexing to settle (a is in the index once the counter
+    # stops moving).
+    local idx=0 prev_idx=-1 i
+    for i in $(seq 1 30); do
+	idx=$(counter_since_mount \
+	    /sys/fs/bcachefs/*/counters/dedup_extent_indexed)
+	(( idx > 0 && idx == prev_idx )) && break
+	prev_idx=$idx
+	sleep 2
+    done
+    (( idx > 0 )) || { echo "FAIL: nothing indexed after 60s"; return 1; }
+
+    # Now the twin: same checksum, hits a's index entry.  NOT plain cp —
+    # coreutils cp reflinks by default on bcachefs, and a reflink_p never
+    # enters the dedup path.  dd forces a genuine second extent.
+    dd if=/mnt/a of=/mnt/b bs=64k status=none
+    sync
+
+    # Wait for the mismatch path to run (each iteration advances the
+    # io_clock with fresh unique data — bare trigger kicks are no-ops
+    # once the clock is caught up).
+    local mismatches=0
+    for i in $(seq 1 30); do
+	mismatches=$(counter_since_mount \
+	    /sys/fs/bcachefs/*/counters/dedup_byte_verify_mismatch)
+	(( mismatches > 0 )) && break
+	dd if=/dev/urandom of=/mnt/kick$i bs=1M count=4 status=none
+	sync
+	rm -f /mnt/kick$i
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_pending_wakeup
+	sleep 2
+    done
+
+    if (( mismatches == 0 )); then
+	echo "FAIL: mismatch path never ran (counter still 0)"
+	for c in dedup_extent_indexed dedup_extent_deduped \
+		 dedup_byte_verify_mismatch dedup_stale_entry; do
+	    echo "  $c = $(counter_since_mount /sys/fs/bcachefs/*/counters/$c 2>/dev/null)"
+	done
+	return 1
+    fi
+
+    # Let the initial pending-work churn settle before opening the
+    # window, so leftover first-pass bumps don't masquerade as slope.
+    local prev=$mismatches i
+    for i in $(seq 1 10); do
+	sleep 2
+	mismatches=$(counter_since_mount \
+	    /sys/fs/bcachefs/*/counters/dedup_byte_verify_mismatch)
+	(( mismatches == prev )) && break
+	prev=$mismatches
+    done
+
+    # Slope window: a bare trigger write is a no-op unless the io_clock
+    # has advanced since the last pass, so each iteration writes fresh
+    # UNIQUE data (unique => indexed, not mismatch-bumped) to advance the
+    # clock, then kicks reconcile.  A rescan re-attempts any extent still
+    # carrying dedup_pending: on an unfixed kernel the collided extent is
+    # re-processed every pass and the counter climbs; on a fixed kernel
+    # its pending bit was cleared at the first mismatch and the counter
+    # stays flat.
+    local start=$mismatches cur=$mismatches
+    for i in $(seq 1 10); do
+	dd if=/dev/urandom of=/mnt/clock$i bs=1M count=16 status=none
+	sync
+	rm -f /mnt/clock$i
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_pending_wakeup
+	sleep 2
+	cur=$(counter_since_mount \
+	    /sys/fs/bcachefs/*/counters/dedup_byte_verify_mismatch)
+    done
+    echo "mismatch counter: $start at window start, $cur after 10 clock-advancing reconcile passes"
+
+    # Quiesce: clear the force knob and dedup so umount/fsck behave.
+    echo 0 > /sys/fs/bcachefs/*/options/dedup_force_byte_verify_mismatch
+    echo 0 > /sys/fs/bcachefs/*/options/background_dedup
+    sleep 3
+
+    # Data must be intact and nothing may have been deduped.
+    cmp /mnt/a /tmp/reference || { echo "FAIL: file a corrupted"; return 1; }
+    cmp /mnt/b /tmp/reference || { echo "FAIL: file b corrupted"; return 1; }
+
+    local deduped=$(counter_since_mount \
+	/sys/fs/bcachefs/*/counters/dedup_extent_deduped)
+    (( deduped == 0 )) ||
+	{ echo "FAIL: $deduped extents deduped despite forced mismatch"; return 1; }
+
+    # The verdict: still reprocessing after 20s of kicks = pending never
+    # cleared = red.  Allow a couple of transient retries on green.
+    if (( cur > start + 2 )); then
+	echo "FAIL: mismatch counter still climbing (+$((cur - start)) over 10 rescans) — dedup_pending never cleared"
+	return 1
+    fi
+    echo "GREEN: mismatch counter flat after terminal skip (pending cleared)"
+
+    umount /mnt
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+main "$@"

--- a/tests/fs/bcachefs/desktop-mode.ktest
+++ b/tests/fs/bcachefs/desktop-mode.ktest
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# Desktop mode: journal_flush_disabled + journal_flush_ordered.
+#
+# The invariant under test is prefix consistency: after a crash, recovery
+# must land on a point-in-time prefix of history — every surviving file is
+# complete, and no later operation survives while an earlier one is lost.
+# fsync is allowed to lie about durability (journal_flush_disabled); the
+# periodic ordered flush boundary is the consistency point.
+#
+# The failure mode this guards against: inode creates land in flushed
+# journal entries while their data extent inserts land in later noflush
+# (blacklisted) entries — zero-byte files after recovery, the signature of
+# the 2026-06-02 pacman crash.
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/bcachefs-test-libs.sh
+
+config-scratch-devs 4G
+config-timeout $(stress_timeout)
+
+# Sequential marker workload: create file_NNNNNN in order, each holding its
+# own number, no fsync.  Stops on the first write error (EROFS after the
+# emergency shutdown).
+#
+# Paced to ~2000 creates/s: the journal_flush_ordered v1 race window is
+# (create rate x sync_inodes_sb duration) — files created while the
+# pre-flush data sync runs share its flush entry but miss the sync.
+# Unpaced (~50k/s) that tail measured ~65k files; the v2 commit gate is
+# the real fix, until then the test pins v1's documented behavior.
+write_seq_files()
+{
+    local dir=$1
+
+    mkdir -p $dir
+    for i in $(seq -w 1 999999); do
+	echo "content-$i" > $dir/file_$i 2>/dev/null || break
+	(( 10#$i % 100 )) || sleep 0.05
+    done
+}
+
+# Verify the prefix-consistency invariant over the surviving files:
+#
+#   1. No holes: creates were sequential, so survivors must be {1..max}.
+#   2. No complete file after a zero-byte file: a zero-byte file means the
+#      create survived but the data didn't; anything complete *after* it
+#      would mean a later write survived while an earlier one was lost.
+#   3. The zero-byte tail is bounded by $3: v1 of journal_flush_ordered has
+#      a known race window (metadata committed between the data sync
+#      returning and the flush entry being written), which can only affect
+#      files created immediately before the flush boundary.  Pass 0 for
+#      strict (v2) semantics.
+#   4. Some complete files survived at all (the mechanism does something).
+verify_prefix()
+{
+    local dir=$1
+    local desc=$2
+    local allowed_zero_tail=$3
+    local nr=0 max_n=0 max_complete=0 min_zero=0 nr_zero=0
+    local fail=0
+
+    for f in $dir/file_*; do
+	[[ -e $f ]] || break
+	local num=${f##*_}
+	local n=$((10#$num))
+
+	nr=$((nr + 1))
+	((n > max_n)) && max_n=$n
+
+	if [[ -s $f ]]; then
+	    [[ "$(cat $f)" = "content-$num" ]] ||
+		{ echo "FAIL($desc): $f content wrong"; fail=1; }
+	    ((n > max_complete)) && max_complete=$n
+	else
+	    nr_zero=$((nr_zero + 1))
+	    [[ $min_zero -eq 0 || $n -lt $min_zero ]] && min_zero=$n
+	fi
+    done
+
+    echo "$desc: $nr survivors, max=$max_n, complete prefix=$max_complete, zero-byte=$nr_zero"
+
+    [[ $nr -gt 0 ]] ||
+	{ echo "FAIL($desc): no files survived at all"; return 1; }
+
+    [[ $nr -eq $max_n ]] ||
+	{ echo "FAIL($desc): holes in survivor set ($nr files, max $max_n)"; fail=1; }
+
+    [[ $max_complete -gt 0 ]] ||
+	{ echo "FAIL($desc): no complete files survived"; fail=1; }
+
+    if [[ $nr_zero -gt 0 ]]; then
+	[[ $min_zero -gt $max_complete ]] ||
+	    { echo "FAIL($desc): complete file_$max_complete survives after zero-byte file_$min_zero"; fail=1; }
+    fi
+
+    [[ $((max_n - max_complete)) -le $allowed_zero_tail ]] ||
+	{ echo "FAIL($desc): zero-byte tail $((max_n - max_complete)) exceeds allowed $allowed_zero_tail"; fail=1; }
+
+    return $fail
+}
+
+crash_one_iteration()
+{
+    local mountopts=$1
+
+    run_quiet "" bcachefs format -f ${ktest_scratch_dev[0]}
+
+    mount -t bcachefs -o $mountopts ${ktest_scratch_dev[0]} /mnt
+
+    write_seq_files /mnt/seq &
+    local writer=$!
+
+    # let several flush cycles happen mid-workload
+    sleep $((3 + RANDOM % 5))
+
+    echo "Triggering emergency shutdown..."
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_emergency_read_only
+
+    wait $writer || true
+    umount /mnt
+
+    # plain recovery: replay stops at the last flush entry,
+    # noflush entries are blacklisted
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+}
+
+# Positive test: with ordered flush, recovery yields a complete prefix.
+# The allowed zero-byte tail covers the documented v1 race window; tighten
+# to 0 when the flush-time commit gate lands.
+test_ordered_flush_prefix()
+{
+    set_watchdog 600
+
+    local iterations=5
+
+    for i in $(seq 1 $iterations); do
+	echo "=== ordered iteration $i/$iterations ==="
+
+	crash_one_iteration journal_flush_disabled,journal_flush_delay=1000,journal_flush_ordered
+
+	local ret=0
+	verify_prefix /mnt/seq "ordered#$i" 200 || ret=1
+
+	umount /mnt
+	bcachefs fsck -ny ${ktest_scratch_dev[0]}
+
+	[[ $ret = 0 ]] || return 1
+    done
+
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+# Negative control: without ordered flush the same workload must produce
+# zero-byte files (creates flushed, extent inserts blacklisted) — proving
+# this test can detect the bug class.  Retry a few times since it depends
+# on where the flush boundary falls.
+test_unordered_negative_control()
+{
+    set_watchdog 600
+
+    local attempts=5
+
+    for i in $(seq 1 $attempts); do
+	echo "=== control attempt $i/$attempts ==="
+
+	crash_one_iteration journal_flush_disabled,journal_flush_delay=1000
+
+	local nr_zero=$(find /mnt/seq -name 'file_*' -size 0 2>/dev/null | wc -l)
+	echo "control#$i: $nr_zero zero-byte files"
+
+	umount /mnt
+
+	if [[ $nr_zero -gt 0 ]]; then
+	    echo "control: bug class detected as expected"
+	    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+	    return 0
+	fi
+    done
+
+    echo "FAIL: unordered control never produced zero-byte files — test cannot detect the bug class"
+    return 1
+}
+
+# Worker lifecycle: mount/unmount cycles and runtime toggling while writes
+# are in flight.  Catches arm/disarm races (the worker self-rearms and is
+# torn down with disable_delayed_work_sync in put_super).
+test_worker_lifecycle()
+{
+    set_watchdog 300
+
+    run_quiet "" bcachefs format -f ${ktest_scratch_dev[0]}
+
+    for i in $(seq 1 20); do
+	mount -t bcachefs -o journal_flush_ordered,journal_flush_delay=100 \
+	    ${ktest_scratch_dev[0]} /mnt
+
+	dd if=/dev/zero of=/mnt/foo bs=64k count=16 oflag=direct 2>/dev/null &
+	local writer=$!
+
+	echo 0 > /sys/fs/bcachefs/*/options/journal_flush_ordered
+	echo 1 > /sys/fs/bcachefs/*/options/journal_flush_ordered
+
+	wait $writer || true
+	umount /mnt
+    done
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+main "$@"

--- a/tests/fs/bcachefs/dkms-commit_lazy.ktest
+++ b/tests/fs/bcachefs/dkms-commit_lazy.ktest
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/dkms-base.sh

--- a/tests/fs/bcachefs/dkms-dedup_mismatch.ktest
+++ b/tests/fs/bcachefs/dkms-dedup_mismatch.ktest
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/dkms-base.sh

--- a/tests/fs/bcachefs/dkms-fsync_pressure.ktest
+++ b/tests/fs/bcachefs/dkms-fsync_pressure.ktest
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/dkms-base.sh

--- a/tests/fs/bcachefs/dkms-reconcile_convergence.ktest
+++ b/tests/fs/bcachefs/dkms-reconcile_convergence.ktest
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/dkms-base.sh

--- a/tests/fs/bcachefs/dkms-swapfile_deadlock.ktest
+++ b/tests/fs/bcachefs/dkms-swapfile_deadlock.ktest
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/dkms-base.sh

--- a/tests/fs/bcachefs/dkms-swapfile_pressure.ktest
+++ b/tests/fs/bcachefs/dkms-swapfile_pressure.ktest
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/dkms-base.sh

--- a/tests/fs/bcachefs/dkms-writeback_pressure.ktest
+++ b/tests/fs/bcachefs/dkms-writeback_pressure.ktest
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/dkms-base.sh

--- a/tests/fs/bcachefs/fsync_pressure.ktest
+++ b/tests/fs/bcachefs/fsync_pressure.ktest
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Journal reclaim under memory exhaustion.  In the swap-deadlock
+# reproductions, bch-reclaim/<dev> (journal reclaim) showed up blocked
+# in the six_lock convoy alongside the write-path kworkers — this test
+# makes journal reclaim the protagonist: a storm of tiny fsync'd
+# transactions forces continuous journal writes and journal reclaim
+# (btree node writeback to free journal space), while the unkillable
+# eater denies all of it memory.
+#
+# A journal-reclaim path that allocates carelessly under pressure, or a
+# flush-ordering scheme that lets reclaim depend on a stalled flush,
+# wedges here: hung_task panics within ~30s, OOM "System is deadlocked
+# on memory", or livelock (run through lib/supervisor).  Particularly
+# relevant to ordered-flush/journal changes (desktop mode): this is the
+# profile where journal-pin dependencies meet memory starvation.
+#
+#   FSYNC_TEST_MEM=512M       VM memory
+#   FSYNC_TEST_CPUS=2         vCPUs
+#   FSYNC_TEST_ROUNDS=3       pressure rounds per boot
+#   FSYNC_TEST_DURATION=120   seconds per round
+#   FSYNC_TEST_WORKERS=4      parallel fsync loops
+#   FSYNC_TEST_NO_KBUILD=1    reuse a prebuilt kernel
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/memory-pressure-libs.sh
+
+require-kernel-config DETECT_HUNG_TASK
+
+config-mem ${FSYNC_TEST_MEM:-512M}
+config-cpus ${FSYNC_TEST_CPUS:-2}
+config-scratch-devs 2G
+config-timeout 900
+
+[[ -n ${FSYNC_TEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+test_fsync_reclaim_pressure()
+{
+    set_watchdog 700
+
+    local dev=${ktest_scratch_dev[0]}
+    echo "=== $(grep MemTotal /proc/meminfo), $(nproc) cpus ==="
+
+    run_quiet "" bcachefs format -f "$dev"
+    mount -t bcachefs "$dev" /mnt
+
+    build_eater
+
+    # No swap: the default overcommit heuristic would refuse an mmap
+    # bigger than RAM outright.  The eater must be allowed to overcommit
+    # so the pressure comes from page touches, not the commit limit.
+    echo 1 > /proc/sys/vm/overcommit_memory
+
+    hung_task_panic_on
+
+    # The fsync storm: parallel workers doing create → 4K write → fsync
+    # → rename → unlink, each cycle a couple of journalled transactions
+    # plus a journal flush.  Directory churn keeps the interior btree
+    # nodes hot so journal reclaim has real btree writeback to do.
+    local workers=${FSYNC_TEST_WORKERS:-4}
+    local pids=() w
+    for (( w = 0; w < workers; w++ )); do
+	mkdir -p /mnt/fsync$w
+	(
+	    trap - ERR
+	    set +e
+	    i=0
+	    while true; do
+		dd if=/dev/zero of=/mnt/fsync$w/tmp bs=4K count=1 \
+		   conv=fsync 2>/dev/null
+		mv /mnt/fsync$w/tmp /mnt/fsync$w/f$((i % 50))
+		i=$((i + 1))
+	    done
+	) &
+	pids+=($!)
+    done
+
+    start_mem_telemetry
+
+    local eat_mb=${FSYNC_TEST_EAT_MB:-$(eater_squeeze_mb)}
+    local duration=${FSYNC_TEST_DURATION:-120}
+    local rounds=${FSYNC_TEST_ROUNDS:-3}
+    local round
+    for (( round = 1; round <= rounds; round++ )); do
+	echo "=== round $round/$rounds: eater ${eat_mb}M for ${duration}s ==="
+	/tmp/eater "$eat_mb" "$duration" || {
+	    stop_mem_telemetry
+	    echo "eater failed"
+	    return 1
+	}
+	sleep 5
+    done
+
+    stop_mem_telemetry
+    local p
+    for p in "${pids[@]}"; do
+	kill $p 2>/dev/null || true
+	wait $p 2>/dev/null || true
+    done
+
+    hung_task_panic_off
+
+    sync
+    rm -rf /mnt/fsync*
+    umount /mnt
+
+    mount -t bcachefs -o fsck,ro "$dev" /mnt
+    umount /mnt
+
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/memory-pressure-libs.sh
+++ b/tests/fs/bcachefs/memory-pressure-libs.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# Shared pieces for the memory-pressure torture tests: an unkillable
+# native-speed memory eater and swap/memory telemetry.
+#
+# The eater details are load-bearing (established by ablation against a
+# reference qemu harness):
+#   - MAP_PRIVATE anonymous, page-touch storm at C speed — reclaim
+#     deadlocks form in the initial swap-out/writeback burst;
+#   - oom_score_adj -1000 — an OOM-killable eater gets reaped, the
+#     pressure collapses and the system recovers;
+#   - continuous re-touching so nothing ages out.
+# Size it ~RAM+300M to also crush the file LRU: on a disk-rooted VM,
+# reclaim otherwise escapes by dropping clean file pages instead of
+# pressuring the filesystem under test.
+
+build_eater()
+{
+    cat > /tmp/eater.c << 'CEOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+	size_t total = (size_t) atol(argv[1]) << 20;
+	int duration = atoi(argv[2]);
+
+	FILE *f = fopen("/proc/self/oom_score_adj", "w");
+	if (f) {
+		fputs("-1000", f);
+		fclose(f);
+	}
+
+	unsigned char *p = mmap(NULL, total, PROT_READ|PROT_WRITE,
+				MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+	if (p == MAP_FAILED) {
+		perror("mmap");
+		return 1;
+	}
+
+	for (size_t i = 0; i < total; i += 4096)
+		p[i] = 0xAA;
+	printf("eater: touched %s MB\n", argv[1]);
+	fflush(stdout);
+
+	volatile unsigned char sink = 0;
+	time_t deadline = time(NULL) + duration;
+	while (time(NULL) < deadline) {
+		for (size_t i = 0; i < total; i += 4096 * 64)
+			sink ^= p[i];
+		sleep(1);
+	}
+	return 0;
+}
+CEOF
+    gcc -O2 -o /tmp/eater /tmp/eater.c
+}
+
+# Default eater size: enough to fill swap (if any) and crush the file LRU.
+eater_default_mb()
+{
+    awk '/MemTotal/ {print int($2 / 1024) + 300}' /proc/meminfo
+}
+
+# Squeeze size for swapless tests: anon memory can't be reclaimed at all
+# without swap, so an eater above RAM just OOM-cascades within seconds —
+# physics, not a filesystem verdict.  ~70% of RAM squeezes reclaim onto
+# the filesystem's dirty/clean pages while staying survivable.
+eater_squeeze_mb()
+{
+    awk '/MemTotal/ {print int($2 * 70 / 100 / 1024)}' /proc/meminfo
+}
+
+# Sacrificial balloon: a killable, eagerly-OOM-targeted memory hog in a
+# respawn loop.  With only the unkillable eater and a few tiny daemons,
+# the OOM killer can run out of victims while swap writeback is still
+# absorbing the initial burst, and the mm layer panics ("System is
+# deadlocked on memory") — a race that can kill even a correct kernel.
+# The balloon guarantees a victim, removing that mm-level failure mode
+# from both sides of a red/green comparison; the filesystem-level
+# deadlock remains the only discriminator.
+start_balloon()
+{
+    local mb=${1:-150}
+    (
+	# ktest's prelude runs set -eE with an ERR trap; subshells inherit
+	# the trap even under set +e, so the loop would die at the first
+	# OOM kill of the balloon (exit 137) instead of respawning.
+	trap - ERR
+	set +e
+	while true; do
+	    /tmp/eater_balloon "$mb" 3600 2>/dev/null
+	    sleep 2
+	done
+    ) &
+    balloon_loop_pid=$!
+}
+
+stop_balloon()
+{
+    [[ -n ${balloon_loop_pid:-} ]] || return 0
+    kill $balloon_loop_pid 2>/dev/null || true
+    wait $balloon_loop_pid 2>/dev/null || true
+    pkill --full "^/tmp/eater_balloon" 2>/dev/null || true
+    balloon_loop_pid=
+}
+
+build_balloon()
+{
+    # Same toucher as the eater, but OOM-preferred instead of exempt.
+    sed 's/-1000/1000/' /tmp/eater.c > /tmp/eater_balloon.c
+    gcc -O2 -o /tmp/eater_balloon /tmp/eater_balloon.c
+}
+
+# Memory/swap telemetry, one line per 15s: proof the pressure actually
+# materialized (a passing run with untouched swap/dirty proves nothing).
+start_mem_telemetry()
+{
+    (
+	trap - ERR
+	set +e
+	while true; do
+	    grep -E "SwapFree|MemFree|Dirty|Writeback:" /proc/meminfo | tr '\n' ' '
+	    echo
+	    sleep 15
+	done
+    ) &
+    mem_telemetry_pid=$!
+}
+
+stop_mem_telemetry()
+{
+    [[ -n ${mem_telemetry_pid:-} ]] || return 0
+    kill $mem_telemetry_pid 2>/dev/null || true
+    wait $mem_telemetry_pid 2>/dev/null || true
+    mem_telemetry_pid=
+}
+
+# hung_task fast-fail for the pressure phase only — swapoff/teardown
+# legitimately sit in D state for a long time under load.
+hung_task_panic_on()
+{
+    echo 30 > /proc/sys/kernel/hung_task_timeout_secs
+    echo 1  > /proc/sys/kernel/hung_task_panic
+}
+
+hung_task_panic_off()
+{
+    echo 0 > /proc/sys/kernel/hung_task_panic
+}

--- a/tests/fs/bcachefs/reconcile-csum-combined-needrb.ktest
+++ b/tests/fs/bcachefs/reconcile-csum-combined-needrb.ktest
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+#
+# Does a COMBINED need_rb set defeat the metadata-only rechecksum fix?
+#
+# The fix (3529712a9b17) dispatches on an exact-equality test,
+# data/reconcile/work.c:
+#
+#     if (r && r->need_rb == BIT(BCH_RECONCILE_data_checksum)) {
+#             unsigned csum_type = bch2_data_checksum_type_rb(c, *r);
+#             ret = reconcile_rechecksum_extent(trans, iter, k, csum_type);
+#
+# Any extent needing more than the checksum fails that test and falls through to
+# the full-rewrite path -- the path that livelocks on compressed extents, because
+# bch2_write_prep_encoded_data()'s "write the extent as is" fast path only
+# rechecksums UNCOMPRESSED data, so the rewrite lands still carrying the old
+# checksum type and set_needs_reconcile re-flags it.
+#
+# fsck -y on the production filesystem reported exactly that shape at scale:
+#
+#     60,233  need_rb=data_replicas,data_checksum
+#     12,668  need_rb=data_replicas,data_checksum,background_target
+#         5   need_rb=data_checksum                    <-- the only shape the fix catches
+#
+# Production runs a kernel carrying the fix and livelocks anyway, with `checksum`
+# pinned at 73.4G byte-identical across hours. reconcile-csum.ktest (1 device)
+# and reconcile-csum-multidev.ktest (4 devices, replicas=2, targets, 1500 small
+# files) both PASS -- and in both, every extent has a PURE need_rb=data_checksum,
+# because replicas were already satisfied before the checksum changed. Neither
+# test has ever exercised a combined set.
+#
+# This test creates one: format at data_replicas=1, write, settle, then raise
+# data_replicas AND change data_checksum together, so every extent needs both.
+#
+# NOT the dedup hypothesis. That one (stale `r` after bch2_dedup_extent()) does
+# not survive reading the code: dedup's terminal and index paths mutate only
+# dedup_pending, never need_rb; a successful dedup converts the extent to
+# reflink_p, which work.c:1028 catches before the checksum dispatch; and
+# bch2_dedup_extent() skips compressed extents outright (dedup.c, crc_is_compressed)
+# while 100% of the production extents seen pinned were `compress zstd`.
+# reconcile-csum-dedup.ktest cannot be made to work as written for that last
+# reason -- its two preconditions are mutually exclusive on the same extent.
+#
+# PRECONDITION DISCIPLINE: reconcile-csum-dedup.ktest burned a VM run discovering
+# at runtime that its precondition was unsatisfiable by construction. So this test
+# asserts the need_rb shape it depends on, and prints the full histogram on every
+# path -- pass or fail. A run that cannot show a combined need_rb says nothing
+# about the hypothesis and must report that rather than a verdict.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+config-scratch-devs 4G
+config-scratch-devs 4G
+config-scratch-devs 8G
+config-scratch-devs 8G
+
+config-mem 6G
+config-timeout 1800
+
+devs()
+{
+    echo ${ktest_scratch_dev[0]} ${ktest_scratch_dev[1]} \
+	 ${ktest_scratch_dev[2]} ${ktest_scratch_dev[3]}
+}
+
+devs_colon()
+{
+    echo ${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]}:${ktest_scratch_dev[2]}:${ktest_scratch_dev[3]}
+}
+
+# Parse `bcachefs reconcile status`, which prints one row per reconcile class:
+#
+#                      data  metadata
+#     replicas:           0         0
+#     checksum:       73.4G         0
+#
+# NB: NOT `fs usage -f rebalance_work` with `$1 == "checksum:"` -- that silently
+# yields EMPTY strings on a multi-device fs, so the settle loop never sees work
+# and never detects a livelock. Print the raw fields so a parse failure is loud.
+reconcile_row_raw()
+{
+    bcachefs reconcile status /mnt | awk -v r="$1:" '$1 == r { print $2, $3; found = 1 }
+	END { if (!found) print "PARSE-FAILED" }'
+}
+
+data_update_sectors()
+{
+    awk '/since mount/ { print $3 }' /sys/fs/bcachefs/*/counters/data_update
+}
+
+# Many small, highly compressible files. The production population is source
+# code, headers, HTML docs and JS bundles of 4-18 KB, which compress to the 4k
+# floor (c_size 8). One big file does NOT produce that extent shape.
+write_small_compressible_files()
+{
+    local dir=$1 count=$2
+    mkdir -p "$dir"
+    local block="the quick brown fox jumps over the lazy dog 0123456789 "
+    local unit="" i
+    for ((i = 0; i < 18; i++)); do unit="$unit$block"; done	# ~1 KB
+    for ((i = 0; i < count; i++)); do
+	local reps=$(( 8 + (i % 25) ))				# ~8-32 KB
+	local j out=""
+	for ((j = 0; j < reps; j++)); do out="$out$unit"; done
+	printf '%s' "$out" > "$dir/f$i"
+    done
+    sync
+}
+
+# Poll a reconcile row to 0 (3 consecutive zeros), kicking reconcile each round
+# and printing data_update alongside, so a livelock -- row pinned while bytes
+# moved climbs without bound -- is visible in the log rather than inferred.
+reconcile_row_settle()
+{
+    local row=$1 iters=${2:-90} zeros=0 i
+    for ((i = 0; i < iters; i++)); do
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+	sleep 2
+	local raw=$(reconcile_row_raw $row)
+	echo "t=$((i * 2))s	$row: [$raw]	data_update: $(data_update_sectors)"
+	if [[ $raw == PARSE-FAILED ]]; then
+	    echo "FAIL: cannot parse the '$row' row out of reconcile status"
+	    bcachefs reconcile status /mnt || true
+	    return 2
+	fi
+	if [[ $raw == "0 0" ]]; then
+	    if (( ++zeros >= 3 )); then return 0; fi
+	else
+	    zeros=0
+	fi
+    done
+    echo "reconcile $row work did not settle"
+    bcachefs reconcile status /mnt || true
+    return 1
+}
+
+# Histogram of the need_rb sets actually present on disk. This is the evidence
+# the whole test turns on, so it is printed on every path, not only on failure.
+print_needrb_histogram()
+{
+    local keys=$1 label=$2
+    echo "--- need_rb histogram ($label) ---"
+    grep --only-matching 'need_rb=[a-z_,]*' <<<"$keys" | sort | uniq -c | sort -rn ||
+	echo "(no need_rb entries found)"
+    echo "---"
+}
+
+# Shared body: build the production extent shape at data_replicas=1, then apply
+# whatever option change the caller wants and see whether checksum work drains.
+#
+# $1 = "combined" (raise data_replicas as well) or "csum-only" (control)
+run_csum_change()
+{
+    local mode=$1
+
+    set_watchdog 1500
+
+    # data_replicas=1 so that raising it later leaves every extent needing
+    # BOTH data_replicas and data_checksum. The multidev test formats at
+    # replicas=2, which is precisely why its need_rb stays pure.
+    run_quiet "" bcachefs format -f				\
+	--block_size=4k						\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}		\
+	--label=ssd.ssd2 ${ktest_scratch_dev[1]}		\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}		\
+	--label=hdd.hdd2 ${ktest_scratch_dev[3]}		\
+	--foreground_target=ssd					\
+	--background_target=hdd					\
+	--promote_target=ssd					\
+	--data_replicas=1					\
+	--data_checksum=crc32c					\
+	--compression=zstd					\
+	--background_compression=zstd:15
+
+    mount -t bcachefs $(devs_colon) /mnt
+
+    write_small_compressible_files /mnt/data 1500
+
+    # Settle compression and target FIRST, so the extents are in the production
+    # shape (compressed to the floor, on the hdd target) before anything else
+    # changes. If this never settles we have a different bug and must stop.
+    echo "--- settling initial background work (compression/target) ---"
+    if ! reconcile_row_settle compression 90; then
+	echo "FAIL: initial compression work never settled -- not the csum bug"
+	return 1
+    fi
+    reconcile_row_settle target 90 || echo "WARNING: target row did not settle"
+
+    umount /mnt
+
+    local keys=$(bcachefs list -b extents $(devs) 2>/dev/null)
+
+    # Precondition A: compressed to the 4k floor, crc32c, durability 1.
+    local n_floor=$(awk '
+	$2 == "c_size" && $4 == "size" && $3 + 0 == 8 && $3 + 0 < $5 + 0 && $11 == "crc32c" { n++ }
+	END { print n + 0 }' <<<"$keys")
+    local n_dur1=$(grep --count "durability: 1" <<<"$keys" || true)
+    echo "precondition A: c_size-8 crc32c extents=$n_floor, durability-1 keys=$n_dur1"
+
+    if (( n_floor == 0 )); then
+	echo "FAIL: precondition A -- no compressed crc32c extents at the 4k floor"
+	grep --extended-regexp "type extent|crc[0-9]*:" <<<"$keys" | head --lines=20
+	return 1
+    fi
+
+    mount -t bcachefs $(devs_colon) /mnt
+
+    # The option change(s). Order matters only in that both must be in force
+    # before reconcile evaluates the extents; the scan is queued by the hook on
+    # each set, and the second set re-queues it.
+    if [[ $mode == combined ]]; then
+	echo "--- raising data_replicas 1 -> 2 AND changing data_checksum crc32c -> xxhash ---"
+	bcachefs set-fs-option --data_replicas=2   ${ktest_scratch_dev[0]}
+	bcachefs set-fs-option --data_checksum=xxhash ${ktest_scratch_dev[0]}
+    else
+	echo "--- changing data_checksum crc32c -> xxhash ONLY (control) ---"
+	bcachefs set-fs-option --data_checksum=xxhash ${ktest_scratch_dev[0]}
+    fi
+
+    local settled=0
+    reconcile_row_settle checksum 90 && settled=1
+
+    umount /mnt
+
+    keys=$(bcachefs list -b extents $(devs) 2>/dev/null)
+    local stale=$(grep --count "csum crc32c" <<<"$keys" || true)
+    local converted=$(grep --count "csum xxhash" <<<"$keys" || true)
+    echo "extents still crc32c: $stale, converted to xxhash: $converted"
+
+    print_needrb_histogram "$keys" "after the change, mode=$mode"
+
+    # Precondition B, and it can only be checked here: the combined run is
+    # meaningless unless a combined need_rb set actually materialised. In the
+    # predicted (livelocked) outcome the extents are still on disk carrying it.
+    if [[ $mode == combined ]]; then
+	local n_combined=$(grep --count 'need_rb=[a-z_]*,[a-z_,]*' <<<"$keys" || true)
+	echo "precondition B: extents carrying a COMBINED need_rb set = $n_combined"
+	if (( n_combined == 0 )) && (( stale > 0 )); then
+	    echo "INCONCLUSIVE: extents did not convert, but none carries a combined"
+	    echo "need_rb either -- so this run does not test the exact-equality guard."
+	    return 1
+	fi
+    fi
+
+    if (( ! settled )) || (( stale > 0 )); then
+	echo "FAIL: data_checksum change did not complete (mode=$mode)"
+	echo "--- a sample of what is left ---"
+	grep --before-context=2 --after-context=6 "csum crc32c" <<<"$keys" | head --lines=30
+	return 1
+    fi
+
+    bcachefs fsck -ny $(devs)
+    bcachefs_test_end_checks $(devs)
+}
+
+# The experiment: every extent needs data_replicas AND data_checksum, so the
+# exact-equality guard misses all of them. If the hypothesis holds this
+# livelocks -- checksum row pinned, data_update climbing, nothing converted.
+test_csum_change_combined_needrb()
+{
+    run_csum_change combined
+}
+
+# The control: same filesystem shape, same data, same code path, but only the
+# checksum changes, so need_rb is pure and the guard matches. Expected to PASS.
+# A run where BOTH subtests fail indicts the shape, not the guard.
+test_csum_change_csum_only_control()
+{
+    run_csum_change csum-only
+}
+
+main "$@"

--- a/tests/fs/bcachefs/reconcile-csum-dedup.ktest
+++ b/tests/fs/bcachefs/reconcile-csum-dedup.ktest
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+#
+# Does background dedup defeat the metadata-only rechecksum fix?
+#
+# reconcile-csum.ktest (single device) and reconcile-csum-multidev.ktest
+# (4 devices, replicas=2, ssd/hdd targets, small files) both PASS on the
+# swap-files kernel: every extent converts. Yet production -- running that same
+# kernel -- livelocks on exactly this work, `checksum` pinned at 73.4G
+# byte-identical across hours while bytes-moved climbs ~10.4 GB per 2 minutes.
+#
+# The one thing production has that neither test had is background dedup:
+# background_dedup=1, ~230k extents indexed. And __do_reconcile_extent() has a
+# suspicious ordering:
+#
+#     const struct bch_extent_reconcile *r = bch2_bkey_reconcile_opts(c, k);
+#
+#     if (r && r->dedup_pending) {
+#             bch2_dedup_extent(ctxt, opts, iter, k);
+#             /* The key might have been modified by dedup, re-read */
+#             k = bkey_try(bch2_btree_iter_peek_slot(iter));
+#             ...
+#     }
+#     ...
+#     if (r && r->need_rb == BIT(BCH_RECONCILE_data_checksum)) {
+#
+# `r` is derived from the pre-dedup `k` and never recomputed, though the code
+# explicitly re-reads `k` and says so. After a dedup pass the checksum-only
+# dispatch therefore tests a stale need_rb -- and `r` points into a bkey buffer
+# that may since have been reused. If that is the bug, extents that went through
+# dedup miss the metadata-only path and fall into the full-rewrite livelock.
+#
+# This test is that experiment: the multidev shape plus background_dedup=1, and
+# deliberately duplicated file content so dedup has work to do.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+config-scratch-devs 4G
+config-scratch-devs 4G
+config-scratch-devs 8G
+config-scratch-devs 8G
+
+config-mem 6G
+config-timeout 1800
+
+# Parse `bcachefs reconcile status`, which prints one row per reconcile class:
+#
+#                      data  metadata
+#     replicas:           0         0
+#     checksum:       73.4G         0
+#
+# Earlier versions of this test parsed `fs usage -f rebalance_work` with
+# `$1 == "checksum:"`, which silently produced EMPTY strings on a multi-device
+# fs -- so the settle loop never saw work and never detected a livelock. Print
+# the raw fields so a parse failure is visible rather than silent.
+reconcile_row_raw()
+{
+    bcachefs reconcile status /mnt | awk -v r="$1:" '$1 == r { print $2, $3; found = 1 }
+	END { if (!found) print "PARSE-FAILED" }'
+}
+
+reconcile_row_busy()
+{
+    local vals=$(reconcile_row_raw "$1")
+    [[ $vals == PARSE-FAILED ]] && return 2
+    [[ $vals == "0 0" ]] && return 1
+    return 0
+}
+
+data_update_sectors()
+{
+    awk '/since mount/ { print $3 }' /sys/fs/bcachefs/*/counters/data_update
+}
+
+dedup_counter()
+{
+    awk '/since mount/ { print $3 }' /sys/fs/bcachefs/*/counters/$1 2>/dev/null
+}
+
+# Many small, highly compressible files, each written TWICE under different
+# names so dedup has real work: the production population is source code and
+# JS/HTML of 4-18 KB compressing to the 4k floor (c_size 8).
+write_dedupable_files()
+{
+    local dir=$1 count=$2
+    mkdir -p "$dir/a" "$dir/b"
+    local block="the quick brown fox jumps over the lazy dog 0123456789 "
+    local unit="" i
+    for ((i = 0; i < 18; i++)); do unit="$unit$block"; done	# ~1 KB
+    for ((i = 0; i < count; i++)); do
+	local reps=$(( 8 + (i % 25) ))				# ~8-32 KB
+	local j out=""
+	for ((j = 0; j < reps; j++)); do out="$out$unit"; done
+	printf '%s' "$out" > "$dir/a/f$i"
+	printf '%s' "$out" > "$dir/b/f$i"			# identical copy
+    done
+    sync
+}
+
+reconcile_row_settle()
+{
+    local row=$1 iters=${2:-90} zeros=0 i
+    for ((i = 0; i < iters; i++)); do
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+	sleep 2
+	local raw=$(reconcile_row_raw $row)
+	echo "t=$((i * 2))s	$row: [$raw]	data_update: $(data_update_sectors)	deduped: $(dedup_counter dedup_extent_deduped)"
+	if [[ $raw == PARSE-FAILED ]]; then
+	    echo "FAIL: cannot parse the '$row' row out of reconcile status"
+	    bcachefs reconcile status /mnt || true
+	    return 2
+	fi
+	if [[ $raw == "0 0" ]]; then
+	    if (( ++zeros >= 3 )); then return 0; fi
+	else
+	    zeros=0
+	fi
+    done
+    echo "reconcile $row work did not settle"
+    bcachefs reconcile status /mnt || true
+    return 1
+}
+
+test_csum_change_with_dedup()
+{
+    set_watchdog 1500
+
+    run_quiet "" bcachefs format -f				\
+	--block_size=4k						\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}		\
+	--label=ssd.ssd2 ${ktest_scratch_dev[1]}		\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}		\
+	--label=hdd.hdd2 ${ktest_scratch_dev[3]}		\
+	--foreground_target=ssd					\
+	--background_target=hdd					\
+	--promote_target=ssd					\
+	--data_replicas=2					\
+	--data_checksum=crc32c					\
+	--compression=zstd					\
+	--background_compression=zstd:15
+
+    local devs=${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]}:${ktest_scratch_dev[2]}:${ktest_scratch_dev[3]}
+    mount -t bcachefs $devs /mnt
+
+    # NB: enable dedup via sysfs, not `format --background_dedup=1`. ktest builds
+    # and caches STOCK bcachefs-tools, which has no such option (dedup is
+    # out-of-tree) -- format rejects it with "unknown option". The option is
+    # OPT_RUNTIME, so the kernel under test can set it after mount.
+    echo 1 > /sys/fs/bcachefs/*/options/background_dedup
+    echo "background_dedup = $(cat /sys/fs/bcachefs/*/options/background_dedup)"
+    if [[ $(cat /sys/fs/bcachefs/*/options/background_dedup) != 1 ]]; then
+	echo "FAIL: could not enable background_dedup -- this kernel may not have it"
+	return 1
+    fi
+
+    write_dedupable_files /mnt/data 1200
+
+    echo "--- settling initial background work, and letting dedup index ---"
+    reconcile_row_settle compression 120 || echo "WARNING: compression row did not settle"
+    reconcile_row_settle target 120      || echo "WARNING: target row did not settle"
+
+    # Give dedup a chance to actually run over the duplicate copies.
+    local w
+    for ((w = 0; w < 30; w++)); do
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+	sleep 2
+    done
+    echo "dedup indexed: $(dedup_counter dedup_extent_indexed), deduped: $(dedup_counter dedup_extent_deduped)"
+
+    if [[ $(dedup_counter dedup_extent_indexed) == 0 ]]; then
+	echo "FAIL: precondition -- dedup never indexed anything, so this test" \
+	     "cannot say anything about dedup's effect on the rechecksum path"
+	return 1
+    fi
+
+    umount /mnt
+
+    local keys=$(bcachefs list -b extents ${ktest_scratch_dev[0]} ${ktest_scratch_dev[1]} ${ktest_scratch_dev[2]} ${ktest_scratch_dev[3]} 2>/dev/null)
+    local n_floor=$(awk '
+	$2 == "c_size" && $4 == "size" && $3 + 0 == 8 && $3 + 0 < $5 + 0 && $11 == "crc32c" { n++ }
+	END { print n + 0 }' <<<"$keys")
+    echo "precondition: c_size-8 crc32c extents=$n_floor"
+    if (( n_floor == 0 )); then
+	echo "FAIL: precondition -- no compressed crc32c extents at the 4k floor"
+	return 1
+    fi
+
+    mount -t bcachefs $devs /mnt
+
+    bcachefs set-fs-option --data_checksum=xxhash ${ktest_scratch_dev[0]}
+
+    local settled=0
+    reconcile_row_settle checksum 120 && settled=1
+
+    umount /mnt
+
+    keys=$(bcachefs list -b extents ${ktest_scratch_dev[0]} ${ktest_scratch_dev[1]} ${ktest_scratch_dev[2]} ${ktest_scratch_dev[3]} 2>/dev/null)
+    local stale=$(grep --count "csum crc32c" <<<"$keys" || true)
+    local converted=$(grep --count "csum xxhash" <<<"$keys" || true)
+    echo "extents still crc32c: $stale, converted to xxhash: $converted"
+
+    if (( ! settled )) || (( stale > 0 )); then
+	echo "FAIL: data_checksum change did not complete with background dedup on"
+	echo "--- sample of what is left ---"
+	grep --before-context=2 --after-context=6 "csum crc32c" <<<"$keys" | head --lines=30
+	return 1
+    fi
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]} ${ktest_scratch_dev[1]} ${ktest_scratch_dev[2]} ${ktest_scratch_dev[3]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]} ${ktest_scratch_dev[1]} ${ktest_scratch_dev[2]} ${ktest_scratch_dev[3]}
+}
+
+main "$@"

--- a/tests/fs/bcachefs/reconcile-csum-kmemleak.ktest
+++ b/tests/fs/bcachefs/reconcile-csum-kmemleak.ktest
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Run the checksum-only rechecksum path under kmemleak.
+#
+# Why: reconcile_rechecksum_extent() allocates a read buffer per extent and must
+# free it on every exit path. While porting it to bcachefs-tools the raw
+# alloc_page()/__bio_add_page()/bio_free_pages() trio had to be swapped for
+# bch2_bio_alloc_pages()/bch2_bio_free_pages_pool(); an intermediate version of
+# that change dropped the free entirely, which would have leaked one buffer per
+# converted extent. That was caught by reading the code, not by a tool.
+#
+# CONFIG_DEBUG_KMEMLEAK is available in the ktest kernel (HAVE_DEBUG_KMEMLEAK=y)
+# but off by default. With it on, a leak in this path shows up directly: the
+# test converts 256 extents, so a per-extent leak is 256 unreferenced objects.
+#
+# This is a tooling test, not a correctness test -- it deliberately re-runs the
+# same workload as reconcile-csum.ktest and then asks the kernel whether
+# anything was left behind.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+config-scratch-devs 4G
+config-mem 4G
+config-timeout 1200
+
+require-kernel-config DEBUG_KMEMLEAK
+require-kernel-config DEBUG_FS
+
+reconcile_work_remaining()
+{
+    bcachefs fs usage -f rebalance_work /mnt | awk '
+	$1 ~ /^(replicas|checksum|erasure_code|compression|target|high_priority|stripes):$/ { sum += $2 + $3 }
+	END { print sum + 0 }'
+}
+
+# kmemleak needs two scans with a gap: the first primes it, and objects must
+# survive a full scan cycle before being reported, which suppresses transients
+# still referenced from registers/stack.
+kmemleak_scan_and_report()
+{
+    local label=$1
+    echo clear > /sys/kernel/debug/kmemleak
+    sleep 5
+    echo scan > /sys/kernel/debug/kmemleak
+    sleep 10
+    echo scan > /sys/kernel/debug/kmemleak
+    sleep 5
+
+    local report=/tmp/kmemleak-$label.txt
+    cat /sys/kernel/debug/kmemleak > $report 2>/dev/null
+
+    local n=$(grep --count 'unreferenced object' $report || true)
+    echo "kmemleak [$label]: $n unreferenced objects"
+    if (( n )); then
+	echo "--- first 60 lines of the report ---"
+	head --lines=60 $report
+	# Anything mentioning bcachefs is ours and is what we care about.
+	local ours=$(grep --count --ignore-case 'bch2_\|bcachefs' $report || true)
+	echo "kmemleak [$label]: $ours of those name a bcachefs symbol"
+	return $ours
+    fi
+    return 0
+}
+
+test_rechecksum_kmemleak()
+{
+    set_watchdog 900
+
+    run_quiet "" bcachefs format -f		\
+	--block_size=4k				\
+	--data_checksum=crc32c			\
+	--compression=zstd			\
+	--background_compression=zstd		\
+	${ktest_scratch_dev[0]}
+
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+    dd if=/dev/zero of=/mnt/data bs=1M count=64 conv=fsync status=none
+    umount /mnt
+
+    mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
+
+    # Baseline: whatever mount/recovery leaves behind is not our concern.
+    kmemleak_scan_and_report baseline || true
+
+    bcachefs set-fs-option --data_checksum=xxhash ${ktest_scratch_dev[0]}
+
+    local i zeros=0 settled=0
+    for ((i = 0; i < 45; i++)); do
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+	sleep 2
+	local work=$(reconcile_work_remaining)
+	echo "t=$((i * 2))s	work remaining: $work"
+	if (( work )); then
+	    zeros=0
+	elif (( ++zeros >= 3 )); then
+	    settled=1
+	    break
+	fi
+    done
+
+    if (( ! settled )); then
+	echo "NOTE: reconcile did not settle; kmemleak result below still valid"
+    fi
+
+    # The interesting scan: after the rechecksum path has run over every extent.
+    local leaked=0
+    kmemleak_scan_and_report after-rechecksum || leaked=$?
+
+    umount /mnt
+
+    if (( leaked )); then
+	echo "FAIL: kmemleak reports $leaked leaked object(s) naming bcachefs" \
+	     "after the checksum-only rechecksum path ran"
+	return 1
+    fi
+
+    echo "PASS: no bcachefs-attributed leaks after rechecksum"
+    bcachefs fsck -ny ${ktest_scratch_dev[0]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+main "$@"

--- a/tests/fs/bcachefs/reconcile-csum-multidev.ktest
+++ b/tests/fs/bcachefs/reconcile-csum-multidev.ktest
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# Why this exists: reconcile-csum.ktest's test_csum_change_compressed PASSES on
+# the swap-files kernel (which carries 3529712a9b17, the metadata-only
+# rechecksum), yet the production desktop -- running that same fix -- livelocks
+# on exactly this work: `checksum` row pinned at 73.4G byte-identical across
+# hours while moving_ctxts bytes-moved climbs ~10.4 GB per 2 minutes.
+#
+# So something about the production shape defeats the fix, and the single-device
+# test does not capture it. Differences, mirrored here:
+#
+#   single-device test          production
+#   ------------------          ----------
+#   1 device                    5 devices, ssd/hdd groups
+#   data_replicas=1 (implicit)  data_replicas=2
+#   no targets                  foreground=ssd background=hdd promote=ssd
+#   compression=zstd (default)  background_compression=zstd:15
+#   one 64 MB file              many small files
+#   extents size 512, c_size 8  extents size 16..128, c_size 8
+#
+# The production extents seen pinned in moving_ctxts look like:
+#
+#   u64s 9 type extent 1275205062:16:U32_MAX len 16 : durability: 2
+#     reconcile: need_rb=data_checksum replicas=2 checksum=xxhash
+#                background_compression=zstd:15 background_target=hdd
+#                promote_target=ssd
+#     crc32: c_size 8 size 16 offset 0 nonce 0 csum crc32c  compress zstd
+#     ptr: sdd1 ...   ptr: sdc ...
+#
+# i.e. durability 2, both pointers on the background (hdd) target, compressed
+# to the 4k floor, pure need_rb=data_checksum.
+#
+# Leading hypothesis (untested): the fix dispatches only on
+#   r->need_rb == BIT(BCH_RECONCILE_data_checksum)
+# an exact-equality test. fsck -y on production reported large populations with
+# combined sets -- need_rb=data_replicas,data_checksum (60233) and
+# need_rb=data_replicas,data_checksum,background_target (12668) -- which fail
+# that test and fall through to the full-rewrite path that livelocks.
+# Against it: the extents actually observed pinned had a pure need_rb. This test
+# is meant to settle which.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+config-scratch-devs 4G
+config-scratch-devs 4G
+config-scratch-devs 8G
+config-scratch-devs 8G
+
+config-mem 6G
+config-timeout 1800
+
+reconcile_row_bytes()
+{
+    bcachefs fs usage -f rebalance_work /mnt | awk -v r="$1:" '
+	$1 == r { print $2 + $3; exit }'
+}
+
+reconcile_work_remaining()
+{
+    bcachefs fs usage -f rebalance_work /mnt | awk '
+	$1 ~ /^(replicas|checksum|erasure_code|compression|target|high_priority|stripes):$/ { sum += $2 + $3 }
+	END { print sum + 0 }'
+}
+
+data_update_sectors()
+{
+    awk '/since mount/ { print $3 }' /sys/fs/bcachefs/*/counters/data_update
+}
+
+# Many small, highly compressible files -- the production population is source
+# code, headers, HTML docs and JS bundles of 4-18 KB, which compress to the 4k
+# floor (c_size 8). One big file does NOT produce that extent shape.
+write_small_compressible_files()
+{
+    local dir=$1 count=$2
+    mkdir -p "$dir"
+    # A compressible ~1 KB block; repeated to reach each file's size.
+    local block="the quick brown fox jumps over the lazy dog 0123456789 "
+    local unit=""
+    local i
+    for ((i = 0; i < 18; i++)); do unit="$unit$block"; done   # ~1 KB
+    for ((i = 0; i < count; i++)); do
+	local reps=$(( 8 + (i % 25) ))                        # ~8-32 KB
+	local j out=""
+	for ((j = 0; j < reps; j++)); do out="$out$unit"; done
+	printf '%s' "$out" > "$dir/f$i"
+    done
+    sync
+}
+
+# Poll a rebalance_work row to 0 (3 consecutive zeros), kicking reconcile each
+# round and printing data_update alongside, so a livelock (row pinned while
+# bytes moved climbs) is visible in the log. Returns 1 on timeout.
+reconcile_row_settle()
+{
+    local row=$1 iters=${2:-90} zeros=0 i
+    for ((i = 0; i < iters; i++)); do
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+	sleep 2
+	local work=$(reconcile_row_bytes $row)
+	echo "t=$((i * 2))s	$row remaining: $work	data_update: $(data_update_sectors)"
+	if (( work )); then
+	    zeros=0
+	elif (( ++zeros >= 3 )); then
+	    return 0
+	fi
+    done
+    echo "reconcile $row work did not settle"
+    bcachefs reconcile status /mnt || true
+    bcachefs fs usage -f rebalance_work /mnt || true
+    return 1
+}
+
+test_csum_change_multidev()
+{
+    set_watchdog 1500
+
+    run_quiet "" bcachefs format -f				\
+	--block_size=4k						\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}		\
+	--label=ssd.ssd2 ${ktest_scratch_dev[1]}		\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}		\
+	--label=hdd.hdd2 ${ktest_scratch_dev[3]}		\
+	--foreground_target=ssd					\
+	--background_target=hdd					\
+	--promote_target=ssd					\
+	--data_replicas=2					\
+	--data_checksum=crc32c					\
+	--compression=zstd					\
+	--background_compression=zstd:15
+
+    mount -t bcachefs ${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]}:${ktest_scratch_dev[2]}:${ktest_scratch_dev[3]} /mnt
+
+    write_small_compressible_files /mnt/data 1500
+
+    # Let the initial background work (compression + move to hdd) settle, so the
+    # extents are in the production shape BEFORE the checksum change. If this
+    # does not settle we have a different bug and should stop here.
+    echo "--- settling initial background work (compression/target) ---"
+    if ! reconcile_row_settle compression 90; then
+	echo "FAIL: initial compression work never settled -- not the csum bug"
+	return 1
+    fi
+    reconcile_row_settle target 90 || echo "WARNING: target row did not settle"
+
+    umount /mnt
+
+    local keys=$(bcachefs list -b extents ${ktest_scratch_dev[0]} ${ktest_scratch_dev[1]} ${ktest_scratch_dev[2]} ${ktest_scratch_dev[3]} 2>/dev/null)
+
+    # Production shape: compressed to the floor, crc32c, durability 2.
+    local n_floor=$(awk '
+	$2 == "c_size" && $4 == "size" && $3 + 0 == 8 && $3 + 0 < $5 + 0 && $11 == "crc32c" { n++ }
+	END { print n + 0 }' <<<"$keys")
+    local n_dur2=$(grep --count "durability: 2" <<<"$keys" || true)
+    echo "precondition: c_size-8 crc32c extents=$n_floor, durability-2 keys=$n_dur2"
+
+    if (( n_floor == 0 )); then
+	echo "FAIL: precondition -- no compressed crc32c extents at the 4k floor"
+	grep --extended-regexp "type extent|crc[0-9]*:" <<<"$keys" | head --lines=20
+	return 1
+    fi
+
+    mount -t bcachefs ${ktest_scratch_dev[0]}:${ktest_scratch_dev[1]}:${ktest_scratch_dev[2]}:${ktest_scratch_dev[3]} /mnt
+
+    bcachefs set-fs-option --data_checksum=xxhash ${ktest_scratch_dev[0]}
+
+    local settled=0
+    reconcile_row_settle checksum 90 && settled=1
+
+    umount /mnt
+
+    keys=$(bcachefs list -b extents ${ktest_scratch_dev[0]} ${ktest_scratch_dev[1]} ${ktest_scratch_dev[2]} ${ktest_scratch_dev[3]} 2>/dev/null)
+    local stale=$(grep --count "csum crc32c" <<<"$keys" || true)
+    local converted=$(grep --count "csum xxhash" <<<"$keys" || true)
+    echo "extents still crc32c: $stale, converted to xxhash: $converted"
+
+    if (( ! settled )) || (( stale > 0 )); then
+	echo "FAIL: data_checksum change did not complete on a multi-device," \
+	     "replicas=2, targeted filesystem"
+	echo "--- a sample of what is left ---"
+	grep --before-context=2 --after-context=6 "csum crc32c" <<<"$keys" | head --lines=30
+	return 1
+    fi
+
+    bcachefs fsck -ny ${ktest_scratch_dev[0]} ${ktest_scratch_dev[1]} ${ktest_scratch_dev[2]} ${ktest_scratch_dev[3]}
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]} ${ktest_scratch_dev[1]} ${ktest_scratch_dev[2]} ${ktest_scratch_dev[3]}
+}
+
+main "$@"

--- a/tests/fs/bcachefs/reconcile-csum.ktest
+++ b/tests/fs/bcachefs/reconcile-csum.ktest
@@ -52,13 +52,49 @@ test_csum_change_compressed()
     umount /mnt
 
     # Precondition: extents must be compressed and crc32c, or we're not
-    # exercising the encoded-data fast path at all
-    local keys=$(bcachefs list -b extents ${ktest_scratch_dev[0]})
-    if ! echo "$keys" | grep -q "csum crc32c.*compress zstd"; then
-	echo "FAIL: precondition — expected zstd-compressed crc32c extents, got:"
-	echo "$keys" | head -20
+    # exercising the encoded-data fast path at all.
+    #
+    # NB: do NOT test this with a single regex spanning both markers.
+    # The crc line is exactly 81 chars and "compress zstd" sits at the very
+    # end (cols 68-81), so any 80-column wrap or truncation in the harness
+    # splits "zstd" and the match fails — while the log still *looks* correct
+    # to a human reading it. That is what made this precondition fail
+    # spuriously in 3s; verified 2026-07-27 against a loopback fs formatted
+    # with these exact options, where the markers do land as expected:
+    #   crc64: c_size 8 size 512 offset 0 nonce 0 csum crc32c 0:… compress zstd
+    local keys keys_rc
+    local errf=$(mktemp)
+    keys=$(bcachefs list -b extents ${ktest_scratch_dev[0]} 2>"$errf"); keys_rc=$?
+
+    if (( keys_rc != 0 )); then
+	echo "FAIL: precondition — 'bcachefs list -b extents' exited $keys_rc"
+	echo "stderr:"; cat "$errf"
+	rm -f "$errf"
 	return 1
     fi
+
+    # Test compression SEMANTICALLY (c_size < size) rather than by the
+    # "compress zstd" label: c_size/size sit at cols ~10-30 and survive
+    # truncation, whereas the label does not. This is also the stronger
+    # assertion — it checks the extent is actually compressed, not merely
+    # labelled. Field layout of a crc line:
+    #   $1=crc64: $2=c_size $3=N $4=size $5=N … $10=csum $11=<type> … $14=<compression>
+    local n_compressed_crc32c=$(awk '
+	$2 == "c_size" && $4 == "size" && $3 + 0 < $5 + 0 && $11 == "crc32c" { n++ }
+	END { print n + 0 }' <<<"$keys")
+    local n_crc32c=$(grep -c "csum crc32c" <<<"$keys" || true)
+    echo "precondition: crc32c lines=$n_crc32c, compressed+crc32c extents=$n_compressed_crc32c"
+
+    if (( n_compressed_crc32c == 0 )); then
+	echo "FAIL: precondition — expected compressed crc32c extents"
+	echo "  captured $(wc -l <<<"$keys") lines from stdout"
+	echo "  stderr:"; cat "$errf"
+	echo "  extent/crc lines seen:"
+	grep -E "type extent|crc[0-9]*:" <<<"$keys" | head -20
+	rm -f "$errf"
+	return 1
+    fi
+    rm -f "$errf"
 
     mount -t bcachefs ${ktest_scratch_dev[0]} /mnt
 

--- a/tests/fs/bcachefs/reconcile-journal-wedge-slowjournal.ktest
+++ b/tests/fs/bcachefs/reconcile-journal-wedge-slowjournal.ktest
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# Reproduce the journal_max_open wedge seen on a production desktop twice
+# (2026-07-25 and 2026-07-26), both times fatal.
+#
+# Prod shape and sequence, which this mirrors:
+#  - 5 devices in two labelled groups, foreground_target=ssd,
+#    background_target=hdd, data_replicas=2, erasure_code=1,
+#    background_compression=zstd, data_checksum=xxhash.
+#  - A large backlog of extents whose cached io_opts were never set, so they
+#    were never enqueued for reconcile.  A check_reconcile_work pass finally
+#    enumerated them, and reconcile started rewriting ~1.1T.
+#  - Recovery completed cleanly.  ~5 minutes later, under sustained reconcile
+#    write load, the journal wedged: one reservation held on an already-closed
+#    buffer stopped bch2_journal_do_writes_locked() from ever starting its
+#    write, seq_write_started froze, the 4-deep ring filled, and every
+#    journal_entry_open() returned journal_max_open forever.
+#
+# Not swap: reproduced on prod with zero swap-on-bcachefs active.
+# Not recovery: both wedges happened well after recovery finished.
+# The trigger is sustained reconcile/move load on a replicated, EC'd fs.
+#
+# SLOW-JOURNAL VARIANT. Generated from reconcile-journal-wedge.ktest.
+#
+# Why: the base test never reaches the wedge -- depth stayed 0 for its whole
+# 639s run. On uniformly fast virtio, a journal write completes before the next
+# entry opens, so unwritten entries never accumulate and a held reservation can
+# never fill the 4-deep ring. Prod is not like that: sdd1 is Rotational: 1 with
+# "Data allowed: journal,btree,user", so journal writes land on spinning rust.
+# What matters is per-IO LATENCY, not bandwidth.
+#
+# So the hdd tier here sits on dm-delay (same idiom as swapfile_deadlock.ktest's
+# SWAPFILE_TEST_DELAY_MS). Journal writes to those devices then take long enough
+# for depth to sit above 0, which is the precondition for a stuck reservation to
+# be fatal rather than merely slow.
+#
+#   JWEDGE_DELAY_MS=8   per-IO latency on the hdd tier
+#
+# The failure is detected by bcachefs-journal-wedge-detect.sh, which watches
+# depth = (journal head seq - oldest unwritten seq) and fires while the fs is
+# still healthy — deliberately, so a wedge does not have to be reached to get
+# the evidence.  See that file for why "refcount != 0" alone is not the signal.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-journal-wedge-detect.sh
+
+config-scratch-devs 4G
+config-scratch-devs 4G
+config-scratch-devs 8G
+config-scratch-devs 8G
+
+require-kernel-config BLK_DEV_DM
+require-kernel-config DM_DELAY
+
+config-mem 6G
+config-timeout 2400
+
+reconcile_work_remaining()
+{
+    bcachefs fs usage -f rebalance_work /mnt | awk '
+	$1 ~ /^(replicas|checksum|erasure_code|compression|target|high_priority|stripes):$/ { sum += $2 + $3 }
+	END { print sum + 0 }'
+}
+
+journal_depth()
+{
+    awk '
+	!inu && /^seq:/       { head = $2; next }
+	/^unwritten entries:/ { inu = 1; next }
+	inu && /^seq:/        { if (!got) { print head - $2; got = 1 } ; next }
+	END { if (!got) print 0 }
+    ' /sys/fs/bcachefs/*/internal/journal_debug 2>/dev/null
+}
+
+data_update_sectors()
+{
+    awk '/since mount/ { print $3 }' /sys/fs/bcachefs/*/counters/data_update
+}
+
+# Build the backlog the way prod got there: write everything at the WRONG
+# checksum and WITHOUT the second replica, then flip the filesystem options so
+# every extent needs both a rechecksum and a replica add. That is exactly the
+# prod need_rb set (data_replicas,data_checksum,erasure_code,background_target).
+test_reconcile_backlog_journal_wedge_slowjournal()
+{
+    set_watchdog 1800
+
+    # Fake spinning rust for the hdd tier: bcachefs allows journal on every
+    # device, so this is what puts journal writes behind real latency.
+    local delay_ms=${JWEDGE_DELAY_MS:-8}
+    local hdd1 hdd2 i=0
+    for d in "${ktest_scratch_dev[2]}" "${ktest_scratch_dev[3]}"; do
+	local sectors=$(blockdev --getsz "$d")
+	dmsetup create "slowhdd$i" --table "0 $sectors delay $d 0 $delay_ms"
+	i=$((i + 1))
+    done
+    hdd1=/dev/mapper/slowhdd0
+    hdd2=/dev/mapper/slowhdd1
+    echo "=== hdd tier on dm-delay ${delay_ms}ms ==="
+
+    run_quiet "" bcachefs format -f				\
+	--block_size=4k						\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}		\
+	--label=ssd.ssd2 ${ktest_scratch_dev[1]}		\
+	--label=hdd.hdd1 $hdd1					\
+	--label=hdd.hdd2 $hdd2					\
+	--foreground_target=ssd					\
+	--background_target=hdd					\
+	--data_checksum=crc32c					\
+	--data_replicas=1					\
+	--compression=zstd					\
+	--background_compression=zstd
+
+    # Prod mount options, verbatim from the failing box's fstab. These are not
+    # incidental: with flushes disabled and a 10s flush delay, journal entries
+    # stay unwritten far longer, so the fs runs permanently close to the 4-deep
+    # JOURNAL_STATE_BUF_NR limit -- which is what makes a single held
+    # reservation fatal rather than merely slow. The failing boot's dump shows
+    # the ratio this produces: nr noflush writes 1362 vs nr flush writes 46.
+    local mntopts=${JWEDGE_MOUNT_OPTS:-journal_flush_disabled=1,journal_flush_delay=10000}
+
+    # Space-separated for the CLI (fsck/list/set-fs-option take <devices>...),
+    # colon-joined for mount(8).
+    local devs="${ktest_scratch_dev[0]} ${ktest_scratch_dev[1]} $hdd1 $hdd2"
+    local devs_joined="${devs// /:}"
+
+    mount -t bcachefs -o "$mntopts" "$devs_joined" /mnt
+
+    # INCOMPRESSIBLE data on purpose. /dev/zero would be the obvious choice, but
+    # with background_compression=zstd a 2G file of zeros collapses to ~37M of
+    # extents -- measured, first run of this test -- which is no backlog at all.
+    # urandom gives real extent count, and matches prod, whose extent dumps show
+    # "compress incompressible" throughout.
+    local i
+    for i in $(seq 0 7); do
+	dd if=/dev/urandom of=/mnt/data.$i bs=1M count=256 conv=fsync status=none
+    done
+    sync
+
+    echo "=== before flip ==="
+    bcachefs fs usage -h /mnt | grep -A4 undegraded || true
+
+    # Now make every extent need rewriting, on several axes at once.
+    # set-fs-option takes DEVICE paths, not a mountpoint ("error reading
+    # superblock: Is a directory" otherwise), and all members must be named.
+    bcachefs set-fs-option --data_checksum=xxhash	$devs
+    bcachefs set-fs-option --data_replicas=2		$devs
+    bcachefs set-fs-option --erasure_code=1		$devs
+
+    # Keep foreground write pressure on while reconcile churns: prod was a
+    # running desktop, not an idle box, and the wedge wants concurrency
+    # between the move path and ordinary transactions.
+    #
+    # Deliberately MANY SMALL fsync'd transactions rather than a few large
+    # writes: the ring is only 4 buffers deep, so what matters is journal entry
+    # TURNOVER, not bytes. The faster buffers close and rotate, the more likely
+    # a reservation held across one of them spans all four and wedges.
+    local churn_pids=()
+    local w
+    for w in 0 1 2 3; do
+	(
+	    trap - ERR
+	    set +e
+	    local j=0
+	    while [[ -d /mnt ]]; do
+		# small write + fsync == one journal entry, as fast as possible
+		dd if=/dev/urandom of=/mnt/churn.$w.$((j % 64)) bs=4k count=4 \
+		    conv=fsync status=none 2>/dev/null
+		(( j % 64 == 63 )) && rm -f /mnt/churn.$w.* 2>/dev/null
+		j=$((j + 1))
+	    done
+	) &
+	churn_pids+=($!)
+    done
+
+    # Drive reconcile and watch both progress and journal depth. The
+    # journal-wedge watchdog is armed independently and will panic the VM with
+    # a full btree_transactions dump the moment depth sticks; this loop is the
+    # human-readable log of the run.
+    local zeros=0 settled=0
+    for ((i = 0; i < 120; i++)); do
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+	sleep 5
+	local work=$(reconcile_work_remaining)
+	echo "t=$((i * 5))s	work: $work	depth: $(journal_depth)	data_update: $(data_update_sectors)"
+	if (( work )); then
+	    zeros=0
+	elif (( ++zeros >= 3 )); then
+	    settled=1
+	    break
+	fi
+    done
+
+    kill "${churn_pids[@]}" 2>/dev/null || true
+    wait "${churn_pids[@]}" 2>/dev/null || true
+
+    echo "=== after reconcile ==="
+    bcachefs fs usage -h /mnt | grep -A4 undegraded || true
+
+    if (( ! settled )); then
+	echo "reconcile did not settle; final journal state:"
+	cat /sys/fs/bcachefs/*/internal/journal_debug || true
+    fi
+
+    umount /mnt
+
+    # A clean run must both settle and leave nothing at the old checksum.
+    local keys=$(bcachefs list -b extents $devs 2>/dev/null)
+    local stale=$(echo "$keys" | grep -c "csum crc32c" || true)
+    echo "extents still crc32c: $stale"
+
+    if (( ! settled )); then
+	echo "FAIL: reconcile backlog did not drain"
+	return 1
+    fi
+
+    bcachefs fsck -ny $devs
+
+    dmsetup remove slowhdd0 slowhdd1
+
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+main "$@"

--- a/tests/fs/bcachefs/reconcile-journal-wedge.ktest
+++ b/tests/fs/bcachefs/reconcile-journal-wedge.ktest
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# Reproduce the journal_max_open wedge seen on a production desktop twice
+# (2026-07-25 and 2026-07-26), both times fatal.
+#
+# Prod shape and sequence, which this mirrors:
+#  - 5 devices in two labelled groups, foreground_target=ssd,
+#    background_target=hdd, data_replicas=2, erasure_code=1,
+#    background_compression=zstd, data_checksum=xxhash.
+#  - A large backlog of extents whose cached io_opts were never set, so they
+#    were never enqueued for reconcile.  A check_reconcile_work pass finally
+#    enumerated them, and reconcile started rewriting ~1.1T.
+#  - Recovery completed cleanly.  ~5 minutes later, under sustained reconcile
+#    write load, the journal wedged: one reservation held on an already-closed
+#    buffer stopped bch2_journal_do_writes_locked() from ever starting its
+#    write, seq_write_started froze, the 4-deep ring filled, and every
+#    journal_entry_open() returned journal_max_open forever.
+#
+# Not swap: reproduced on prod with zero swap-on-bcachefs active.
+# Not recovery: both wedges happened well after recovery finished.
+# The trigger is sustained reconcile/move load on a replicated, EC'd fs.
+#
+# The failure is detected by bcachefs-journal-wedge-detect.sh, which watches
+# depth = (journal head seq - oldest unwritten seq) and fires while the fs is
+# still healthy — deliberately, so a wedge does not have to be reached to get
+# the evidence.  See that file for why "refcount != 0" alone is not the signal.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-journal-wedge-detect.sh
+
+config-scratch-devs 4G
+config-scratch-devs 4G
+config-scratch-devs 8G
+config-scratch-devs 8G
+
+config-mem 6G
+config-timeout 1800
+
+reconcile_work_remaining()
+{
+    bcachefs fs usage -f rebalance_work /mnt | awk '
+	$1 ~ /^(replicas|checksum|erasure_code|compression|target|high_priority|stripes):$/ { sum += $2 + $3 }
+	END { print sum + 0 }'
+}
+
+journal_depth()
+{
+    awk '
+	!inu && /^seq:/       { head = $2; next }
+	/^unwritten entries:/ { inu = 1; next }
+	inu && /^seq:/        { if (!got) { print head - $2; got = 1 } ; next }
+	END { if (!got) print 0 }
+    ' /sys/fs/bcachefs/*/internal/journal_debug 2>/dev/null
+}
+
+data_update_sectors()
+{
+    awk '/since mount/ { print $3 }' /sys/fs/bcachefs/*/counters/data_update
+}
+
+# Build the backlog the way prod got there: write everything at the WRONG
+# checksum and WITHOUT the second replica, then flip the filesystem options so
+# every extent needs both a rechecksum and a replica add. That is exactly the
+# prod need_rb set (data_replicas,data_checksum,erasure_code,background_target).
+test_reconcile_backlog_journal_wedge()
+{
+    set_watchdog 1200
+
+    run_quiet "" bcachefs format -f				\
+	--block_size=4k						\
+	--label=ssd.ssd1 ${ktest_scratch_dev[0]}		\
+	--label=ssd.ssd2 ${ktest_scratch_dev[1]}		\
+	--label=hdd.hdd1 ${ktest_scratch_dev[2]}		\
+	--label=hdd.hdd2 ${ktest_scratch_dev[3]}		\
+	--foreground_target=ssd					\
+	--background_target=hdd					\
+	--data_checksum=crc32c					\
+	--data_replicas=1					\
+	--compression=zstd					\
+	--background_compression=zstd
+
+    # Prod mount options, verbatim from the failing box's fstab. These are not
+    # incidental: with flushes disabled and a 10s flush delay, journal entries
+    # stay unwritten far longer, so the fs runs permanently close to the 4-deep
+    # JOURNAL_STATE_BUF_NR limit -- which is what makes a single held
+    # reservation fatal rather than merely slow. The failing boot's dump shows
+    # the ratio this produces: nr noflush writes 1362 vs nr flush writes 46.
+    local mntopts=${JWEDGE_MOUNT_OPTS:-journal_flush_disabled=1,journal_flush_delay=10000}
+
+    # Space-separated for the CLI (fsck/list/set-fs-option take <devices>...),
+    # colon-joined for mount(8).
+    local devs="${ktest_scratch_dev[0]} ${ktest_scratch_dev[1]} ${ktest_scratch_dev[2]} ${ktest_scratch_dev[3]}"
+    local devs_joined="${devs// /:}"
+
+    mount -t bcachefs -o "$mntopts" "$devs_joined" /mnt
+
+    # INCOMPRESSIBLE data on purpose. /dev/zero would be the obvious choice, but
+    # with background_compression=zstd a 2G file of zeros collapses to ~37M of
+    # extents -- measured, first run of this test -- which is no backlog at all.
+    # urandom gives real extent count, and matches prod, whose extent dumps show
+    # "compress incompressible" throughout.
+    local i
+    for i in $(seq 0 7); do
+	dd if=/dev/urandom of=/mnt/data.$i bs=1M count=256 conv=fsync status=none
+    done
+    sync
+
+    echo "=== before flip ==="
+    bcachefs fs usage -h /mnt | grep -A4 undegraded || true
+
+    # Now make every extent need rewriting, on several axes at once.
+    # set-fs-option takes DEVICE paths, not a mountpoint ("error reading
+    # superblock: Is a directory" otherwise), and all members must be named.
+    bcachefs set-fs-option --data_checksum=xxhash	$devs
+    bcachefs set-fs-option --data_replicas=2		$devs
+    bcachefs set-fs-option --erasure_code=1		$devs
+
+    # Keep foreground write pressure on while reconcile churns: prod was a
+    # running desktop, not an idle box, and the wedge wants concurrency
+    # between the move path and ordinary transactions.
+    #
+    # Deliberately MANY SMALL fsync'd transactions rather than a few large
+    # writes: the ring is only 4 buffers deep, so what matters is journal entry
+    # TURNOVER, not bytes. The faster buffers close and rotate, the more likely
+    # a reservation held across one of them spans all four and wedges.
+    local churn_pids=()
+    local w
+    for w in 0 1 2 3; do
+	(
+	    trap - ERR
+	    set +e
+	    local j=0
+	    while [[ -d /mnt ]]; do
+		# small write + fsync == one journal entry, as fast as possible
+		dd if=/dev/urandom of=/mnt/churn.$w.$((j % 64)) bs=4k count=4 \
+		    conv=fsync status=none 2>/dev/null
+		(( j % 64 == 63 )) && rm -f /mnt/churn.$w.* 2>/dev/null
+		j=$((j + 1))
+	    done
+	) &
+	churn_pids+=($!)
+    done
+
+    # Drive reconcile and watch both progress and journal depth. The
+    # journal-wedge watchdog is armed independently and will panic the VM with
+    # a full btree_transactions dump the moment depth sticks; this loop is the
+    # human-readable log of the run.
+    local zeros=0 settled=0
+    for ((i = 0; i < 120; i++)); do
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+	sleep 5
+	local work=$(reconcile_work_remaining)
+	echo "t=$((i * 5))s	work: $work	depth: $(journal_depth)	data_update: $(data_update_sectors)"
+	if (( work )); then
+	    zeros=0
+	elif (( ++zeros >= 3 )); then
+	    settled=1
+	    break
+	fi
+    done
+
+    kill "${churn_pids[@]}" 2>/dev/null || true
+    wait "${churn_pids[@]}" 2>/dev/null || true
+
+    echo "=== after reconcile ==="
+    bcachefs fs usage -h /mnt | grep -A4 undegraded || true
+
+    if (( ! settled )); then
+	echo "reconcile did not settle; final journal state:"
+	cat /sys/fs/bcachefs/*/internal/journal_debug || true
+    fi
+
+    umount /mnt
+
+    # A clean run must both settle and leave nothing at the old checksum.
+    local keys=$(bcachefs list -b extents $devs 2>/dev/null)
+    local stale=$(echo "$keys" | grep -c "csum crc32c" || true)
+    echo "extents still crc32c: $stale"
+
+    if (( ! settled )); then
+	echo "FAIL: reconcile backlog did not drain"
+	return 1
+    fi
+
+    bcachefs fsck -ny $devs
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+main "$@"

--- a/tests/fs/bcachefs/reconcile_convergence.ktest
+++ b/tests/fs/bcachefs/reconcile_convergence.ktest
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Reconcile-pass convergence: after data is written and an option change
+# makes the stored per-extent reconcile opts stale, one full reconcile
+# pass must actually persist the refreshed opts — verified by fsck's
+# "extent with incorrect/missing reconcile opts" check coming back clean.
+#
+# This fails loudly on bugs where the move path's transaction commits
+# are silently dropped: the reconcile pass claims to process every
+# extent, but nothing reaches the journal and fsck finds every extent
+# still stale.  Regression test for the inverted condition in
+# bch2_trans_commit_lazy() (bcachefs-tools#780): red on the buggy
+# wrapper, green with the fix.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+config-scratch-devs 4G
+config-timeout 600
+
+# Reuse a prebuilt (bcachefs-less, for dkms runs) kernel — ktest's config
+# regeneration would re-enable built-in bcachefs otherwise.
+[[ -n ${KTEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+test_reconcile_opts_converge()
+{
+    set_watchdog 300
+
+    run_quiet "" bcachefs format -f "${ktest_scratch_dev[0]}"
+    mount -t bcachefs "${ktest_scratch_dev[0]}" /mnt
+
+    # Data first, option second: the extents' stored reconcile opts are
+    # now stale relative to the fs options.
+    for i in $(seq 0 9); do
+	dd if=/dev/urandom of=/mnt/file$i bs=1M count=4 status=none
+    done
+    sync
+
+    echo 1 > /sys/fs/bcachefs/*/options/background_compression 2>/dev/null ||
+	echo lz4 > /sys/fs/bcachefs/*/options/background_compression
+
+    # Kick reconcile and let it work through the backlog.
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+
+    # Wait for reconcile to go idle: no data updates in flight and no
+    # movement for a few consecutive polls.
+    local quiet=0 prev=-1
+    for i in $(seq 1 120); do
+	local moved=$(awk '/since mount:/ { print $NF; exit }' \
+	    /sys/fs/bcachefs/*/counters/data_update 2>/dev/null)
+	if [[ $moved = $prev ]]; then
+	    quiet=$((quiet + 1))
+	    (( quiet >= 5 )) && break
+	else
+	    quiet=0
+	    prev=$moved
+	fi
+	sleep 1
+    done
+    echo "reconcile quiesced after ${i}s (data_update=$prev)"
+
+    # Phase 2: CLEAR the option.  Extents now carry reconcile entries that
+    # are stale relative to the fs opts, and removing a stale entry is an
+    # opts-only update — no data movement can mask a dropped commit.
+    echo none > /sys/fs/bcachefs/*/options/background_compression 2>/dev/null ||
+	echo 0 > /sys/fs/bcachefs/*/options/background_compression
+
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+
+    quiet=0; prev=-1
+    for i in $(seq 1 120); do
+	local moved2=$(awk '/since mount:/ { print $NF; exit }' \
+	    /sys/fs/bcachefs/*/counters/data_update 2>/dev/null)
+	if [[ $moved2 = $prev ]]; then
+	    quiet=$((quiet + 1))
+	    (( quiet >= 5 )) && break
+	else
+	    quiet=0
+	    prev=$moved2
+	fi
+	sleep 1
+    done
+    echo "clear-phase quiesced after ${i}s (data_update=$prev)"
+
+    umount /mnt
+
+    # The loud assertion: with the reconcile-opt updates actually
+    # committed, fsck is clean.  If the move path dropped its commits,
+    # every extent still has stale opts and fsck reports
+    # "extent with incorrect/missing reconcile opts".
+    bcachefs fsck -ny "${ktest_scratch_dev[0]}"
+
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/reflink_evacuate_panic.ktest
+++ b/tests/fs/bcachefs/reflink_evacuate_panic.ktest
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Reproducer for the 2026-07-13 copygc panic:
+#
+#   bcachefs (...): pointer to missing indirect extent in .../disk1.img
+#     ... missing reflink btree range ..., fixing
+#   Kernel panic - not syncing: in transaction restart: EPERM,
+#     last restarted by 0x800080000000a00
+#   Comm: bch-copygc/...
+#     __bch2_write <- bch2_moving_ctxt_do_pending_writes <- bch2_move_ratelimit
+#     <- __bch2_move_data_phys <- bch2_evacuate_bucket <- bch2_copygc
+#
+# The production fs had a dangling reflink_p -> missing reflink_v (a known
+# artifact of the dedup code + prior hard resets, self-healed on read).
+# copygc, evacuating a bucket during early recovery, panicked in the write
+# path with an INVALID trans restart state (restarted printed as "EPERM" = raw
+# 1, last_restarted_ip garbage) — values the restart machinery cannot
+# legitimately produce (btree/iter.h:498 BUG_ONs non-restart codes).
+#
+# This test builds that on-disk PRECONDITION deterministically with
+# `kill_btree_node reflink:0:N` (removes reflink_v leaves of a MULTI-LEVEL
+# reflink btree, leaving those reflink_p dangling but the topology intact so
+# the fs still mounts), then drives the copygc/evacuate move path over the
+# orphaned buckets while readers hammer the dangling reflink_p (the "fixing"
+# repair path) — the two threads that were racing at the panic.
+#
+# No dedup required: reflink + kill_btree_node + the move path are all stock.
+#
+# STATUS (2026-07-13): the PRECONDITION reproduces on demand (exact production
+# "pointer to missing indirect extent ... fixing" signature, lazy repair on
+# read).  The PANIC itself does NOT fire here — SURVIVED on both a plain debug
+# kernel and one with BCACHEFS_INJECT_TRANSACTION_RESTARTS=y.  The production
+# panic happened during EARLY POST-CRASH RECOVERY (journal replay + fsck repair
+# + copygc racing on a dirty-journal fs); this test does a CLEAN mount (offline
+# kill_btree_node preserves the clean state), so it can't recreate that
+# interleaving without a two-boot crash sequence.  See
+# artifacts/finding-copygc-reflink-trans-restart-panic-2026-07-13.md.
+#
+# So this serves as a REGRESSION GUARD for the hardening the panic calls for
+# (the move/write path must not crash on a corrupt-reflink source):
+#   PASS  = copygc/evacuate survives the dangling reflinks (current behaviour).
+#   PANIC = a regression reintroduced the crash on this simpler profile.
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/bcachefs-test-libs.sh
+
+config-mem 4G   # debug-kernel mount + in-VM bcachefs-tools build need headroom
+config-scratch-devs 4G
+config-scratch-devs 4G
+
+# INJECT_TRANSACTION_RESTARTS hammers the exact machinery whose state was
+# found corrupt; keep it on when the config supports it (debug kernels do).
+require-kernel-config-soft BCACHEFS_INJECT_TRANSACTION_RESTARTS
+
+config-timeout $(stress_timeout)
+
+# For dkms runs (prebuilt bcachefs-less kernel), don't let ktest rebuild.
+[[ -n ${KTEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+# Number of distinct reflink_v keys to create.  Tiny btree nodes ENOMEM the
+# btree-update trans pool (8k was unviable), so instead we force a MULTI-LEVEL
+# reflink btree with DEFAULT nodes by creating a large number of distinct
+# reflink_v keys.  Killing a level-0 leaf then leaves the interior root
+# (topology) intact so the fs still mounts and the orphaned reflink_p repair
+# lazily on read.  The test verifies the level count and warns if it's flat.
+REFLINK_EXTENTS=${REFLINK_EXTENTS:-12000}
+READERS=${READERS:-16}
+
+reflink_evacuate_body()
+{
+    local dev0=${ktest_scratch_dev[0]}
+    local dev1=${ktest_scratch_dev[1]}
+
+    # Small btree nodes: a modest number of reflink_v keys then builds a
+    # multi-LEVEL reflink btree.  Killing a level-0 leaf (below) drops only
+    # that leaf's keys; the interior root survives, recovery completes, and
+    # the orphaned reflink_p are "fixed" lazily on read — the production shape
+    # (vs iteration 2, where killing the single-node root was unrecoverable).
+    # Default btree node size (tiny nodes ENOMEM the btree-update trans pool).
+    # version_upgrade=none: the tools format at 1.39 and the kernel would
+    # otherwise upgrade to 1.40 on mount — irrelevant to the reflink repro.
+    run_quiet "" bcachefs format -f "$dev0" "$dev1"
+    mount -t bcachefs -o version_upgrade=none "$dev0":"$dev1" /mnt
+
+    # Many DISTINCT reflink_v keys: split a random file into 8k pieces and
+    # reflink each piece to its own file.
+    dd if=/dev/urandom of=/mnt/seed bs=8k count=$REFLINK_EXTENTS status=none
+    ( cd /mnt && split -b 8k -a 4 seed src. )
+    local f n=0
+    for f in /mnt/src.*; do
+	cp --reflink=always "$f" "/mnt/link.${f##*/}"
+	n=$((n+1))
+    done
+    # Bulk reflinked data so evacuate has real work to move off dev0.
+    dd if=/dev/urandom of=/mnt/big bs=1M count=32 status=none
+    cp --reflink=always /mnt/big /mnt/biglink
+    sync
+    echo "created $n reflinked extents"
+
+    # Verify the reflink btree is multi-level BEFORE killing a leaf.
+    cat /sys/kernel/debug/bcachefs/*/reflink/formats > /tmp/rf-formats.log 2>/dev/null || true
+    echo "=== reflink btree node levels (want a level >0) ==="
+    grep -o "l [0-9]*" /tmp/rf-formats.log | sort | uniq -c || true
+    echo "==="
+
+    umount /mnt
+
+    # Inject: kill a few level-0 leaves (NOT the interior root).
+    local idx
+    for idx in 1 2 3; do
+	bcachefs kill_btree_node -n reflink:0:$idx "$dev0" "$dev1" 2>/dev/null || true
+    done
+
+    # Confirm the dangling reflink_p (dry-run -n, NO repair — must survive to
+    # the kernel mount). Temp file, not `| head`, to avoid SIGPIPE under set -e.
+    bcachefs fsck -n "$dev0" "$dev1" > /tmp/fsck-confirm.log 2>&1 || true
+    echo "=== fsck -n (expect missing indirect extent) ==="
+    grep -i "missing indirect\|missing reflink\|reflink_p_to" /tmp/fsck-confirm.log | tail -6 || true
+    echo "==="
+
+    # Mount RW: topology intact (interior root survived), recovery completes,
+    # killed leaves' reflink_p dangle and are fixed lazily on read.
+    if ! mount -t bcachefs -o version_upgrade=none "$dev0":"$dev1" /mnt; then
+	echo "MOUNT FAILED after leaf kill — reflink btree was not multi-level?"
+	echo "  bump REFLINK_EXTENTS. formats dump:"; head -8 /tmp/rf-formats.log || true
+	return 1
+    fi
+
+    trap - ERR   # background loops must not die on the prelude ERR trap
+
+    # Racing thread A: readers hammer the dangling reflink_p -> "missing
+    # indirect extent, fixing".
+    local pids=() w
+    for w in $(seq 1 $READERS); do
+	( while true; do cat /mnt/link.* > /dev/null 2>&1 || true; done ) &
+	pids+=($!)
+    done
+
+    # Racing thread B: the copygc/evacuate move path over dev0 (the exact
+    # __bch2_move_data_phys / bch2_evacuate_bucket path that panicked).
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_gc 2>/dev/null || true
+    local round
+    for round in $(seq 1 15); do
+	echo "--- evacuate round $round ---"
+	bcachefs device evacuate "$dev0" > /tmp/evac.log 2>&1 || true
+	tail -2 /tmp/evac.log || true
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_gc 2>/dev/null || true
+	sleep 2
+    done
+
+    kill "${pids[@]}" 2>/dev/null || true
+    wait "${pids[@]}" 2>/dev/null || true
+
+    echo "SURVIVED: no panic through evacuate + repair"
+    umount /mnt
+    bcachefs fsck -ny "$dev0" "$dev1" || true
+    bcachefs_test_end_checks "$dev0" "$dev1"
+}
+
+test_reflink_evacuate_panic()
+{
+    set_watchdog $(stress_timeout)
+    reflink_evacuate_body
+}
+
+main "$@"

--- a/tests/fs/bcachefs/reflink_recovery_panic.ktest
+++ b/tests/fs/bcachefs/reflink_recovery_panic.ktest
@@ -38,10 +38,17 @@
 #   PANIC         = the target crash reproduced (RED), or a regression.
 
 . $(dirname $(readlink -e ${BASH_SOURCE[0]}))/bcachefs-test-libs.sh
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/memory-pressure-libs.sh
 
-config-mem 4G           # debug-kernel mount + in-VM tools build need headroom
+# 4G default suits the reflink setup + debug mount; the swap-pressure flavour
+# overrides lower (REFLINK_MEM=2G) so the eater actually drives swap writeout.
+config-mem ${REFLINK_MEM:-4G}
 config-scratch-devs 4G
 config-scratch-devs 4G
+
+# Swap-pressure flavour needs these; soft so the other flavours don't gate on them.
+require-kernel-config-soft SWAP
+require-kernel-config-soft DETECT_HUNG_TASK
 
 # More CPUs widens the trans-restart-state race the panic implicates (the
 # stomped trans->restarted).  Unlike the swap livelock tests (which need 2
@@ -409,6 +416,105 @@ test_reflink_dedup_recovery_panic()
     dedup_quiesce
     robust_umount || true
     bcachefs fsck -ny "$dev0" "$dev1" || true
+    bcachefs_test_end_checks "$dev0" "$dev1" || echo "(expected end-check residue after kill_btree_node)"
+    return 0
+}
+
+# --- flavour 4: copygc-vs-dangling-reflink race UNDER swap-on-bcachefs pressure
+#
+# The one production element flavours 1-3 lack: swap-on-bcachefs actively
+# written by reclaim (reclaim -> swap_writeout -> bch2_swap_rw) while copygc's
+# nested __bch2_write trans moves buckets over the dangling reflink_p.  The
+# swap machinery (unkillable eater, sacrificial balloon, dd-fragmented swapfile,
+# swappiness=100) is the calibrated profile from swapfile_deadlock.ktest +
+# memory-pressure-libs.sh.
+#
+# MUST run on a kernel WITH the NOIO reclaim fixes (HEAD 08660722 / prod
+# FCD0854).  On an ancestor lacking them, swap pressure trips the *already-
+# fixed* wb-darray/journal_buf_prealloc deadlock (a hung_task panic) and
+# confounds the copygc-panic signal.  Run with REFLINK_MEM=2G REFLINK_CPUS=2.
+#
+#   REFLINK_SWAP_MB=768    dd-written swapfile size
+#   REFLINK_SWAP_ROUNDS=3  eater touch-storm rounds (race amplifier)
+#   REFLINK_SWAP_DUR=90    seconds of pressure per round
+
+test_reflink_swap_pressure_panic()
+{
+    set_watchdog $(stress_timeout)
+    local dev0=${ktest_scratch_dev[0]}
+    local dev1=${ktest_scratch_dev[1]}
+
+    setup_dangling_reflink "$dev0" "$dev1"
+
+    mount -t bcachefs -o $RECOVERY_OPTS "$dev0":"$dev1" /mnt
+
+    # Swapfile ON the fs under test — dd-written so it fragments into many
+    # extents (more btree traffic per swap I/O), the production shape.  Sized
+    # 1.5x RAM (the proven swapfile_deadlock ratio) so the eater drives
+    # continuous swap WRITEBACK without EXHAUSTING swap — swap exhaustion drops
+    # into the mm OOM-cascade regime (which kills the test harness), not a
+    # filesystem signal.
+    local swap_mb=${REFLINK_SWAP_MB:-$(awk '/MemTotal/ {print int($2 * 3 / 2 / 1024)}' /proc/meminfo)}
+    dd if=/dev/zero of=/mnt/swapfile bs=1M count=$swap_mb conv=fsync status=none
+    chmod 600 /mnt/swapfile
+    mkswap /mnt/swapfile
+    swapon /mnt/swapfile
+    grep -q /mnt/swapfile /proc/swaps || { echo "swapon failed"; return 1; }
+    echo 100 > /proc/sys/vm/swappiness
+
+    build_eater
+    build_balloon
+    start_mem_telemetry
+    start_balloon 150
+    hung_task_panic_on
+
+    # Protect the test harness (and its children — readers, evacuate driver)
+    # from the OOM killer so a transient spike can't kill the test itself; the
+    # balloon (+1000) stays the designated victim.  Proper swap sizing above
+    # already prevents exhaustion, but this is cheap insurance.
+    echo -1000 > /proc/self/oom_score_adj 2>/dev/null || true
+
+    trap - ERR
+    local pids=() w
+    for w in $(seq 1 $READERS); do
+	( while true; do cat /mnt/link.* > /dev/null 2>&1 || true; done ) &
+	pids+=($!)
+    done
+
+    local eat_mb=$(eater_default_mb)
+    local rounds=${REFLINK_SWAP_ROUNDS:-3}
+    local dur=${REFLINK_SWAP_DUR:-90}
+    local round eater_pid
+    for round in $(seq 1 $rounds); do
+	echo "=== round $round/$rounds: eater ${eat_mb}M ${dur}s + evacuate/gc ==="
+	/tmp/eater "$eat_mb" "$dur" &
+	eater_pid=$!
+	# Hammer copygc/evacuate + gc for the whole touch storm: copygc's
+	# nested trans now races reclaim's swap writeback through the fs.
+	while kill -0 $eater_pid 2>/dev/null; do
+	    bcachefs device evacuate "$dev0" > /tmp/evac.log 2>&1 || true
+	    echo 1 > /sys/fs/bcachefs/*/internal/trigger_gc 2>/dev/null || true
+	    sleep 1
+	done
+	wait $eater_pid 2>/dev/null || true
+	sleep 3
+    done
+
+    hung_task_panic_off
+    kill "${pids[@]}" 2>/dev/null || true
+    pkill -f 'cat /mnt/' 2>/dev/null || true
+    wait "${pids[@]}" 2>/dev/null || true
+    stop_mem_telemetry
+    stop_balloon
+
+    grep -E "SwapFree|MemFree" /proc/meminfo
+    echo "SURVIVED: no panic through copygc + swap-reclaim pressure race"
+
+    swapoff /mnt/swapfile 2>/dev/null || true
+    rm -f /mnt/swapfile
+    robust_umount || true
+    # in-kernel fsck (userspace fsck OOMs in a small VM)
+    if mount -t bcachefs -o fsck,ro "$dev0":"$dev1" /mnt; then umount /mnt; fi
     bcachefs_test_end_checks "$dev0" "$dev1" || echo "(expected end-check residue after kill_btree_node)"
     return 0
 }

--- a/tests/fs/bcachefs/reflink_recovery_panic.ktest
+++ b/tests/fs/bcachefs/reflink_recovery_panic.ktest
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+#
+# Escalation of reflink_evacuate_panic.ktest towards the 2026-07-13 copygc
+# panic:
+#
+#   bcachefs (...): pointer to missing indirect extent ... missing reflink
+#     btree range ..., fixing
+#   Kernel panic - not syncing: in transaction restart: EPERM,
+#     last restarted by 0x800080000000a00
+#   Comm: bch-copygc/...
+#     __bch2_write <- bch2_moving_ctxt_do_pending_writes <- bch2_move_ratelimit
+#     <- __bch2_move_data_phys <- bch2_evacuate_bucket <- bch2_copygc
+#
+# reflink_evacuate_panic builds the on-disk precondition (dangling reflink_p ->
+# missing reflink_v, via kill_btree_node on a multi-level reflink btree) but
+# mounts CLEANLY and stays GREEN.  The production panic fired during EARLY
+# POST-CRASH RECOVERY: journal replay + fsck repair + copygc all racing on a
+# freshly-crashed (dirty-journal) fs.  This test adds exactly that context —
+# the untried lever from the finding
+# (artifacts/finding-copygc-reflink-trans-restart-panic-2026-07-13.md, step 4):
+#
+#   1. dangling reflink_p on disk (kill_btree_node, as before), PLUS
+#   2. a DIRTY JOURNAL at the recovery mount (unreplayed entries, incl.
+#      in-flight copygc/move updates captured mid-evacuate), PLUS
+#   3. fsck repair forced AT the recovery mount so it runs concurrently with
+#      journal replay and a fresh copygc/evacuate + reader race.
+#
+# Two flavours of "crash", selectable by test function:
+#   - test_reflink_recovery_panic:  simulated crash via trigger_emergency_
+#     read_only (single boot, deterministic — the journal-rewind idiom).
+#   - test_reflink_reboot_recovery_panic: a REAL hard reset (sysrq-b via the
+#     ktest reboot protocol), highest fidelity to production.  Two boots.
+#
+# Everything runs in-VM on scratch devices; the host fs is never touched.
+#
+#   PASS/SURVIVED = copygc/evacuate survives corrupt-reflink + dirty-journal
+#                   recovery (current behaviour — a regression guard).
+#   PANIC         = the target crash reproduced (RED), or a regression.
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/bcachefs-test-libs.sh
+
+config-mem 4G           # debug-kernel mount + in-VM tools build need headroom
+config-scratch-devs 4G
+config-scratch-devs 4G
+
+# More CPUs widens the trans-restart-state race the panic implicates (the
+# stomped trans->restarted).  Unlike the swap livelock tests (which need 2
+# vCPUs for D-state signatures), the target here is a PANIC, so more
+# parallelism helps.  Overridable.
+config-cpus ${REFLINK_CPUS:-4}
+
+# Hammer the exact machinery whose state was found corrupt.
+require-kernel-config-soft BCACHEFS_INJECT_TRANSACTION_RESTARTS
+
+config-timeout $(stress_timeout)
+
+# For dkms runs (prebuilt bcachefs-less kernel), don't let ktest rebuild.
+[[ -n ${KTEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+# Many DISTINCT reflink_v keys -> multi-LEVEL reflink btree with default nodes,
+# so killing a level-0 leaf leaves the interior root (topology) intact and the
+# fs still mounts (tiny --btree_node_size ENOMEMs the btree-update trans pool).
+REFLINK_EXTENTS=${REFLINK_EXTENTS:-12000}
+READERS=${READERS:-16}
+EVAC_ROUNDS=${EVAC_ROUNDS:-20}
+MNTOPTS="version_upgrade=none"
+
+# LAZY reflink repair (default) matches production: the panic raced the
+# on-READ "fixing" path against the internal copygc thread during recovery,
+# NOT a synchronous mount-time fsck pass.  Forcing fsck,fix_errors at mount
+# repairs the dangling reflink_p up front and CLOSES that race window
+# (confirmed GREEN, run 2).  Set REFLINK_FSCK=1 to force the fsck pass instead.
+RECOVERY_OPTS="$MNTOPTS"
+[[ -n ${REFLINK_FSCK:-} ]] && RECOVERY_OPTS="$MNTOPTS,fsck,fix_errors"
+
+# Unmount that survives active readers / a just-crashed fs.
+robust_umount()
+{
+    trap - ERR
+    pkill -f 'cat /mnt/' 2>/dev/null || true
+    local attempt
+    for attempt in $(seq 1 15); do
+	grep -q " /mnt " /proc/mounts || return 0
+	umount /mnt 2>/tmp/umount.err && return 0
+	fuser -km /mnt 2>/dev/null || true
+	sleep 1
+    done
+    grep -q " /mnt " /proc/mounts && { echo "UMOUNT FAILED:"; cat /tmp/umount.err 2>/dev/null; return 1; }
+    return 0
+}
+
+# --- shared building blocks ---------------------------------------------------
+
+# Format + populate a multi-level reflink btree, then kill a few level-0
+# leaves offline (on a CLEAN journal, so kill_btree_node has nothing to
+# replay).  Leaves the fs UNMOUNTED with dangling reflink_p on disk.
+setup_dangling_reflink()
+{
+    local dev0=$1 dev1=$2
+
+    run_quiet "" bcachefs format -f "$dev0" "$dev1"
+    mount -t bcachefs -o $MNTOPTS "$dev0":"$dev1" /mnt
+
+    dd if=/dev/urandom of=/mnt/seed bs=8k count=$REFLINK_EXTENTS status=none
+    ( cd /mnt && split -b 8k -a 4 seed src. )
+    local f n=0
+    for f in /mnt/src.*; do
+	cp --reflink=always "$f" "/mnt/link.${f##*/}"
+	n=$((n+1))
+    done
+    # Bulk reflinked data so evacuate has real work to move off dev0.
+    dd if=/dev/urandom of=/mnt/big bs=1M count=64 status=none
+    cp --reflink=always /mnt/big /mnt/biglink
+    sync
+    echo "created $n reflinked extents"
+
+    cat /sys/kernel/debug/bcachefs/*/reflink/formats > /tmp/rf-formats.log 2>/dev/null || true
+    echo "=== reflink btree node levels (want a level >0) ==="
+    grep -o "l [0-9]*" /tmp/rf-formats.log | sort | uniq -c || true
+    echo "==="
+
+    umount /mnt
+
+    local idx
+    for idx in 1 2 3; do
+	bcachefs kill_btree_node -n reflink:0:$idx "$dev0" "$dev1" 2>/dev/null || true
+    done
+
+    bcachefs fsck -n "$dev0" "$dev1" > /tmp/fsck-confirm.log 2>&1 || true
+    echo "=== fsck -n (expect missing indirect extent) ==="
+    grep -i "missing indirect\|missing reflink\|reflink_p_to" /tmp/fsck-confirm.log | tail -6 || true
+    echo "==="
+}
+
+# Background churn that dirties the journal WITHOUT syncing (so the entries
+# stay unreplayed across the crash) and does NOT read the killed extents (so
+# their reflink_p stay dangling for the recovery mount to trip over).  Sets the
+# global CHURN_PID (avoids the $(...) subshell-reparenting hazard).
+CHURN_PID=""
+start_journal_churn()
+{
+    trap - ERR   # background loops must survive the prelude ERR trap
+    ( local i=0
+      while true; do
+	  dd if=/dev/urandom of=/mnt/churn.$i bs=1M count=4 status=none 2>/dev/null || true
+	  i=$(( (i + 1) % 64 ))
+      done ) &
+    CHURN_PID=$!
+}
+
+# The recovery-race: readers hammer the dangling reflink_p ("fixing") while
+# copygc/evacuate moves buckets off dev0 — the two threads racing at the panic,
+# now on a just-recovered (dirty-journal) fs with repair still in flight.
+recovery_race()
+{
+    local dev0=$1 dev1=$2
+
+    trap - ERR
+
+    local pids=() w
+    for w in $(seq 1 $READERS); do
+	( while true; do cat /mnt/link.* > /dev/null 2>&1 || true; done ) &
+	pids+=($!)
+    done
+
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_gc 2>/dev/null || true
+    local round
+    for round in $(seq 1 $EVAC_ROUNDS); do
+	echo "--- evacuate round $round ---"
+	bcachefs device evacuate "$dev0" > /tmp/evac.log 2>&1 || true
+	tail -2 /tmp/evac.log || true
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_gc 2>/dev/null || true
+	sleep 1
+    done
+
+    kill "${pids[@]}" 2>/dev/null || true
+    pkill -f 'cat /mnt/' 2>/dev/null || true   # reap the loops' cat children
+    wait "${pids[@]}" 2>/dev/null || true
+}
+
+# --- flavour 1: simulated crash, single boot ---------------------------------
+
+reflink_recovery_body()
+{
+    local dev0=${ktest_scratch_dev[0]}
+    local dev1=${ktest_scratch_dev[1]}
+
+    setup_dangling_reflink "$dev0" "$dev1"
+
+    # Mount RW (default opts, no fsck yet).  Do NOT read the killed extents.
+    mount -t bcachefs -o $MNTOPTS "$dev0":"$dev1" /mnt
+
+    # Get copygc move updates INTO the journal, then crash mid-move so the
+    # dirty journal carries in-flight copygc state (as production's did).
+    start_journal_churn
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_gc 2>/dev/null || true
+    bcachefs device evacuate "$dev0" > /tmp/evac-pre.log 2>&1 &
+    local evac_pid=$!
+    sleep 3
+
+    echo ":: simulated crash — emergency read-only mid-evacuate"
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_emergency_read_only 2>/dev/null || true
+
+    # Quiesce everything holding /mnt, then umount — emergency-ro leaves the fs
+    # MOUNTED (just internally ro), so we must actually unmount before the
+    # recovery mount can replay the dirty journal.  (The churn dd + evacuate
+    # exit on their own once the fs is ro; kill + fuser are belt-and-braces.)
+    kill $CHURN_PID $evac_pid 2>/dev/null || true
+    wait $CHURN_PID 2>/dev/null || true
+    wait $evac_pid  2>/dev/null || true
+    robust_umount || { echo "cannot set up recovery"; return 1; }
+
+    # RECOVERY mount: dirty journal (replay) + LAZY reflink repair, raced by the
+    # copygc/evacuate + reader ("fixing") threads.
+    echo ":: recovery mount ($RECOVERY_OPTS) — replay + lazy repair + copygc race"
+    if ! mount -t bcachefs -o $RECOVERY_OPTS "$dev0":"$dev1" /mnt; then
+	echo "RECOVERY MOUNT FAILED (dirty journal + killed reflink leaves)"
+	return 1
+    fi
+
+    recovery_race "$dev0" "$dev1"
+
+    echo "SURVIVED: no panic through dirty-journal recovery + repair + evacuate"
+    robust_umount || true
+    bcachefs fsck -ny "$dev0" "$dev1" || true
+    # kill_btree_node leaves deliberate residual inconsistency; end-check
+    # failure here is EXPECTED, not the signal (a panic is).
+    bcachefs_test_end_checks "$dev0" "$dev1" || echo "(expected end-check residue after kill_btree_node)"
+    return 0
+}
+
+test_reflink_recovery_panic()
+{
+    set_watchdog $(stress_timeout)
+    reflink_recovery_body
+}
+
+# --- flavour 2: real hard reset, two boots -----------------------------------
+#
+# Highest fidelity: an actual sysrq-b between the corruption+churn and the
+# recovery mount.  Uses the ktest reboot protocol (EXPECTED_REBOOT bookkeeping)
+# but deliberately does NOT sync the test fs first (do_reboot's copy_to_host
+# would clean the journal), so the reset leaves a genuinely dirty journal.
+
+expect_reboot_then_crash()
+{
+    # Mirror do_reboot's EXPECTED_REBOOT bookkeeping so the next boot isn't
+    # flagged as an UNEXPECTED REBOOT — but skip do_reboot's sync/copy_to_host
+    # so the journal stays dirty.  testrunner has already written NR_REBOOTS+1
+    # to /NR_REBOOTS before running us, and do_reboot would write that same
+    # value to /EXPECTED_REBOOT, so just copy it across.  $NR_REBOOTS the shell
+    # var is NOT exported to this subprocess; the file is the source of truth.
+    echo 1 > /proc/sys/kernel/sysrq 2>/dev/null || true
+    local nr=0; [[ -e /NR_REBOOTS ]] && nr=$(</NR_REBOOTS)
+    echo "$nr" | dd of=/EXPECTED_REBOOT oflag=direct 2> /dev/null
+    echo b > /proc/sysrq-trigger
+    sleep 60   # never returns
+}
+
+test_reflink_reboot_recovery_panic()
+{
+    set_watchdog $(stress_timeout)
+    local dev0=${ktest_scratch_dev[0]}
+    local dev1=${ktest_scratch_dev[1]}
+
+    # Phase marker on the rootfs overlay (persists across the guest reboot,
+    # discarded only when qemu exits).  Robust vs the un-exported $NR_REBOOTS.
+    if [[ ! -e /reflink_crashed ]]; then
+	setup_dangling_reflink "$dev0" "$dev1"
+
+	mount -t bcachefs -o $MNTOPTS "$dev0":"$dev1" /mnt
+	start_journal_churn
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_gc 2>/dev/null || true
+	bcachefs device evacuate "$dev0" > /tmp/evac-pre.log 2>&1 &
+	sleep 3
+
+	# Mark BEFORE crashing so the next boot takes the recovery branch.
+	echo 1 | dd of=/reflink_crashed oflag=direct 2>/dev/null
+
+	# Hard reset mid-evacuate, fs still mounted, journal unsynced.
+	echo ":: real crash — sysrq-b mid-evacuate (dirty journal preserved)"
+	expect_reboot_then_crash
+	return 0   # unreached
+    fi
+
+    # Boot 1: the scratch devices carry the dangling reflink_p + dirty journal.
+    echo ":: post-crash recovery mount ($RECOVERY_OPTS) — replay of in-flight"
+    echo "   copygc moves + lazy reflink repair + fresh copygc race"
+    if ! mount -t bcachefs -o $RECOVERY_OPTS "$dev0":"$dev1" /mnt; then
+	echo "RECOVERY MOUNT FAILED after real crash"
+	return 1
+    fi
+
+    recovery_race "$dev0" "$dev1"
+
+    echo "SURVIVED: no panic through real-crash recovery + repair + evacuate"
+    robust_umount || true
+    bcachefs fsck -ny "$dev0" "$dev1" || true
+    bcachefs_test_end_checks "$dev0" "$dev1" || echo "(expected end-check residue after kill_btree_node)"
+    return 0
+}
+
+# --- flavour 3: active dedup/reconcile during crash-recovery -----------------
+#
+# The fullest production soup: LIVE background dedup + reconcile (which creates
+# shared reflink_v and, on source deletion, the dangling reflink_p NATURALLY —
+# the production origin) layered ON TOP of the kill_btree_node injection, across
+# a real sysrq-b crash, with copygc + lazy repair all racing during unclean
+# recovery.  Reconcile is io_clock driven, so each kick advances the clock (64M
+# write) and pokes both wakeups (idioms lifted from dedup_mismatch.ktest).
+# Dedup is enabled at RUNTIME via sysfs (the intree kernel is dedup-capable),
+# avoiding any dependence on the VM userspace tool's --background_dedup flag.
+
+dedup_kick()
+{
+    dd if=/dev/zero of=/mnt/clock bs=1M count=64 status=none 2>/dev/null || true
+    sync 2>/dev/null || true
+    rm -f /mnt/clock 2>/dev/null || true
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup 2>/dev/null || true
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_pending_wakeup 2>/dev/null || true
+}
+
+dedup_on()
+{
+    local f
+    for f in /sys/fs/bcachefs/*/options/background_dedup; do
+	[[ -e $f ]] || { echo "NOTE: kernel has no background_dedup — dedup lever unavailable"; return 1; }
+	echo 1 > "$f" 2>/dev/null || true
+    done
+    return 0
+}
+
+dedup_quiesce()
+{
+    echo 0 > /sys/fs/bcachefs/*/options/background_dedup 2>/dev/null || true
+    echo 0 > /sys/fs/bcachefs/*/options/dedup_force_byte_verify_mismatch 2>/dev/null || true
+    sleep 3
+}
+
+# Identical file pairs collide in the dedup index naturally and get shared into
+# reflink_v — giving reconcile real dedup work.
+write_dup_data()
+{
+    trap - ERR
+    local i
+    for i in $(seq 1 200); do
+	dd if=/dev/urandom of=/mnt/dup.$i.a bs=16k count=1 status=none 2>/dev/null || true
+	cp /mnt/dup.$i.a /mnt/dup.$i.b 2>/dev/null || true
+    done
+    sync
+}
+
+test_reflink_dedup_recovery_panic()
+{
+    set_watchdog $(stress_timeout)
+    local dev0=${ktest_scratch_dev[0]}
+    local dev1=${ktest_scratch_dev[1]}
+
+    if [[ ! -e /reflink_crashed ]]; then
+	setup_dangling_reflink "$dev0" "$dev1"
+
+	mount -t bcachefs -o $MNTOPTS "$dev0":"$dev1" /mnt
+	if ! dedup_on; then robust_umount || true; return 1; fi
+	write_dup_data
+	dedup_kick
+	start_journal_churn
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_gc 2>/dev/null || true
+	bcachefs device evacuate "$dev0" > /tmp/evac-pre.log 2>&1 &
+	# Let dedup + copygc + churn interleave, kicking reconcile, then crash
+	# mid-flight so the dirty journal carries in-flight dedup AND move state.
+	local k
+	for k in 1 2 3; do dedup_kick; sleep 1; done
+
+	echo 1 | dd of=/reflink_crashed oflag=direct 2>/dev/null
+	echo ":: real crash — sysrq-b mid dedup+evacuate (dirty journal preserved)"
+	expect_reboot_then_crash
+	return 0
+    fi
+
+    echo ":: post-crash recovery mount ($RECOVERY_OPTS) — replay + live dedup +"
+    echo "   lazy reflink repair + copygc, all racing during unclean recovery"
+    if ! mount -t bcachefs -o $RECOVERY_OPTS "$dev0":"$dev1" /mnt; then
+	echo "RECOVERY MOUNT FAILED after real crash (dedup variant)"
+	return 1
+    fi
+    dedup_on || true
+
+    trap - ERR
+    local pids=() w
+    for w in $(seq 1 $READERS); do
+	( while true; do cat /mnt/link.* /mnt/dup.*.b > /dev/null 2>&1 || true; done ) &
+	pids+=($!)
+    done
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_gc 2>/dev/null || true
+    local round
+    for round in $(seq 1 $EVAC_ROUNDS); do
+	echo "--- evacuate+reconcile round $round ---"
+	bcachefs device evacuate "$dev0" > /tmp/evac.log 2>&1 || true
+	tail -1 /tmp/evac.log || true
+	dedup_kick
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_gc 2>/dev/null || true
+	sleep 1
+    done
+    kill "${pids[@]}" 2>/dev/null || true
+    pkill -f 'cat /mnt/' 2>/dev/null || true
+    wait "${pids[@]}" 2>/dev/null || true
+
+    echo "SURVIVED: no panic through dedup + copygc crash-recovery race"
+    dedup_quiesce
+    robust_umount || true
+    bcachefs fsck -ny "$dev0" "$dev1" || true
+    bcachefs_test_end_checks "$dev0" "$dev1" || echo "(expected end-check residue after kill_btree_node)"
+    return 0
+}
+
+main "$@"

--- a/tests/fs/bcachefs/swapfile_deadlock.ktest
+++ b/tests/fs/bcachefs/swapfile_deadlock.ktest
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# Reproducer for the swapfile-under-reclaim deadlock
+# (koverstreet/bcachefs-tools#646): with swap on bcachefs and sustained
+# reclaim pressure, bcachefs kworkers convoy on btree locks —
+# write-path index updates saturate their workqueue (rescuer included)
+# while the allocator's discard worker blocks in six_lock_contended() —
+# and the box hung-tasks or livelocks.
+#
+# Faithful port of the qemu ablation harness profile that reproduced
+# this at every memory size from 768M down to 128M on a swap-files
+# implementation without the reclaim-path armor (PF_MEMALLOC propagation
+# to the write path, btree node pinning, btree cache pre-reserve,
+# mempool sizing), and never with it.  The load-bearing details:
+#   - low-memory VM, few vCPUs (small worker pools starve fast)
+#   - the swapfile is WRITTEN OUT with buffered zero-writes, not
+#     fallocated: that fragments it into many small extents, so every
+#     swap I/O carries more btree traffic
+#   - the eater holds ~RAM+300M of touched-hot anonymous memory,
+#     re-touches it continuously, and is exempted from the OOM killer
+#     (oom_score_adj -1000).  A killable eater gets OOM-killed, the
+#     pressure collapses and the system recovers — that alone flips the
+#     result from deadlock to pass.
+#   - a sacrificial balloon keeps the OOM killer supplied with victims,
+#     removing the mm-level "System is deadlocked on memory" panic that
+#     can otherwise race ahead and kill even a correct kernel
+#   - vm.swappiness=100
+#
+# hung_task_panic is enabled during the pressure phase so a deadlock
+# fails the test loudly with console backtraces within ~30s of forming.
+# Some wedges starve userspace without leaving D-state tasks (workqueue
+# lockup dumps, console-dead livelock); those are caught by the
+# supervisor timeout, so run this THROUGH lib/supervisor — bare
+# build-test-kernel run has no host-side timeout enforcement.
+#
+#   SWAPFILE_TEST_MEM=512M      VM memory (the matrix repro point)
+#   SWAPFILE_TEST_CPUS=2        vCPUs
+#   SWAPFILE_TEST_ROUNDS=3      pressure rounds per boot (race amplifier)
+#   SWAPFILE_TEST_DURATION=120  seconds of pressure per round
+#   SWAPFILE_TEST_SWAP_MB=768   swapfile size (dd-written).  Sized so
+#                               total anon commit (eater + balloon +
+#                               daemons) is ~80% of RAM+swap: the burst
+#                               that triggers the deadlock is unchanged,
+#                               but a correct kernel can never reach
+#                               OOM-victim exhaustion, so the mm-level
+#                               "deadlocked on memory" panic disappears
+#                               from both sides of the comparison
+#   SWAPFILE_TEST_EAT_MB        eater size; default MemTotal+150M — well
+#                               past RAM (crushes the file LRU, denying
+#                               reclaim its non-swap escape valve) but
+#                               comfortably under RAM+swap: total anon
+#                               commit ~85% of capacity, so a correct
+#                               kernel never reaches OOM-victim
+#                               exhaustion, while a broken one still
+#                               deadlocks in the swap-out burst
+#   SWAPFILE_TEST_FILEIO=0      disable the 64K-file write/delete churn
+#   SWAPFILE_TEST_DELAY_MS      optional: dm-delay fake spinning rust
+#
+# Note for dkms runs: the in-VM bcachefs-tools/dkms build needs ~4G; run
+# once with SWAPFILE_TEST_MEM=4G to warm the tools/dkms caches for a new
+# deps HEAD before using the low-memory config.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/memory-pressure-libs.sh
+
+require-kernel-config SWAP
+require-kernel-config DETECT_HUNG_TASK
+require-kernel-config BLK_DEV_DM
+require-kernel-config DM_DELAY
+
+config-mem ${SWAPFILE_TEST_MEM:-512M}
+config-cpus ${SWAPFILE_TEST_CPUS:-2}
+config-scratch-devs 2G
+config-timeout 900
+
+# Parallel matrix runs reuse a prebuilt kernel — skip the kernel build.
+# (Debug assertions matter for the reproduction; bcachefs-test-libs
+# already requires BCACHEFS_DEBUG in-tree and exports it for dkms builds.)
+[[ -n ${SWAPFILE_TEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+test_swapfile_reclaim_deadlock()
+{
+    set_watchdog 700
+
+    local dev=${ktest_scratch_dev[0]}
+
+    # Optional fake spinning rust: adds per-I/O latency under the fs so
+    # swap-out stalls while reclaim pressure keeps building.
+    if [[ -n ${SWAPFILE_TEST_DELAY_MS:-} ]]; then
+	local sectors=$(blockdev --getsz "$dev")
+	dmsetup create swapdelay --table \
+	    "0 $sectors delay $dev 0 ${SWAPFILE_TEST_DELAY_MS}"
+	dev=/dev/mapper/swapdelay
+	echo "=== swap fs on dm-delay ${SWAPFILE_TEST_DELAY_MS}ms ==="
+    fi
+    echo "=== $(grep MemTotal /proc/meminfo), $(nproc) cpus ==="
+
+    run_quiet "" bcachefs format -f "$dev"
+    mount -t bcachefs "$dev" /mnt
+
+    # dd, not fallocate: buffered zero-writes fragment the swapfile into
+    # many small extents, multiplying the btree traffic per swap I/O.
+    # This is one of the details the deadlock needs.
+    dd if=/dev/zero of=/mnt/swapfile bs=1M count=${SWAPFILE_TEST_SWAP_MB:-768} \
+       conv=fsync status=none
+    chmod 600 /mnt/swapfile
+    mkswap /mnt/swapfile
+    swapon /mnt/swapfile
+    grep -q /mnt/swapfile /proc/swaps
+
+    echo 100 > /proc/sys/vm/swappiness
+
+    # Fail fast and loudly: a task uninterruptible for 30s panics the box
+    # with backtraces.  Enabled only for the pressure phase — swapoff
+    # legitimately sits in D state for a long time under load.
+    echo 30 > /proc/sys/kernel/hung_task_timeout_secs
+    echo 1  > /proc/sys/kernel/hung_task_panic
+
+    # 64K-file write/sync/delete churn on the same fs, adding foreground
+    # btree lock traffic to the mix (disable with SWAPFILE_TEST_FILEIO=0).
+    local fileio_pid=
+    if [[ ${SWAPFILE_TEST_FILEIO:-1} != 0 ]]; then
+	mkdir -p /mnt/fileio
+	(
+	    trap - ERR
+	    set +e
+	    i=0
+	    while true; do
+		dd if=/dev/zero of=/mnt/fileio/f$i bs=64K count=1 2>/dev/null
+		i=$((i + 1))
+		if (( i % 100 == 0 )); then
+		    sync
+		    for (( j = i - 100; j < i; j++ )); do
+			rm -f /mnt/fileio/f$j
+		    done
+		fi
+	    done
+	) &
+	fileio_pid=$!
+    fi
+
+    # The eater and the sacrificial balloon (see memory-pressure-libs.sh
+    # for why both are load-bearing).
+    build_eater
+    build_balloon
+
+    local eat_mb=${SWAPFILE_TEST_EAT_MB:-$(awk '/MemTotal/ {print int($2 / 1024) + 300}' /proc/meminfo)}
+    local duration=${SWAPFILE_TEST_DURATION:-120}
+    local rounds=${SWAPFILE_TEST_ROUNDS:-3}
+
+    start_mem_telemetry
+    start_balloon 150
+
+    # The reproduction is a race; each fresh touch storm is another roll
+    # of the dice, so run several rounds per boot.
+    local round
+    for (( round = 1; round <= rounds; round++ )); do
+	echo "=== round $round/$rounds: eater ${eat_mb}M for ${duration}s ==="
+	/tmp/eater "$eat_mb" "$duration" || {
+	    stop_mem_telemetry
+	    echo "eater failed"
+	    return 1
+	}
+	sleep 5
+    done
+    stop_mem_telemetry
+
+    if [[ -n $fileio_pid ]]; then
+	kill $fileio_pid 2>/dev/null || true
+	wait $fileio_pid 2>/dev/null || true
+    fi
+
+    echo 0 > /proc/sys/kernel/hung_task_panic
+
+    cat /proc/swaps
+    grep -E "MemFree|SwapFree" /proc/meminfo
+
+    # Optional: swapoff while a MODEST eater keeps the system under
+    # pressure.  The eater must stay below RAM: with committed anon over
+    # RAM, try_to_unuse() has nowhere to put the pages and livelocks by
+    # design — an mm property, not a filesystem verdict.  Sized so the
+    # swapped pages fit back, swapoff MUST succeed; wedging or erroring
+    # is a filesystem swap_activate/readback bug.  (hung_task_panic is
+    # already off: swapoff sits in D state legitimately here.)
+    if [[ -n ${SWAPFILE_TEST_SWAPOFF:-} ]]; then
+	echo "=== swapoff under pressure ==="
+	local squeeze_mb=$(awk '/MemTotal/ {print int($2 * 60 / 100 / 1024)}' /proc/meminfo)
+	/tmp/eater "$squeeze_mb" 300 &
+	local swapoff_eater=$!
+	sleep 20
+	grep -E "SwapFree" /proc/meminfo
+	swapoff /mnt/swapfile
+	echo "swapoff under pressure: succeeded"
+	kill $swapoff_eater 2>/dev/null || true
+	wait $swapoff_eater 2>/dev/null || true
+	swapon /mnt/swapfile
+    fi
+
+    stop_balloon
+
+    swapoff /mnt/swapfile
+    rm -f /mnt/swapfile
+    rm -rf /mnt/fileio
+    umount /mnt
+
+    # In-kernel fsck: the userspace fsck wants a large fraction of RAM up
+    # front and OOMs in a VM this small; the kernel's runs in the same
+    # footprint as a normal mount.
+    mount -t bcachefs -o fsck,ro "$dev" /mnt
+    umount /mnt
+
+    if [[ $dev = /dev/mapper/swapdelay ]]; then
+	dmsetup remove swapdelay
+    fi
+
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/swapfile_deadlock_nopin.ktest
+++ b/tests/fs/bcachefs/swapfile_deadlock_nopin.ktest
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+#
+# Reproducer for the swapfile-under-reclaim deadlock
+# (koverstreet/bcachefs-tools#646): with swap on bcachefs and sustained
+# reclaim pressure, bcachefs kworkers convoy on btree locks —
+# write-path index updates saturate their workqueue (rescuer included)
+# while the allocator's discard worker blocks in six_lock_contended() —
+# and the box hung-tasks or livelocks.
+#
+# Faithful port of the qemu ablation harness profile that reproduced
+# this at every memory size from 768M down to 128M on a swap-files
+# implementation without the reclaim-path armor (PF_MEMALLOC propagation
+# to the write path, btree node pinning, btree cache pre-reserve,
+# mempool sizing), and never with it.  The load-bearing details:
+#   - low-memory VM, few vCPUs (small worker pools starve fast)
+#   - the swapfile is WRITTEN OUT with buffered zero-writes, not
+#     fallocated: that fragments it into many small extents, so every
+#     swap I/O carries more btree traffic
+#   - the eater holds ~RAM+300M of touched-hot anonymous memory,
+#     re-touches it continuously, and is exempted from the OOM killer
+#     (oom_score_adj -1000).  A killable eater gets OOM-killed, the
+#     pressure collapses and the system recovers — that alone flips the
+#     result from deadlock to pass.
+#   - a sacrificial balloon keeps the OOM killer supplied with victims,
+#     removing the mm-level "System is deadlocked on memory" panic that
+#     can otherwise race ahead and kill even a correct kernel
+#   - vm.swappiness=100
+#
+# hung_task_panic is enabled during the pressure phase so a deadlock
+# fails the test loudly with console backtraces within ~30s of forming.
+# Some wedges starve userspace without leaving D-state tasks (workqueue
+# lockup dumps, console-dead livelock); those are caught by the
+# supervisor timeout, so run this THROUGH lib/supervisor — bare
+# build-test-kernel run has no host-side timeout enforcement.
+#
+#   SWAPFILE_TEST_MEM=512M      VM memory (the matrix repro point)
+#   SWAPFILE_TEST_CPUS=2        vCPUs
+#   SWAPFILE_TEST_ROUNDS=3      pressure rounds per boot (race amplifier)
+#   SWAPFILE_TEST_DURATION=120  seconds of pressure per round
+#   SWAPFILE_TEST_SWAP_MB=768   swapfile size (dd-written).  Sized so
+#                               total anon commit (eater + balloon +
+#                               daemons) is ~80% of RAM+swap: the burst
+#                               that triggers the deadlock is unchanged,
+#                               but a correct kernel can never reach
+#                               OOM-victim exhaustion, so the mm-level
+#                               "deadlocked on memory" panic disappears
+#                               from both sides of the comparison
+#   SWAPFILE_TEST_EAT_MB        eater size; default MemTotal+150M — well
+#                               past RAM (crushes the file LRU, denying
+#                               reclaim its non-swap escape valve) but
+#                               comfortably under RAM+swap: total anon
+#                               commit ~85% of capacity, so a correct
+#                               kernel never reaches OOM-victim
+#                               exhaustion, while a broken one still
+#                               deadlocks in the swap-out burst
+#   SWAPFILE_TEST_FILEIO=0      disable the 64K-file write/delete churn
+#   SWAPFILE_TEST_DELAY_MS      optional: dm-delay fake spinning rust
+#
+# Note for dkms runs: the in-VM bcachefs-tools/dkms build needs ~4G; run
+# once with SWAPFILE_TEST_MEM=4G to warm the tools/dkms caches for a new
+# deps HEAD before using the low-memory config.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/memory-pressure-libs.sh
+
+# Ablation variant: btree node pinning OFF (bcachefs.swap_nopin), rest of
+# the armour ON.  Generated from swapfile_deadlock.ktest.
+require-kernel-append "bcachefs.swap_nopin"
+
+require-kernel-config SWAP
+require-kernel-config DETECT_HUNG_TASK
+require-kernel-config BLK_DEV_DM
+require-kernel-config DM_DELAY
+
+config-mem ${SWAPFILE_TEST_MEM:-512M}
+config-cpus ${SWAPFILE_TEST_CPUS:-2}
+config-scratch-devs 2G
+config-timeout 900
+
+# Parallel matrix runs reuse a prebuilt kernel — skip the kernel build.
+# (Debug assertions matter for the reproduction; bcachefs-test-libs
+# already requires BCACHEFS_DEBUG in-tree and exports it for dkms builds.)
+[[ -n ${SWAPFILE_TEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+test_swapfile_reclaim_deadlock()
+{
+    set_watchdog 700
+
+    local dev=${ktest_scratch_dev[0]}
+
+    # Optional fake spinning rust: adds per-I/O latency under the fs so
+    # swap-out stalls while reclaim pressure keeps building.
+    if [[ -n ${SWAPFILE_TEST_DELAY_MS:-} ]]; then
+	local sectors=$(blockdev --getsz "$dev")
+	dmsetup create swapdelay --table \
+	    "0 $sectors delay $dev 0 ${SWAPFILE_TEST_DELAY_MS}"
+	dev=/dev/mapper/swapdelay
+	echo "=== swap fs on dm-delay ${SWAPFILE_TEST_DELAY_MS}ms ==="
+    fi
+    echo "=== $(grep MemTotal /proc/meminfo), $(nproc) cpus ==="
+
+    run_quiet "" bcachefs format -f "$dev"
+    mount -t bcachefs "$dev" /mnt
+
+    # dd, not fallocate: buffered zero-writes fragment the swapfile into
+    # many small extents, multiplying the btree traffic per swap I/O.
+    # This is one of the details the deadlock needs.
+    dd if=/dev/zero of=/mnt/swapfile bs=1M count=${SWAPFILE_TEST_SWAP_MB:-768} \
+       conv=fsync status=none
+    chmod 600 /mnt/swapfile
+    mkswap /mnt/swapfile
+    swapon /mnt/swapfile
+    grep -q /mnt/swapfile /proc/swaps
+
+    echo 100 > /proc/sys/vm/swappiness
+
+    # Fail fast and loudly: a task uninterruptible for 30s panics the box
+    # with backtraces.  Enabled only for the pressure phase — swapoff
+    # legitimately sits in D state for a long time under load.
+    echo 30 > /proc/sys/kernel/hung_task_timeout_secs
+    echo 1  > /proc/sys/kernel/hung_task_panic
+
+    # 64K-file write/sync/delete churn on the same fs, adding foreground
+    # btree lock traffic to the mix (disable with SWAPFILE_TEST_FILEIO=0).
+    local fileio_pid=
+    if [[ ${SWAPFILE_TEST_FILEIO:-1} != 0 ]]; then
+	mkdir -p /mnt/fileio
+	(
+	    trap - ERR
+	    set +e
+	    i=0
+	    while true; do
+		dd if=/dev/zero of=/mnt/fileio/f$i bs=64K count=1 2>/dev/null
+		i=$((i + 1))
+		if (( i % 100 == 0 )); then
+		    sync
+		    for (( j = i - 100; j < i; j++ )); do
+			rm -f /mnt/fileio/f$j
+		    done
+		fi
+	    done
+	) &
+	fileio_pid=$!
+    fi
+
+    # The eater and the sacrificial balloon (see memory-pressure-libs.sh
+    # for why both are load-bearing).
+    build_eater
+    build_balloon
+
+    local eat_mb=${SWAPFILE_TEST_EAT_MB:-$(awk '/MemTotal/ {print int($2 / 1024) + 300}' /proc/meminfo)}
+    local duration=${SWAPFILE_TEST_DURATION:-120}
+    local rounds=${SWAPFILE_TEST_ROUNDS:-3}
+
+    start_mem_telemetry
+    start_balloon 150
+
+    # The reproduction is a race; each fresh touch storm is another roll
+    # of the dice, so run several rounds per boot.
+    local round
+    for (( round = 1; round <= rounds; round++ )); do
+	echo "=== round $round/$rounds: eater ${eat_mb}M for ${duration}s ==="
+	/tmp/eater "$eat_mb" "$duration" || {
+	    stop_mem_telemetry
+	    echo "eater failed"
+	    return 1
+	}
+	sleep 5
+    done
+    stop_mem_telemetry
+
+    if [[ -n $fileio_pid ]]; then
+	kill $fileio_pid 2>/dev/null || true
+	wait $fileio_pid 2>/dev/null || true
+    fi
+
+    echo 0 > /proc/sys/kernel/hung_task_panic
+
+    cat /proc/swaps
+    grep -E "MemFree|SwapFree" /proc/meminfo
+
+    # Optional: swapoff while a MODEST eater keeps the system under
+    # pressure.  The eater must stay below RAM: with committed anon over
+    # RAM, try_to_unuse() has nowhere to put the pages and livelocks by
+    # design — an mm property, not a filesystem verdict.  Sized so the
+    # swapped pages fit back, swapoff MUST succeed; wedging or erroring
+    # is a filesystem swap_activate/readback bug.  (hung_task_panic is
+    # already off: swapoff sits in D state legitimately here.)
+    if [[ -n ${SWAPFILE_TEST_SWAPOFF:-} ]]; then
+	echo "=== swapoff under pressure ==="
+	local squeeze_mb=$(awk '/MemTotal/ {print int($2 * 60 / 100 / 1024)}' /proc/meminfo)
+	/tmp/eater "$squeeze_mb" 300 &
+	local swapoff_eater=$!
+	sleep 20
+	grep -E "SwapFree" /proc/meminfo
+	swapoff /mnt/swapfile
+	echo "swapoff under pressure: succeeded"
+	kill $swapoff_eater 2>/dev/null || true
+	wait $swapoff_eater 2>/dev/null || true
+	swapon /mnt/swapfile
+    fi
+
+    stop_balloon
+
+    swapoff /mnt/swapfile
+    rm -f /mnt/swapfile
+    rm -rf /mnt/fileio
+    umount /mnt
+
+    # In-kernel fsck: the userspace fsck wants a large fraction of RAM up
+    # front and OOMs in a VM this small; the kernel's runs in the same
+    # footprint as a normal mount.
+    mount -t bcachefs -o fsck,ro "$dev" /mnt
+    umount /mnt
+
+    if [[ $dev = /dev/mapper/swapdelay ]]; then
+	dmsetup remove swapdelay
+    fi
+
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/swapfile_deadlock_nopin.ktest
+++ b/tests/fs/bcachefs/swapfile_deadlock_nopin.ktest
@@ -86,6 +86,19 @@ test_swapfile_reclaim_deadlock()
 {
     set_watchdog 700
 
+    # This test ablates via a kernel command-line toggle. Those __setup
+    # handlers have been removed from bcachefs -- neither swap_noreclaim nor
+    # swap_nopin matches any source file on current master -- and an
+    # unrecognised parameter is silently ignored. Without this check the run
+    # below builds and exercises the FULLY ARMOURED kernel and reports a pass
+    # while claiming to have tested the ablated one, which is worse than no
+    # test: it certifies what it can no longer see.
+    if dmesg | grep --quiet --extended-regexp \
+	    'Unknown kernel command line parameters.*bcachefs\.'; then
+	dmesg | grep --extended-regexp 'Unknown kernel command line parameters' || true
+	fail "ABLATION INERT: this kernel ignored the bcachefs.* toggle this test ablates with, so the armour is still on and the result below would be meaningless. The __setup handlers were removed; ablate at source and build a second kernel instead."
+    fi
+
     local dev=${ktest_scratch_dev[0]}
 
     # Optional fake spinning rust: adds per-I/O latency under the fs so

--- a/tests/fs/bcachefs/swapfile_deadlock_noreclaim.ktest
+++ b/tests/fs/bcachefs/swapfile_deadlock_noreclaim.ktest
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+#
+# Reproducer for the swapfile-under-reclaim deadlock
+# (koverstreet/bcachefs-tools#646): with swap on bcachefs and sustained
+# reclaim pressure, bcachefs kworkers convoy on btree locks —
+# write-path index updates saturate their workqueue (rescuer included)
+# while the allocator's discard worker blocks in six_lock_contended() —
+# and the box hung-tasks or livelocks.
+#
+# Faithful port of the qemu ablation harness profile that reproduced
+# this at every memory size from 768M down to 128M on a swap-files
+# implementation without the reclaim-path armor (PF_MEMALLOC propagation
+# to the write path, btree node pinning, btree cache pre-reserve,
+# mempool sizing), and never with it.  The load-bearing details:
+#   - low-memory VM, few vCPUs (small worker pools starve fast)
+#   - the swapfile is WRITTEN OUT with buffered zero-writes, not
+#     fallocated: that fragments it into many small extents, so every
+#     swap I/O carries more btree traffic
+#   - the eater holds ~RAM+300M of touched-hot anonymous memory,
+#     re-touches it continuously, and is exempted from the OOM killer
+#     (oom_score_adj -1000).  A killable eater gets OOM-killed, the
+#     pressure collapses and the system recovers — that alone flips the
+#     result from deadlock to pass.
+#   - a sacrificial balloon keeps the OOM killer supplied with victims,
+#     removing the mm-level "System is deadlocked on memory" panic that
+#     can otherwise race ahead and kill even a correct kernel
+#   - vm.swappiness=100
+#
+# hung_task_panic is enabled during the pressure phase so a deadlock
+# fails the test loudly with console backtraces within ~30s of forming.
+# Some wedges starve userspace without leaving D-state tasks (workqueue
+# lockup dumps, console-dead livelock); those are caught by the
+# supervisor timeout, so run this THROUGH lib/supervisor — bare
+# build-test-kernel run has no host-side timeout enforcement.
+#
+#   SWAPFILE_TEST_MEM=512M      VM memory (the matrix repro point)
+#   SWAPFILE_TEST_CPUS=2        vCPUs
+#   SWAPFILE_TEST_ROUNDS=3      pressure rounds per boot (race amplifier)
+#   SWAPFILE_TEST_DURATION=120  seconds of pressure per round
+#   SWAPFILE_TEST_SWAP_MB=768   swapfile size (dd-written).  Sized so
+#                               total anon commit (eater + balloon +
+#                               daemons) is ~80% of RAM+swap: the burst
+#                               that triggers the deadlock is unchanged,
+#                               but a correct kernel can never reach
+#                               OOM-victim exhaustion, so the mm-level
+#                               "deadlocked on memory" panic disappears
+#                               from both sides of the comparison
+#   SWAPFILE_TEST_EAT_MB        eater size; default MemTotal+150M — well
+#                               past RAM (crushes the file LRU, denying
+#                               reclaim its non-swap escape valve) but
+#                               comfortably under RAM+swap: total anon
+#                               commit ~85% of capacity, so a correct
+#                               kernel never reaches OOM-victim
+#                               exhaustion, while a broken one still
+#                               deadlocks in the swap-out burst
+#   SWAPFILE_TEST_FILEIO=0      disable the 64K-file write/delete churn
+#   SWAPFILE_TEST_DELAY_MS      optional: dm-delay fake spinning rust
+#
+# Note for dkms runs: the in-VM bcachefs-tools/dkms build needs ~4G; run
+# once with SWAPFILE_TEST_MEM=4G to warm the tools/dkms caches for a new
+# deps HEAD before using the low-memory config.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/memory-pressure-libs.sh
+
+# Ablation variant: PF_MEMALLOC propagation OFF (bcachefs.swap_noreclaim),
+# rest of the armour ON.  Generated from swapfile_deadlock.ktest.
+require-kernel-append "bcachefs.swap_noreclaim"
+
+require-kernel-config SWAP
+require-kernel-config DETECT_HUNG_TASK
+require-kernel-config BLK_DEV_DM
+require-kernel-config DM_DELAY
+
+config-mem ${SWAPFILE_TEST_MEM:-512M}
+config-cpus ${SWAPFILE_TEST_CPUS:-2}
+config-scratch-devs 2G
+config-timeout 900
+
+# Parallel matrix runs reuse a prebuilt kernel — skip the kernel build.
+# (Debug assertions matter for the reproduction; bcachefs-test-libs
+# already requires BCACHEFS_DEBUG in-tree and exports it for dkms builds.)
+[[ -n ${SWAPFILE_TEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+test_swapfile_reclaim_deadlock()
+{
+    set_watchdog 700
+
+    local dev=${ktest_scratch_dev[0]}
+
+    # Optional fake spinning rust: adds per-I/O latency under the fs so
+    # swap-out stalls while reclaim pressure keeps building.
+    if [[ -n ${SWAPFILE_TEST_DELAY_MS:-} ]]; then
+	local sectors=$(blockdev --getsz "$dev")
+	dmsetup create swapdelay --table \
+	    "0 $sectors delay $dev 0 ${SWAPFILE_TEST_DELAY_MS}"
+	dev=/dev/mapper/swapdelay
+	echo "=== swap fs on dm-delay ${SWAPFILE_TEST_DELAY_MS}ms ==="
+    fi
+    echo "=== $(grep MemTotal /proc/meminfo), $(nproc) cpus ==="
+
+    run_quiet "" bcachefs format -f "$dev"
+    mount -t bcachefs "$dev" /mnt
+
+    # dd, not fallocate: buffered zero-writes fragment the swapfile into
+    # many small extents, multiplying the btree traffic per swap I/O.
+    # This is one of the details the deadlock needs.
+    dd if=/dev/zero of=/mnt/swapfile bs=1M count=${SWAPFILE_TEST_SWAP_MB:-768} \
+       conv=fsync status=none
+    chmod 600 /mnt/swapfile
+    mkswap /mnt/swapfile
+    swapon /mnt/swapfile
+    grep -q /mnt/swapfile /proc/swaps
+
+    echo 100 > /proc/sys/vm/swappiness
+
+    # Fail fast and loudly: a task uninterruptible for 30s panics the box
+    # with backtraces.  Enabled only for the pressure phase — swapoff
+    # legitimately sits in D state for a long time under load.
+    echo 30 > /proc/sys/kernel/hung_task_timeout_secs
+    echo 1  > /proc/sys/kernel/hung_task_panic
+
+    # 64K-file write/sync/delete churn on the same fs, adding foreground
+    # btree lock traffic to the mix (disable with SWAPFILE_TEST_FILEIO=0).
+    local fileio_pid=
+    if [[ ${SWAPFILE_TEST_FILEIO:-1} != 0 ]]; then
+	mkdir -p /mnt/fileio
+	(
+	    trap - ERR
+	    set +e
+	    i=0
+	    while true; do
+		dd if=/dev/zero of=/mnt/fileio/f$i bs=64K count=1 2>/dev/null
+		i=$((i + 1))
+		if (( i % 100 == 0 )); then
+		    sync
+		    for (( j = i - 100; j < i; j++ )); do
+			rm -f /mnt/fileio/f$j
+		    done
+		fi
+	    done
+	) &
+	fileio_pid=$!
+    fi
+
+    # The eater and the sacrificial balloon (see memory-pressure-libs.sh
+    # for why both are load-bearing).
+    build_eater
+    build_balloon
+
+    local eat_mb=${SWAPFILE_TEST_EAT_MB:-$(awk '/MemTotal/ {print int($2 / 1024) + 300}' /proc/meminfo)}
+    local duration=${SWAPFILE_TEST_DURATION:-120}
+    local rounds=${SWAPFILE_TEST_ROUNDS:-3}
+
+    start_mem_telemetry
+    start_balloon 150
+
+    # The reproduction is a race; each fresh touch storm is another roll
+    # of the dice, so run several rounds per boot.
+    local round
+    for (( round = 1; round <= rounds; round++ )); do
+	echo "=== round $round/$rounds: eater ${eat_mb}M for ${duration}s ==="
+	/tmp/eater "$eat_mb" "$duration" || {
+	    stop_mem_telemetry
+	    echo "eater failed"
+	    return 1
+	}
+	sleep 5
+    done
+    stop_mem_telemetry
+
+    if [[ -n $fileio_pid ]]; then
+	kill $fileio_pid 2>/dev/null || true
+	wait $fileio_pid 2>/dev/null || true
+    fi
+
+    echo 0 > /proc/sys/kernel/hung_task_panic
+
+    cat /proc/swaps
+    grep -E "MemFree|SwapFree" /proc/meminfo
+
+    # Optional: swapoff while a MODEST eater keeps the system under
+    # pressure.  The eater must stay below RAM: with committed anon over
+    # RAM, try_to_unuse() has nowhere to put the pages and livelocks by
+    # design — an mm property, not a filesystem verdict.  Sized so the
+    # swapped pages fit back, swapoff MUST succeed; wedging or erroring
+    # is a filesystem swap_activate/readback bug.  (hung_task_panic is
+    # already off: swapoff sits in D state legitimately here.)
+    if [[ -n ${SWAPFILE_TEST_SWAPOFF:-} ]]; then
+	echo "=== swapoff under pressure ==="
+	local squeeze_mb=$(awk '/MemTotal/ {print int($2 * 60 / 100 / 1024)}' /proc/meminfo)
+	/tmp/eater "$squeeze_mb" 300 &
+	local swapoff_eater=$!
+	sleep 20
+	grep -E "SwapFree" /proc/meminfo
+	swapoff /mnt/swapfile
+	echo "swapoff under pressure: succeeded"
+	kill $swapoff_eater 2>/dev/null || true
+	wait $swapoff_eater 2>/dev/null || true
+	swapon /mnt/swapfile
+    fi
+
+    stop_balloon
+
+    swapoff /mnt/swapfile
+    rm -f /mnt/swapfile
+    rm -rf /mnt/fileio
+    umount /mnt
+
+    # In-kernel fsck: the userspace fsck wants a large fraction of RAM up
+    # front and OOMs in a VM this small; the kernel's runs in the same
+    # footprint as a normal mount.
+    mount -t bcachefs -o fsck,ro "$dev" /mnt
+    umount /mnt
+
+    if [[ $dev = /dev/mapper/swapdelay ]]; then
+	dmsetup remove swapdelay
+    fi
+
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/swapfile_deadlock_noreclaim.ktest
+++ b/tests/fs/bcachefs/swapfile_deadlock_noreclaim.ktest
@@ -86,6 +86,19 @@ test_swapfile_reclaim_deadlock()
 {
     set_watchdog 700
 
+    # This test ablates via a kernel command-line toggle. Those __setup
+    # handlers have been removed from bcachefs -- neither swap_noreclaim nor
+    # swap_nopin matches any source file on current master -- and an
+    # unrecognised parameter is silently ignored. Without this check the run
+    # below builds and exercises the FULLY ARMOURED kernel and reports a pass
+    # while claiming to have tested the ablated one, which is worse than no
+    # test: it certifies what it can no longer see.
+    if dmesg | grep --quiet --extended-regexp \
+	    'Unknown kernel command line parameters.*bcachefs\.'; then
+	dmesg | grep --extended-regexp 'Unknown kernel command line parameters' || true
+	fail "ABLATION INERT: this kernel ignored the bcachefs.* toggle this test ablates with, so the armour is still on and the result below would be meaningless. The __setup handlers were removed; ablate at source and build a second kernel instead."
+    fi
+
     local dev=${ktest_scratch_dev[0]}
 
     # Optional fake spinning rust: adds per-I/O latency under the fs so

--- a/tests/fs/bcachefs/swapfile_deadlock_noreclaim_nopin.ktest
+++ b/tests/fs/bcachefs/swapfile_deadlock_noreclaim_nopin.ktest
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+#
+# Reproducer for the swapfile-under-reclaim deadlock
+# (koverstreet/bcachefs-tools#646): with swap on bcachefs and sustained
+# reclaim pressure, bcachefs kworkers convoy on btree locks —
+# write-path index updates saturate their workqueue (rescuer included)
+# while the allocator's discard worker blocks in six_lock_contended() —
+# and the box hung-tasks or livelocks.
+#
+# Faithful port of the qemu ablation harness profile that reproduced
+# this at every memory size from 768M down to 128M on a swap-files
+# implementation without the reclaim-path armor (PF_MEMALLOC propagation
+# to the write path, btree node pinning, btree cache pre-reserve,
+# mempool sizing), and never with it.  The load-bearing details:
+#   - low-memory VM, few vCPUs (small worker pools starve fast)
+#   - the swapfile is WRITTEN OUT with buffered zero-writes, not
+#     fallocated: that fragments it into many small extents, so every
+#     swap I/O carries more btree traffic
+#   - the eater holds ~RAM+300M of touched-hot anonymous memory,
+#     re-touches it continuously, and is exempted from the OOM killer
+#     (oom_score_adj -1000).  A killable eater gets OOM-killed, the
+#     pressure collapses and the system recovers — that alone flips the
+#     result from deadlock to pass.
+#   - a sacrificial balloon keeps the OOM killer supplied with victims,
+#     removing the mm-level "System is deadlocked on memory" panic that
+#     can otherwise race ahead and kill even a correct kernel
+#   - vm.swappiness=100
+#
+# hung_task_panic is enabled during the pressure phase so a deadlock
+# fails the test loudly with console backtraces within ~30s of forming.
+# Some wedges starve userspace without leaving D-state tasks (workqueue
+# lockup dumps, console-dead livelock); those are caught by the
+# supervisor timeout, so run this THROUGH lib/supervisor — bare
+# build-test-kernel run has no host-side timeout enforcement.
+#
+#   SWAPFILE_TEST_MEM=512M      VM memory (the matrix repro point)
+#   SWAPFILE_TEST_CPUS=2        vCPUs
+#   SWAPFILE_TEST_ROUNDS=3      pressure rounds per boot (race amplifier)
+#   SWAPFILE_TEST_DURATION=120  seconds of pressure per round
+#   SWAPFILE_TEST_SWAP_MB=768   swapfile size (dd-written).  Sized so
+#                               total anon commit (eater + balloon +
+#                               daemons) is ~80% of RAM+swap: the burst
+#                               that triggers the deadlock is unchanged,
+#                               but a correct kernel can never reach
+#                               OOM-victim exhaustion, so the mm-level
+#                               "deadlocked on memory" panic disappears
+#                               from both sides of the comparison
+#   SWAPFILE_TEST_EAT_MB        eater size; default MemTotal+150M — well
+#                               past RAM (crushes the file LRU, denying
+#                               reclaim its non-swap escape valve) but
+#                               comfortably under RAM+swap: total anon
+#                               commit ~85% of capacity, so a correct
+#                               kernel never reaches OOM-victim
+#                               exhaustion, while a broken one still
+#                               deadlocks in the swap-out burst
+#   SWAPFILE_TEST_FILEIO=0      disable the 64K-file write/delete churn
+#   SWAPFILE_TEST_DELAY_MS      optional: dm-delay fake spinning rust
+#
+# Note for dkms runs: the in-VM bcachefs-tools/dkms build needs ~4G; run
+# once with SWAPFILE_TEST_MEM=4G to warm the tools/dkms caches for a new
+# deps HEAD before using the low-memory config.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/memory-pressure-libs.sh
+
+# Ablation variant: PF_MEMALLOC propagation AND btree node pinning OFF,
+# rest of the armour ON.  Generated from swapfile_deadlock.ktest.
+require-kernel-append "bcachefs.swap_noreclaim bcachefs.swap_nopin"
+
+require-kernel-config SWAP
+require-kernel-config DETECT_HUNG_TASK
+require-kernel-config BLK_DEV_DM
+require-kernel-config DM_DELAY
+
+config-mem ${SWAPFILE_TEST_MEM:-512M}
+config-cpus ${SWAPFILE_TEST_CPUS:-2}
+config-scratch-devs 2G
+config-timeout 900
+
+# Parallel matrix runs reuse a prebuilt kernel — skip the kernel build.
+# (Debug assertions matter for the reproduction; bcachefs-test-libs
+# already requires BCACHEFS_DEBUG in-tree and exports it for dkms builds.)
+[[ -n ${SWAPFILE_TEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+test_swapfile_reclaim_deadlock()
+{
+    set_watchdog 700
+
+    local dev=${ktest_scratch_dev[0]}
+
+    # Optional fake spinning rust: adds per-I/O latency under the fs so
+    # swap-out stalls while reclaim pressure keeps building.
+    if [[ -n ${SWAPFILE_TEST_DELAY_MS:-} ]]; then
+	local sectors=$(blockdev --getsz "$dev")
+	dmsetup create swapdelay --table \
+	    "0 $sectors delay $dev 0 ${SWAPFILE_TEST_DELAY_MS}"
+	dev=/dev/mapper/swapdelay
+	echo "=== swap fs on dm-delay ${SWAPFILE_TEST_DELAY_MS}ms ==="
+    fi
+    echo "=== $(grep MemTotal /proc/meminfo), $(nproc) cpus ==="
+
+    run_quiet "" bcachefs format -f "$dev"
+    mount -t bcachefs "$dev" /mnt
+
+    # dd, not fallocate: buffered zero-writes fragment the swapfile into
+    # many small extents, multiplying the btree traffic per swap I/O.
+    # This is one of the details the deadlock needs.
+    dd if=/dev/zero of=/mnt/swapfile bs=1M count=${SWAPFILE_TEST_SWAP_MB:-768} \
+       conv=fsync status=none
+    chmod 600 /mnt/swapfile
+    mkswap /mnt/swapfile
+    swapon /mnt/swapfile
+    grep -q /mnt/swapfile /proc/swaps
+
+    echo 100 > /proc/sys/vm/swappiness
+
+    # Fail fast and loudly: a task uninterruptible for 30s panics the box
+    # with backtraces.  Enabled only for the pressure phase — swapoff
+    # legitimately sits in D state for a long time under load.
+    echo 30 > /proc/sys/kernel/hung_task_timeout_secs
+    echo 1  > /proc/sys/kernel/hung_task_panic
+
+    # 64K-file write/sync/delete churn on the same fs, adding foreground
+    # btree lock traffic to the mix (disable with SWAPFILE_TEST_FILEIO=0).
+    local fileio_pid=
+    if [[ ${SWAPFILE_TEST_FILEIO:-1} != 0 ]]; then
+	mkdir -p /mnt/fileio
+	(
+	    trap - ERR
+	    set +e
+	    i=0
+	    while true; do
+		dd if=/dev/zero of=/mnt/fileio/f$i bs=64K count=1 2>/dev/null
+		i=$((i + 1))
+		if (( i % 100 == 0 )); then
+		    sync
+		    for (( j = i - 100; j < i; j++ )); do
+			rm -f /mnt/fileio/f$j
+		    done
+		fi
+	    done
+	) &
+	fileio_pid=$!
+    fi
+
+    # The eater and the sacrificial balloon (see memory-pressure-libs.sh
+    # for why both are load-bearing).
+    build_eater
+    build_balloon
+
+    local eat_mb=${SWAPFILE_TEST_EAT_MB:-$(awk '/MemTotal/ {print int($2 / 1024) + 300}' /proc/meminfo)}
+    local duration=${SWAPFILE_TEST_DURATION:-120}
+    local rounds=${SWAPFILE_TEST_ROUNDS:-3}
+
+    start_mem_telemetry
+    start_balloon 150
+
+    # The reproduction is a race; each fresh touch storm is another roll
+    # of the dice, so run several rounds per boot.
+    local round
+    for (( round = 1; round <= rounds; round++ )); do
+	echo "=== round $round/$rounds: eater ${eat_mb}M for ${duration}s ==="
+	/tmp/eater "$eat_mb" "$duration" || {
+	    stop_mem_telemetry
+	    echo "eater failed"
+	    return 1
+	}
+	sleep 5
+    done
+    stop_mem_telemetry
+
+    if [[ -n $fileio_pid ]]; then
+	kill $fileio_pid 2>/dev/null || true
+	wait $fileio_pid 2>/dev/null || true
+    fi
+
+    echo 0 > /proc/sys/kernel/hung_task_panic
+
+    cat /proc/swaps
+    grep -E "MemFree|SwapFree" /proc/meminfo
+
+    # Optional: swapoff while a MODEST eater keeps the system under
+    # pressure.  The eater must stay below RAM: with committed anon over
+    # RAM, try_to_unuse() has nowhere to put the pages and livelocks by
+    # design — an mm property, not a filesystem verdict.  Sized so the
+    # swapped pages fit back, swapoff MUST succeed; wedging or erroring
+    # is a filesystem swap_activate/readback bug.  (hung_task_panic is
+    # already off: swapoff sits in D state legitimately here.)
+    if [[ -n ${SWAPFILE_TEST_SWAPOFF:-} ]]; then
+	echo "=== swapoff under pressure ==="
+	local squeeze_mb=$(awk '/MemTotal/ {print int($2 * 60 / 100 / 1024)}' /proc/meminfo)
+	/tmp/eater "$squeeze_mb" 300 &
+	local swapoff_eater=$!
+	sleep 20
+	grep -E "SwapFree" /proc/meminfo
+	swapoff /mnt/swapfile
+	echo "swapoff under pressure: succeeded"
+	kill $swapoff_eater 2>/dev/null || true
+	wait $swapoff_eater 2>/dev/null || true
+	swapon /mnt/swapfile
+    fi
+
+    stop_balloon
+
+    swapoff /mnt/swapfile
+    rm -f /mnt/swapfile
+    rm -rf /mnt/fileio
+    umount /mnt
+
+    # In-kernel fsck: the userspace fsck wants a large fraction of RAM up
+    # front and OOMs in a VM this small; the kernel's runs in the same
+    # footprint as a normal mount.
+    mount -t bcachefs -o fsck,ro "$dev" /mnt
+    umount /mnt
+
+    if [[ $dev = /dev/mapper/swapdelay ]]; then
+	dmsetup remove swapdelay
+    fi
+
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/swapfile_deadlock_noreclaim_nopin.ktest
+++ b/tests/fs/bcachefs/swapfile_deadlock_noreclaim_nopin.ktest
@@ -86,6 +86,19 @@ test_swapfile_reclaim_deadlock()
 {
     set_watchdog 700
 
+    # This test ablates via a kernel command-line toggle. Those __setup
+    # handlers have been removed from bcachefs -- neither swap_noreclaim nor
+    # swap_nopin matches any source file on current master -- and an
+    # unrecognised parameter is silently ignored. Without this check the run
+    # below builds and exercises the FULLY ARMOURED kernel and reports a pass
+    # while claiming to have tested the ablated one, which is worse than no
+    # test: it certifies what it can no longer see.
+    if dmesg | grep --quiet --extended-regexp \
+	    'Unknown kernel command line parameters.*bcachefs\.'; then
+	dmesg | grep --extended-regexp 'Unknown kernel command line parameters' || true
+	fail "ABLATION INERT: this kernel ignored the bcachefs.* toggle this test ablates with, so the armour is still on and the result below would be meaningless. The __setup handlers were removed; ablate at source and build a second kernel instead."
+    fi
+
     local dev=${ktest_scratch_dev[0]}
 
     # Optional fake spinning rust: adds per-I/O latency under the fs so

--- a/tests/fs/bcachefs/swapfile_pressure.ktest
+++ b/tests/fs/bcachefs/swapfile_pressure.ktest
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Swapfile-under-reclaim pressure test, parametrized by VM memory.
+#
+# Based on the shape of koverstreet/ktest#63 (companion to
+# koverstreet/bcachefs-tools#646) so results are directly comparable,
+# with the memory size dialed down to probe the low-memory regime where
+# the original swap-files implementation needed PF_MEMALLOC propagation,
+# btree node pinning, cache pre-reserves and mempool sizing to survive.
+#
+#   SWAPFILE_TEST_MEM=768M (default) | 256M | 192M   VM memory
+#   SWAPFILE_TEST_DURATION=120                       seconds of pressure
+#
+# PASS = pressure workload completes and fsck is clean.
+# FAIL/watchdog timeout = reclaim hang or crash — the interesting result.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+require-kernel-config SWAP
+# For the fake-spinning-rust variant (dm-delay under the fs holding swap):
+require-kernel-config BLK_DEV_DM
+require-kernel-config DM_DELAY
+
+config-mem ${SWAPFILE_TEST_MEM:-768M}
+config-scratch-devs 2G
+config-timeout 600
+
+# Parallel matrix runs reuse a prebuilt kernel (reflinked into the run's
+# output dir) — skip the kernel build for those.
+[[ -n ${SWAPFILE_TEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+dump_swap_debug()
+{
+    cat /proc/swaps || true
+    grep -E "MemTotal|MemFree|MemAvailable|SwapTotal|SwapFree" /proc/meminfo || true
+    dmesg | tail -n 100 || true
+}
+
+disable_swapfile()
+{
+    swapoff /mnt/swapfile 2>/dev/null || true
+}
+
+test_swapfile_reclaim_pressure()
+{
+    set_watchdog 400
+
+    echo "=== VM memory: $(grep MemTotal /proc/meminfo) ==="
+
+    local dev=${ktest_scratch_dev[0]}
+
+    # Fake spinning rust: SWAPFILE_TEST_DELAY_MS adds that much latency to
+    # every I/O on the device under the filesystem holding the swapfile,
+    # so swap-out stalls while reclaim pressure keeps building.
+    if [[ -n ${SWAPFILE_TEST_DELAY_MS:-} ]]; then
+	local sectors=$(blockdev --getsz "$dev")
+	dmsetup create swapdelay --table \
+	    "0 $sectors delay $dev 0 ${SWAPFILE_TEST_DELAY_MS}"
+	dev=/dev/mapper/swapdelay
+	echo "=== swap fs on dm-delay ${SWAPFILE_TEST_DELAY_MS}ms ==="
+    fi
+
+    run_quiet "" bcachefs format -f "$dev"
+    mount -t bcachefs "$dev" /mnt
+
+    fallocate -l 512M /mnt/swapfile
+    chmod 600 /mnt/swapfile
+    mkswap /mnt/swapfile
+
+    if ! swapon /mnt/swapfile; then
+	echo "bcachefs swapfile swapon failed"
+	dump_swap_debug
+	return 1
+    fi
+    trap disable_swapfile EXIT
+
+    grep -q /mnt/swapfile /proc/swaps
+
+    # Two workers at SWAPFILE_TEST_VM_BYTES (percent of RAM) each:
+    # the default ~130% total forces sustained swap while staying within
+    # swapfile capacity at every memory size; crank it (e.g. 85) for the
+    # harsh variant.
+    stress-ng --vm 2 --vm-bytes ${SWAPFILE_TEST_VM_BYTES:-65}% --vm-keep \
+	      -t ${SWAPFILE_TEST_DURATION:-120} --metrics-brief || {
+	echo "swap pressure workload failed"
+	dump_swap_debug
+	return 1
+    }
+
+    dump_swap_debug
+
+    swapoff /mnt/swapfile
+    trap - EXIT
+
+    rm -f /mnt/swapfile
+    umount /mnt
+
+    # In-kernel fsck: the userspace fsck implementation OOMs in small VMs
+    # (it wants a large fraction of RAM up front); the kernel's works in
+    # the same footprint as a normal mount.
+    mount -t bcachefs -o fsck,ro "$dev" /mnt
+    umount /mnt
+
+    if [[ $dev = /dev/mapper/swapdelay ]]; then
+	dmsetup remove swapdelay
+    fi
+
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/upgrade-138-139-accounting-underflow.ktest
+++ b/tests/fs/bcachefs/upgrade-138-139-accounting-underflow.ktest
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# accounting_key_underflow after a 1.38 -> 1.39 on-disk upgrade: is it the
+# in-kernel path, or is it the on-disk state?
+#
+# WHY THIS EXISTS
+# ---------------
+# version-upgrade-138-to-139.ktest reports, after the upgrade,
+#
+#   errors this recovery:
+#     accounting_mismatch                  4
+#     accounting_key_underflow             1
+#
+# and the underflow does NOT appear when the same image is upgraded with
+# `bcachefs fsck -y` in userspace on the host. That could mean either
+#
+#   (a) the in-kernel fsck/upgrade path is what introduces or reports it, or
+#   (b) the difference is mount-vs-fsck: a mount runs only the passes the
+#       upgrade table schedules for 1.39, which do NOT include
+#       check_allocations, while `fsck` runs the full PASS_FSCK set and so
+#       rebuilds accounting from scratch.
+#
+# This test discriminates. It holds the *upgrade* fixed (an in-kernel mount)
+# and varies only the *checker*: the same post-upgrade device is checked once
+# with the in-kernel fsck and once with the userspace one.
+#
+# ktest's bcachefs-test-libs.sh exports BCACHEFS_KERNEL_ONLY=1, and
+# src/commands/fsck.rs checks that env var BEFORE cli.no_kernel, so -K alone
+# cannot force userspace here. `env --unset=BCACHEFS_KERNEL_ONLY` can.
+# Watch for the "Running userspace offline fsck" / "Running in-kernel offline
+# fsck" banner rather than assuming.
+#
+# It also answers whether the underflow is transient: a read-only check is
+# repeated, then a repairing fsck, then a check.
+#
+# USAGE
+#   ktest_138_image=<out1>/upgrade-138/fs-1.38.img \
+#   build-test-kernel run -k <1.39-tree> -o <out2> \
+#       tests/fs/bcachefs/upgrade-138-139-accounting-underflow.ktest underflow_paths
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+config-mem 2G
+config-timeout 1800
+config-image	"$ktest_138_image"
+
+upgrade_dev=/dev/vdb
+
+# The counters that matter. Printed for every fsck run so the runs can be
+# compared line by line.
+report_acct()
+{
+    local tag=$1 log=$2 rc=$3
+
+    echo "--- $tag: exit $rc ---"
+    grep --extended-regexp 'Running (in-kernel|userspace) offline fsck' "$log" ||
+	echo "  (no fsck implementation banner -- check the log)"
+    grep --after-context=2 'Accounting underflow for' "$log" ||
+	echo "  (no accounting underflow)"
+    grep --after-context=8 'errors this recovery' "$log" ||
+	echo "  (no errors this recovery)"
+}
+
+test_underflow_paths()
+{
+    set_watchdog 900
+
+    if [[ -z ${ktest_138_image:-} ]]; then
+	echo "FAIL: ktest_138_image is not set"
+	return 1
+    fi
+
+    local out=${ktest_out:-/ktest-out}/underflow
+    mkdir --parents "$out"
+
+    bcachefs show-super "$upgrade_dev" | grep --max-count=1 '^Version:'
+
+    # ---- the upgrade: an ordinary in-kernel read-write mount -------------
+    dmesg -C
+    mount -t bcachefs "$upgrade_dev" /mnt
+    umount /mnt
+    dmesg > "$out/upgrade-dmesg.txt"
+
+    bcachefs show-super "$upgrade_dev" | grep --max-count=1 '^Version:'
+
+    # ---- same device, two checkers, both read-only (nochanges) ----------
+    local rc=0
+    bcachefs fsck -n "$upgrade_dev" > "$out/post-kernel.log" 2>&1 || rc=$?
+    report_acct "post-upgrade, IN-KERNEL fsck -n" "$out/post-kernel.log" $rc
+
+    rc=0
+    env --unset=BCACHEFS_KERNEL_ONLY \
+	bcachefs fsck --no-kernel -n "$upgrade_dev" > "$out/post-userspace.log" 2>&1 || rc=$?
+    report_acct "post-upgrade, USERSPACE fsck -n" "$out/post-userspace.log" $rc
+
+    # Export the post-upgrade image so the same bytes can be re-checked on
+    # the host, outside any VM.
+    dd if="$upgrade_dev" of="$out/fs-after-upgrade.img" bs=1M conv=sparse status=none
+    sync
+
+    # ---- transient or persistent? ---------------------------------------
+    # Repeat the read-only check: nochanges means nothing was written, so a
+    # still-reported underflow is on-disk state, not a one-off.
+    rc=0
+    bcachefs fsck -n "$upgrade_dev" > "$out/post-kernel-2.log" 2>&1 || rc=$?
+    report_acct "post-upgrade, IN-KERNEL fsck -n (repeat)" "$out/post-kernel-2.log" $rc
+
+    # Now let it write, and check again.
+    rc=0
+    bcachefs fsck -y "$upgrade_dev" > "$out/repair.log" 2>&1 || rc=$?
+    report_acct "repairing fsck -y" "$out/repair.log" $rc
+
+    rc=0
+    bcachefs fsck -n "$upgrade_dev" > "$out/after-repair.log" 2>&1 || rc=$?
+    report_acct "after repair, fsck -n" "$out/after-repair.log" $rc
+
+    echo "artefacts in <ktest_out>/underflow/"
+    echo "DONE"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/version-upgrade-138-to-139.ktest
+++ b/tests/fs/bcachefs/version-upgrade-138-to-139.ktest
@@ -1,0 +1,574 @@
+#!/usr/bin/env bash
+#
+# Does the on-disk upgrade from 1.38 (need_discard_by_journal_seq) to stock
+# 1.39 (per_dev_fragmentation_lru) preserve per-inode IO options?
+#
+# WHY THIS EXISTS
+# ---------------
+# A production filesystem sits at on-disk 1.38 with ~413,000 inodes carrying
+# explicit per-inode data_replicas overrides. Upstream's 1.39 upgrade entry
+# (fs/sb/downgrade.c, UPGRADE_TABLE) schedules
+#
+#   check_lrus, check_alloc_to_lru_refs, check_inodes, check_xattrs,
+#   check_snapshots, check_subvols, delete_dead_snapshots
+#
+# and lists these errors as tolerated, which feeds them to errors_silent:
+#
+#   inode_has_inode_opts_flag_wrong, inode_has_access_acl_flag_wrong,
+#   inode_has_default_acl_flag_wrong, lru_entry_bad,
+#   alloc_key_to_missing_lru_entry, snapshot_state_bad, subvol_state_bad
+#
+# So the upgrade repairs them without naming a single one in dmesg -- the
+# mount log says only "Fixed errors, running fsck a second time". Nor does
+# the superblock "errors" field help: that lists errors the filesystem still
+# carries, and is empty on a healthy fs. This test therefore counts the
+# repairs two independent ways and cross-checks them:
+#
+#   1. the has_inode_opts / has_access_acl / has_default_acl bits in the
+#      inodes btree, dumped with `bcachefs list` before and after (see
+#      inode_flag_counts below), and
+#   2. the "errors this recovery:" summary of a full 1.39 fsck run on the
+#      un-upgraded image with -o version_upgrade=none, which is not silenced
+#      and names each error with a count.
+#
+# check_inodes is the dangerous one: it rewrites every inode whose
+# has_inode_opts / has_access_acl / has_default_acl flag is wrong. A rewrite
+# that dropped bi_data_replicas would silently destroy the production
+# overrides. That rewrite path is the thing this test is built to exercise.
+#
+# TWO STAGES, TWO KERNELS, ONE IMAGE
+# ----------------------------------
+# ktest boots exactly one kernel per invocation, so this runs as two separate
+# invocations sharing a disk image:
+#
+#   stage 1  test_populate_138  -- run against a kernel whose
+#            bcachefs_metadata_version_current == 1.38 (upstream
+#            ca944a61e079 or equivalent). Formats, populates, sets per-inode
+#            and per-directory options plus POSIX ACLs, records a manifest
+#            INSIDE the filesystem, and exports the raw device to
+#            $ktest_out/upgrade-138/fs-1.38.img.
+#
+#   stage 2  test_upgrade_139   -- run against a kernel whose current version
+#            is 1.39, with ktest_138_image pointing at that exported image.
+#            Mounts it (version_upgrade defaults to `compatible`, which is
+#            what makes the upgrade run), then asserts.
+#
+# Stage 1 MUST be run on a 1.38 kernel and not merely formatted at 1.38 by a
+# 1.39 kernel. bch2_inode_pack() (fs/fs/inode.c) recomputes
+# BCH_INODE_has_inode_opts on *every* pack, unconditionally and independent of
+# the on-disk version -- so a 1.39 kernel writing inodes into a 1.38-format
+# filesystem already sets the flag correctly, check_inodes finds nothing to
+# fix, no inode is ever rewritten, and the test proves nothing about the
+# repair path. Only a kernel that predates the flag (<= 1.38) leaves the bit
+# clear on disk. The stage-2 assertions therefore include a check that the
+# repair actually fired; if it did not, the run is reported as NOT having
+# exercised the interesting path rather than as a pass.
+#
+# USAGE
+#   # stage 1, against a 1.38 kernel tree:
+#   build-test-kernel run -k <1.38-tree> -o <out1> \
+#       tests/fs/bcachefs/version-upgrade-138-to-139.ktest populate_138
+#
+#   # stage 2, against a 1.39 kernel tree:
+#   ktest_138_image=<out1>/upgrade-138/fs-1.38.img \
+#   build-test-kernel run -k <1.39-tree> -o <out2> \
+#       tests/fs/bcachefs/version-upgrade-138-to-139.ktest upgrade_139
+#
+# The image is attached with qemu snapshot=on, so stage 2 never modifies the
+# host copy and can be re-run as many times as needed.
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+config-mem 2G
+config-timeout 1800
+
+# Stage 2 consumes an image built by stage 1; stage 1 needs a blank scratch
+# device. Both land on /dev/vdb (images are attached before scratch devs, and
+# only one of the two is ever declared).
+if [[ -n ${ktest_138_image:-} ]]; then
+    config-image	"$ktest_138_image"
+else
+    config-scratch-devs	1G
+fi
+
+upgrade_dev=/dev/vdb
+
+# Manifest lives inside the test filesystem so it travels with the image
+# across the two invocations. Excluded from its own checksum list.
+manifest_in_fs=/manifest.tsv
+
+nr_files=400		# total regular files created under /mnt/data
+nr_repl1=200		# of those, how many get an explicit data_replicas=1
+nr_repl2=8		# ... and how many get data_replicas=2
+nr_acl=12		# how many get a POSIX access ACL
+
+# "Version:  need_discard_by_journal_seq (1.38)" -> "1.38". Assert on the
+# numeric only: version *names* differ between forks, numbers do not.
+sb_version_number()
+{
+    bcachefs show-super "$1" 2>/dev/null |
+	grep --max-count=1 '^Version:' |
+	sed --quiet 's/^Version:.*(\([0-9]*\.[0-9]*\))[[:space:]]*$/\1/p'
+}
+
+sb_version_line()
+{
+    bcachefs show-super "$1" 2>/dev/null |
+	grep --extended-regexp '^(Version|Oldest version on disk|Version upgrade complete):' || true
+}
+
+# Explicit per-inode value of a bcachefs IO option, or the empty string when
+# the inode carries no override. `bcachefs set-file-option` is a setxattr on
+# bcachefs.<opt>; the same xattr read back reports only explicitly-set
+# options (the bcachefs_effective.* namespace is the one that reports
+# inherited/default values, and is deliberately NOT what we check here).
+file_opt()
+{
+    getfattr --only-values --absolute-names --name="bcachefs.$2" "$1" 2>/dev/null || true
+}
+
+# The superblock "errors" field lists errors the filesystem still carries; it
+# is NOT a repair tally, and it is empty on a healthy fs. Printed for the
+# record only -- do not read repair counts out of it.
+sb_error_counts()
+{
+    bcachefs show-super --field-only errors "$1" 2>/dev/null || true
+}
+
+# Direct measurement of the three inode flags the 1.39 upgrade sets, straight
+# out of the inodes btree with `bcachefs list` (pure userspace, offline, no
+# kernel involvement). This is the only reliable count available: the upgrade
+# entry feeds its errors to errors_silent, so nothing reaches dmesg, and the
+# superblock error field is not a counter either. Bit numbers from
+# fs/fs/inode_format.h BCH_INODE_FLAGS(): has_inode_opts 12 (0x1000),
+# has_access_acl 13 (0x2000), has_default_acl 14 (0x4000).
+#
+# Prints: <inodes with bi_data_replicas != 0> <has_inode_opts> <has_access_acl> <has_default_acl>
+inode_flag_counts()
+{
+    local dev=$1 dump=$2
+
+    bcachefs list --btree inodes "$dev" > "$dump" 2>/dev/null || true
+    # NB: match /flags=/, NOT /flags=\(/. bcachefs prints the hex bare when no
+    # named flag is set ("flags=(19300000)") but prefixes the names when any
+    # is ("flags=has_inode_opts(19301000)") -- so anchoring on the paren
+    # matches exactly the inodes we are trying to count and reports 0.
+    gawk '
+	/flags=/ {
+	    h = $0; sub(/.*\(/, "", h); sub(/\).*/, "", h)
+	    v = strtonum("0x" h)
+	    if (and(v,  4096)) opts++
+	    if (and(v,  8192)) aacl++
+	    if (and(v, 16384)) dacl++
+	}
+	/bi_data_replicas=[1-9]/ { repl++ }
+	END { print repl+0, opts+0, aacl+0, dacl+0 }' "$dump"
+}
+
+# ---------------------------------------------------------------------------
+# stage 1: build a 1.38 filesystem with per-inode options, on a 1.38 kernel
+# ---------------------------------------------------------------------------
+test_populate_138()
+{
+    set_watchdog 900
+
+    if [[ -n ${ktest_138_image:-} ]]; then
+	echo "FAIL: ktest_138_image is set, so /dev/vdb is a pre-built image"
+	echo "      rather than a blank scratch device. Unset it for stage 1."
+	return 1
+    fi
+
+    local out=${ktest_out:-/ktest-out}/upgrade-138
+    mkdir --parents "$out"
+
+    run_quiet "" bcachefs format --force --version=1.38 "$upgrade_dev"
+
+    mount -t bcachefs "$upgrade_dev" /mnt
+
+    # PRECONDITION 1: the kernel that just initialised this filesystem must
+    # itself be a 1.38 kernel. A 1.39 kernel would have upgraded on mount
+    # (version_upgrade defaults to `compatible`), and -- more importantly --
+    # would already be setting BCH_INODE_has_inode_opts on every inode it
+    # packs, leaving stage 2's check_inodes with nothing to repair.
+    local v=$(sb_version_number "$upgrade_dev")
+    echo "on-disk version after first mount: $v"
+    sb_version_line "$upgrade_dev"
+    if [[ $v != 1.38 ]]; then
+	echo "FAIL: precondition -- expected on-disk version 1.38 after the"
+	echo "      first mount, got '$v'. This stage MUST run against a"
+	echo "      kernel whose bcachefs_metadata_version_current is 1.38;"
+	echo "      anything newer auto-upgrades on mount and makes the whole"
+	echo "      two-stage test meaningless. Check which -k tree was used."
+	umount /mnt
+	return 1
+    fi
+
+    mkdir --parents /mnt/data /mnt/diropt /mnt/acldir
+
+    local i path
+    echo "creating $nr_files files"
+    for ((i = 0; i < nr_files; i++)); do
+	path=$(printf '/mnt/data/f%04d' $i)
+	# Distinct, non-trivial content per file; 16K each.
+	dd if=/dev/urandom of="$path" bs=4k count=4 status=none
+    done
+    sync
+
+    # Per-inode overrides. data_replicas=1 matches production's dominant case
+    # (an explicit override that happens to equal the fs default -- still a
+    # nonzero bi_data_replicas, still lost if the upgrade drops it).
+    echo "setting data_replicas=1 on $nr_repl1 files"
+    for ((i = 0; i < nr_repl1; i++)); do
+	path=$(printf '/mnt/data/f%04d' $i)
+	bcachefs set-file-option --data_replicas=1 "$path"
+    done
+
+    # A handful at 2, mirroring production's 3 such inodes. This is a
+    # single-device filesystem, so the second replica can never be allocated;
+    # that is fine, the point is the inode field, not the data placement.
+    echo "setting data_replicas=2 on $nr_repl2 files"
+    for ((i = nr_repl1; i < nr_repl1 + nr_repl2; i++)); do
+	path=$(printf '/mnt/data/f%04d' $i)
+	bcachefs set-file-option --data_replicas=2 "$path"
+    done
+
+    # Per-DIRECTORY option, so inheritance is exercised: files created under
+    # it afterwards inherit, and set-file-option propagates to the ones
+    # already there (propagate_recurse in src/commands/attr.rs).
+    echo "setting a per-directory option and creating inheriting children"
+    for ((i = 0; i < 10; i++)); do
+	dd if=/dev/urandom of=$(printf '/mnt/diropt/pre%02d' $i) bs=4k count=2 status=none
+    done
+    bcachefs set-file-option --data_replicas=1 --background_compression=zstd /mnt/diropt
+    for ((i = 0; i < 10; i++)); do
+	dd if=/dev/urandom of=$(printf '/mnt/diropt/post%02d' $i) bs=4k count=2 status=none
+    done
+    sync
+
+    # POSIX ACLs: an access ACL on some files (drives has_access_acl) and a
+    # default ACL on a directory (drives has_default_acl).
+    echo "setting POSIX ACLs on $nr_acl files and a default ACL on /mnt/acldir"
+    for ((i = 0; i < nr_acl; i++)); do
+	path=$(printf '/mnt/data/f%04d' $i)
+	setfacl --modify=u:1000:rw "$path"
+    done
+    setfacl --default --modify=u:1000:rwx /mnt/acldir
+    for ((i = 0; i < 5; i++)); do
+	dd if=/dev/urandom of=$(printf '/mnt/acldir/a%02d' $i) bs=4k count=2 status=none
+    done
+    sync
+
+    # Record path <TAB> explicit data_replicas (empty = none) <TAB> sha256,
+    # for every regular file. Written into the filesystem itself so it
+    # survives into stage 2's VM.
+    echo "recording manifest"
+    local tmp=/tmp/manifest.tsv
+    : > "$tmp"
+    local f sum repl
+    while IFS= read -r f; do
+	sum=$(sha256sum "$f")
+	sum=${sum%% *}
+	repl=$(file_opt "$f" data_replicas)
+	printf '%s\t%s\t%s\n' "${f#/mnt}" "$repl" "$sum" >> "$tmp"
+    done < <(find /mnt -type f -not -name "$(basename $manifest_in_fs)" | sort)
+
+    local nr_recorded=$(wc --lines < "$tmp")
+    local nr_with_opt=$(awk --field-separator='\t' '$2 != "" { n++ } END { print n + 0 }' "$tmp")
+    echo "manifest: $nr_recorded files, $nr_with_opt with an explicit data_replicas"
+
+    # PRECONDITION 2: the overrides must actually be readable back, or stage
+    # 2 has nothing to compare against and would trivially "pass".
+    if (( nr_with_opt < nr_repl1 + nr_repl2 )); then
+	echo "FAIL: precondition -- only $nr_with_opt files carry an explicit"
+	echo "      data_replicas, expected at least $((nr_repl1 + nr_repl2))."
+	echo "      Either set-file-option did not take, or getfattr is not"
+	echo "      reporting bcachefs.data_replicas. Sample:"
+	head --lines=5 "$tmp"
+	umount /mnt
+	return 1
+    fi
+
+    cp "$tmp" "/mnt$manifest_in_fs"
+    cp "$tmp" "$out/manifest.tsv"
+    sync
+
+    umount /mnt
+
+    v=$(sb_version_number "$upgrade_dev")
+    echo "on-disk version after clean unmount: $v"
+    if [[ $v != 1.38 ]]; then
+	echo "FAIL: on-disk version drifted to '$v' during stage 1"
+	return 1
+    fi
+
+    echo "=== stage 1 superblock ==="
+    sb_version_line "$upgrade_dev"
+    echo "=== stage 1 error counters ==="
+    sb_error_counts "$upgrade_dev"
+
+    # CONTROL: the same offline fsck stage 2 runs after the upgrade, run here
+    # before it. Without this baseline a dirty fsck in stage 2 cannot be
+    # attributed to the upgrade rather than to how this filesystem was built.
+    # Reported, not fatal -- a dirty baseline is information stage 2 needs,
+    # not a reason to withhold the image.
+    echo "=== stage 1 control: offline fsck of the 1.38 filesystem ==="
+    local fsck_rc=0
+    bcachefs fsck -ny "$upgrade_dev" || fsck_rc=$?
+    echo "pre-upgrade fsck -ny exit status: $fsck_rc"
+
+    # Export the raw device for stage 2. Sparse so the host copy stays small.
+    echo "exporting $upgrade_dev to $out/fs-1.38.img"
+    dd if="$upgrade_dev" of="$out/fs-1.38.img" bs=1M conv=sparse status=none
+    sync
+    ls --size --human-readable "$out/fs-1.38.img"
+
+    echo "STAGE 1 COMPLETE: 1.38 image at <ktest_out>/upgrade-138/fs-1.38.img"
+    echo "Run stage 2 with ktest_138_image pointing at it."
+}
+
+# ---------------------------------------------------------------------------
+# stage 2: mount that image on a 1.39 kernel and check what survived
+# ---------------------------------------------------------------------------
+test_upgrade_139()
+{
+    set_watchdog 900
+
+    if [[ -z ${ktest_138_image:-} ]]; then
+	echo "FAIL: ktest_138_image is not set, so /dev/vdb is a blank scratch"
+	echo "      device rather than the 1.38 filesystem stage 1 built."
+	echo "      This stage cannot synthesise its own input: the whole"
+	echo "      point is inodes written by a kernel that predates"
+	echo "      BCH_INODE_has_inode_opts. Run stage 1 first."
+	return 1
+    fi
+
+    local out=${ktest_out:-/ktest-out}/upgrade-139
+    mkdir --parents "$out"
+
+    echo "=== before mount ==="
+    sb_version_line "$upgrade_dev"
+    local before=$(sb_version_number "$upgrade_dev")
+    echo "on-disk version before mount: $before"
+
+    if [[ $before != 1.38 ]]; then
+	echo "FAIL: precondition -- the supplied image is at version"
+	echo "      '$before', not 1.38. ktest_138_image points at the wrong"
+	echo "      file, or stage 1 ran against the wrong kernel."
+	return 1
+    fi
+
+    echo "=== superblock errors field before the upgrade (not a repair count) ==="
+    sb_error_counts "$upgrade_dev"
+
+    # Baseline straight out of the inodes btree, offline.
+    local repl_before opts_before aacl_before dacl_before
+    read -r repl_before opts_before aacl_before dacl_before \
+	< <(inode_flag_counts "$upgrade_dev" "$out/inodes-before.txt")
+    echo "=== inodes btree before the upgrade ==="
+    echo "  inodes with bi_data_replicas != 0: $repl_before"
+    echo "  has_inode_opts set:                $opts_before"
+    echo "  has_access_acl set:                $aacl_before"
+    echo "  has_default_acl set:               $dacl_before"
+
+    # CONTROL for the post-upgrade fsck below. Stage 1's control fsck used
+    # the 1.38 checker on a 1.38 filesystem, so a dirty fsck after the
+    # upgrade has two possible causes: the upgrade damaged something, or
+    # 1.39's fsck simply checks more than 1.38's did. This run holds the
+    # checker fixed at 1.39 and varies only whether the upgrade happened.
+    #
+    # -o version_upgrade=none is what makes it a control: fsck runs the same
+    # recovery code as mount, and would otherwise perform the 1.38 -> 1.39
+    # upgrade in memory before checking anything, measuring the post-upgrade
+    # state all over again. -n keeps it read-only, so the image is untouched.
+    #
+    # NB: this runs in-kernel, and -K/--no-kernel CANNOT change that here.
+    # bcachefs-test-libs.sh exports BCACHEFS_KERNEL_ONLY=1 for every bcachefs
+    # ktest, and src/commands/fsck.rs checks that env var *before* cli.kernel
+    # / cli.no_kernel, so it wins over the flag outright. Watch for the
+    # "Running in-kernel offline fsck" line rather than assuming.
+    echo "=== control: 1.39 fsck of the 1.38 filesystem, upgrade suppressed ==="
+    local pre_fsck_rc=0
+    bcachefs fsck -ny -o version_upgrade=none "$upgrade_dev" || pre_fsck_rc=$?
+    echo "1.39-fsck-on-un-upgraded-1.38 exit status: $pre_fsck_rc"
+
+    # Clear dmesg so the captured log is exactly the upgrade.
+    dmesg -C
+
+    mount -t bcachefs "$upgrade_dev" /mnt
+
+    dmesg > "$out/upgrade-dmesg.txt"
+    echo "=== upgrade dmesg (full copy at <ktest_out>/upgrade-139/upgrade-dmesg.txt) ==="
+    cat "$out/upgrade-dmesg.txt"
+
+    # ---- assertion 1: the filesystem is now at 1.39 --------------------
+    local after=$(sb_version_number "$upgrade_dev")
+    echo "on-disk version after mount: $after"
+    sb_version_line "$upgrade_dev"
+
+    local failed=0
+    if [[ $after != 1.39 ]]; then
+	echo "FAIL: expected on-disk version 1.39 after mounting with a"
+	echo "      1.39-capable kernel, got '$after'."
+	failed=1
+    fi
+
+    # ---- assertions 2-4: every recorded file, option and checksum ------
+    if [[ ! -f "/mnt$manifest_in_fs" ]]; then
+	echo "FAIL: no manifest at /mnt$manifest_in_fs -- the image was not"
+	echo "      built by this test's stage 1."
+	umount /mnt
+	return 1
+    fi
+
+    local nr=0 opt_ok=0 opt_bad=0 opt_lost=0 opt_gained=0 sum_ok=0 sum_bad=0
+    local line rest path want_repl want_sum got_repl got_sum
+    # NB: split the TSV by hand rather than `IFS=$'\t' read -r a b c`. Tab is
+    # an IFS *whitespace* character, so read collapses runs of tabs into one
+    # delimiter -- a file with no override (empty middle field) would have its
+    # checksum silently read as its data_replicas. That misparse made 217 of
+    # 425 files report bogus mismatches on the first run of this test.
+    while IFS= read -r line; do
+	path=${line%%$'\t'*}
+	rest=${line#*$'\t'}
+	want_repl=${rest%%$'\t'*}
+	want_sum=${rest#*$'\t'}
+	nr=$((nr + 1))
+	got_repl=$(file_opt "/mnt$path" data_replicas)
+	got_sum=$(sha256sum "/mnt$path")
+	got_sum=${got_sum%% *}
+
+	if [[ $got_repl = "$want_repl" ]]; then
+	    opt_ok=$((opt_ok + 1))
+	else
+	    opt_bad=$((opt_bad + 1))
+	    if [[ -n $want_repl && -z $got_repl ]]; then
+		opt_lost=$((opt_lost + 1))
+	    elif [[ -z $want_repl && -n $got_repl ]]; then
+		opt_gained=$((opt_gained + 1))
+	    fi
+	    if (( opt_bad <= 10 )); then
+		echo "  option mismatch: $path want='$want_repl' got='$got_repl'"
+	    fi
+	fi
+
+	if [[ $got_sum = "$want_sum" ]]; then
+	    sum_ok=$((sum_ok + 1))
+	else
+	    sum_bad=$((sum_bad + 1))
+	    if (( sum_bad <= 10 )); then
+		echo "  checksum mismatch: $path"
+	    fi
+	fi
+    done < "/mnt$manifest_in_fs"
+
+    local want_with_opt=$(awk --field-separator='\t' '$2 != "" { n++ } END { print n + 0 }' "/mnt$manifest_in_fs")
+
+    echo "=== manifest verification ==="
+    echo "files checked:                       $nr"
+    echo "files that had a data_replicas override: $want_with_opt"
+    echo "data_replicas matches:               $opt_ok"
+    echo "data_replicas mismatches:            $opt_bad (lost: $opt_lost, gained: $opt_gained)"
+    echo "content checksum matches:            $sum_ok"
+    echo "content checksum mismatches:         $sum_bad"
+
+    (( opt_bad )) && failed=1
+    (( sum_bad )) && failed=1
+    if (( nr == 0 )); then
+	echo "FAIL: manifest was empty"
+	failed=1
+    fi
+
+    umount /mnt
+
+    # ---- step 6: what the upgrade actually repaired --------------------
+    echo "=== superblock errors field after the upgrade (not a repair count) ==="
+    sb_error_counts "$upgrade_dev"
+
+    local repl_after opts_after aacl_after dacl_after
+    read -r repl_after opts_after aacl_after dacl_after \
+	< <(inode_flag_counts "$upgrade_dev" "$out/inodes-after.txt")
+
+    echo "=== inodes btree after the upgrade (before -> after) ==="
+    printf '  %-34s %6s -> %6s\n' "inodes with bi_data_replicas != 0" "$repl_before" "$repl_after"
+    printf '  %-34s %6s -> %6s\n' "has_inode_opts set"    "$opts_before" "$opts_after"
+    printf '  %-34s %6s -> %6s\n' "has_access_acl set"    "$aacl_before" "$aacl_after"
+    printf '  %-34s %6s -> %6s\n' "has_default_acl set"   "$dacl_before" "$dacl_after"
+
+    echo "=== fsck errors the upgrade repaired ==="
+    echo "  inode_has_inode_opts_flag_wrong    $((opts_after - opts_before))"
+    echo "  inode_has_access_acl_flag_wrong    $((aacl_after - aacl_before))"
+    echo "  inode_has_default_acl_flag_wrong   $((dacl_after - dacl_before))"
+    echo "  (lru_entry_bad, alloc_key_to_missing_lru_entry, snapshot_state_bad,"
+    echo "   subvol_state_bad: not separately countable -- see dmesg section below)"
+
+    echo "=== dmesg mentions of the tolerated errors (expected: none --"
+    echo "    the upgrade entry feeds them to errors_silent) ==="
+    grep --extended-regexp \
+	'inode_has_inode_opts_flag_wrong|inode_has_access_acl_flag_wrong|inode_has_default_acl_flag_wrong|lru_entry_bad|alloc_key_to_missing_lru_entry|snapshot_state_bad|subvol_state_bad|has_inode_opts flag wrong|has_access_acl|has_default_acl' \
+	"$out/upgrade-dmesg.txt" || echo "  (none)"
+
+    echo "=== did the upgrade fix anything at all? ==="
+    grep --extended-regexp 'Fixed errors, running fsck a second time' \
+	"$out/upgrade-dmesg.txt" || echo "  (no -- the upgrade found nothing to repair)"
+
+    echo "=== recovery passes the upgrade ran ==="
+    grep --extended-regexp 'running recovery pass|check_inodes|check_xattrs|check_lrus|check_alloc_to_lru_refs|check_snapshots|check_subvols|delete_dead_snapshots|version upgrade|upgrading' \
+	"$out/upgrade-dmesg.txt" || echo "  (none found in dmesg)"
+
+    # ---- assertion 5: no inode lost its options --------------------------
+    # The btree-level check, stronger than the manifest one above: it counts
+    # every inode carrying a nonzero bi_data_replicas, including directories
+    # and inherited children that the bcachefs.<opt> xattr does not report.
+    if (( repl_after != repl_before )); then
+	echo "FAIL: the number of inodes carrying bi_data_replicas changed"
+	echo "      across the upgrade: $repl_before -> $repl_after."
+	failed=1
+    fi
+
+    # ---- did the interesting path actually run? ------------------------
+    local repaired=$((opts_after - opts_before))
+    if (( repaired <= 0 )); then
+	echo "WARNING: check_inodes set ZERO has_inode_opts flags, so no inode"
+	echo "         carrying an option was ever rewritten. The"
+	echo "         option-preservation result above is therefore WEAK: it"
+	echo "         shows the upgrade did not touch the inodes, not that a"
+	echo "         rewrite preserves options. This happens when stage 1"
+	echo "         ran on a kernel that already knows the flag (>= 1.39)."
+	echo "         Re-run stage 1 against a genuine 1.38 kernel."
+	failed=1
+    fi
+
+    # Offline fsck, reported rather than aborting: the option/checksum
+    # numbers above are the point of this test and must be printed even when
+    # fsck is unhappy. Stage 1 runs the same check on the same filesystem
+    # *before* the upgrade, so a nonzero exit here is only attributable to the
+    # upgrade if stage 1's control run was clean -- compare the two.
+    echo "=== post-upgrade offline fsck ==="
+    local fsck_rc=0
+    bcachefs fsck -ny "$upgrade_dev" || fsck_rc=$?
+    echo "post-upgrade fsck -ny exit status: $fsck_rc"
+    echo "  (control, same 1.39 fsck on the un-upgraded 1.38 image: $pre_fsck_rc)"
+    if (( fsck_rc != 0 && pre_fsck_rc == 0 )); then
+	echo "FAIL: fsck -ny is clean on the 1.38 image but not after the"
+	echo "      upgrade (exit $fsck_rc). The upgrade introduced this."
+	failed=1
+    elif (( fsck_rc != 0 )); then
+	echo "NOTE: fsck -ny is dirty after the upgrade (exit $fsck_rc), but it"
+	echo "      is equally dirty on the 1.38 image when checked by the same"
+	echo "      1.39 fsck (exit $pre_fsck_rc). That is a pre-existing"
+	echo "      condition the newer checker reports, not upgrade damage."
+    fi
+
+    check_bcachefs_leaks
+    check_bcachefs_device_errors "$upgrade_dev"
+
+    if (( failed )); then
+	echo "FAIL: version upgrade 1.38 -> 1.39 did not preserve everything"
+	return 1
+    fi
+
+    echo "PASS: on-disk version 1.39, $opt_ok/$nr per-inode options intact," \
+	 "$sum_ok/$nr checksums intact"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/writeback_pressure.ktest
+++ b/tests/fs/bcachefs/writeback_pressure.ktest
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Dirty-writeback under memory exhaustion — the no-swap sibling of
+# swapfile_deadlock.ktest.  No swap is configured, so when the eater
+# exhausts memory the ONLY way reclaim can make progress is writing
+# back dirty bcachefs page cache — while the bcachefs write path itself
+# needs memory to do that.  Same recursion class as the swap deadlock
+# (allocation → reclaim → fs writeback → allocation), reached without
+# any swap support in the fs.
+#
+# The writer keeps a large dirty working set on the fs; the eater denies
+# reclaim everything else (unkillable, crushes the file LRU).  A kernel
+# whose writeback path allocates carelessly under pressure deadlocks or
+# OOM-panics ("System is deadlocked on memory"); a correct one grinds
+# through.  hung_task_panic makes a wedge fail loudly within ~30s; run
+# through lib/supervisor for the livelock case.
+#
+#   WRITEBACK_TEST_MEM=512M      VM memory
+#   WRITEBACK_TEST_CPUS=2        vCPUs
+#   WRITEBACK_TEST_ROUNDS=3      pressure rounds per boot
+#   WRITEBACK_TEST_DURATION=120  seconds per round
+#   WRITEBACK_TEST_DIRTY_MB=256  writer working set
+#   WRITEBACK_TEST_NO_KBUILD=1   reuse a prebuilt kernel
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/memory-pressure-libs.sh
+
+require-kernel-config DETECT_HUNG_TASK
+
+config-mem ${WRITEBACK_TEST_MEM:-512M}
+config-cpus ${WRITEBACK_TEST_CPUS:-2}
+config-scratch-devs 2G
+config-timeout 900
+
+[[ -n ${WRITEBACK_TEST_NO_KBUILD:-} ]] && config-no-kbuild
+
+test_writeback_reclaim_pressure()
+{
+    set_watchdog 700
+
+    local dev=${ktest_scratch_dev[0]}
+    echo "=== $(grep MemTotal /proc/meminfo), $(nproc) cpus, no swap ==="
+
+    run_quiet "" bcachefs format -f "$dev"
+    mount -t bcachefs "$dev" /mnt
+
+    build_eater
+
+    # No swap: the default overcommit heuristic would refuse an mmap
+    # bigger than RAM outright.  The eater must be allowed to overcommit
+    # so the pressure comes from page touches, not the commit limit.
+    echo 1 > /proc/sys/vm/overcommit_memory
+
+    # Let dirty pages pile up: writeback should be driven by reclaim and
+    # the fs, not by the dirty throttle kicking in early.
+    echo 40 > /proc/sys/vm/dirty_ratio
+    echo 20 > /proc/sys/vm/dirty_background_ratio
+
+    hung_task_panic_on
+
+    # The writer: continuously rewrite a working set of 8M files,
+    # fsync-free, keeping a steady supply of dirty bcachefs pages that
+    # only writeback can reclaim.
+    local dirty_mb=${WRITEBACK_TEST_DIRTY_MB:-256}
+    local nfiles=$((dirty_mb / 8))
+    mkdir -p /mnt/dirty
+    (
+	trap - ERR
+	set +e
+	while true; do
+	    for (( i = 0; i < nfiles; i++ )); do
+		dd if=/dev/zero of=/mnt/dirty/f$i bs=1M count=8 2>/dev/null
+	    done
+	done
+    ) &
+    local writer_pid=$!
+
+    start_mem_telemetry
+
+    local eat_mb=${WRITEBACK_TEST_EAT_MB:-$(eater_squeeze_mb)}
+    local duration=${WRITEBACK_TEST_DURATION:-120}
+    local rounds=${WRITEBACK_TEST_ROUNDS:-3}
+    local round
+    for (( round = 1; round <= rounds; round++ )); do
+	echo "=== round $round/$rounds: eater ${eat_mb}M for ${duration}s ==="
+	/tmp/eater "$eat_mb" "$duration" || {
+	    stop_mem_telemetry
+	    echo "eater failed"
+	    return 1
+	}
+	sleep 5
+    done
+
+    stop_mem_telemetry
+    kill $writer_pid 2>/dev/null || true
+    wait $writer_pid 2>/dev/null || true
+
+    hung_task_panic_off
+
+    grep -E "Dirty|Writeback:" /proc/meminfo
+
+    sync
+    rm -rf /mnt/dirty
+    umount /mnt
+
+    mount -t bcachefs -o fsck,ro "$dev" /mnt
+    umount /mnt
+
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"

--- a/tests/prelude.sh
+++ b/tests/prelude.sh
@@ -50,6 +50,7 @@ ktest_images=()
 ktest_rw_images=()
 ktest_scratch_dev=()
 ktest_scratch_dev_sizes=()
+ktest_scratch_slowdevs=()
 ktest_scratch_dev_count=0
 ktest_make_install=()
 ktest_kernel_config_require=()
@@ -199,6 +200,25 @@ config-scratch-devs()
     ktest_scratch_dev_sizes+=("$1")
 }
 
+# Like config-scratch-devs, but the device is rate limited by qemu (300 iops,
+# 100MB/s) -- see ktest_scratch_slowdevs in lib/libktest.sh. Use this to model a
+# mixed fast/slow pool, e.g. an SSD tier plus rotational disks that are also
+# allowed to carry the journal: journal writes then take long enough for
+# unwritten entries to accumulate, which uniformly fast virtio disks never do.
+#
+# NOTE: libktest attaches every normal scratch dev before any slow one, so all
+# config-scratch-devs lines must come BEFORE the config-scratch-slowdevs lines
+# or the ktest_scratch_dev names will not line up with the attach order.
+config-scratch-slowdevs()
+{
+    local chars=( {b..z} )
+
+    ktest_scratch_dev+=("/dev/${ktest_dev_prefix}${chars[$ktest_scratch_dev_count]}")
+    ktest_scratch_dev_count=$((ktest_scratch_dev_count + 1))
+
+    ktest_scratch_slowdevs+=("$1")
+}
+
 config-pmem-devs()
 {
     ktest_pmem_devs+=("$1")
@@ -341,6 +361,15 @@ run_test()
 
     if ktest_in_vm; then
 	echo "|/bin/cp --sparse=always /dev/stdin $test_output/core.%e.PID%p.SIG%s.TIME%t" > /proc/sys/kernel/core_pattern
+    fi
+
+    # Optional per-test hooks (e.g. bcachefs's livelock watchdog).  The EXIT
+    # trap ensures teardown runs even when $test_fn fails under set -e.
+    if [[ $(type -t ktest_test_teardown) = function ]]; then
+	trap ktest_test_teardown EXIT
+    fi
+    if [[ $(type -t ktest_test_setup) = function ]]; then
+	ktest_test_setup "$test_name"
     fi
 
     $test_fn


### PR DESCRIPTION
This is the test suite behind the swap-on-bcachefs ablation posted on
koverstreet/bcachefs-tools#646: four memory-pressure tests plus a shared
helper library, and a supervisor fix they depend on. The branch is rebased
onto current master.

The supervisor fix comes first because everything else needs it. On timeout,
lib/supervisor injected a marker into the guest console and waited for the
guest to echo it back — which never happens when the guest is wedged, so a
hung guest hung the supervisor with it. It now escalates instead: marker,
30-second grace, SIGTERM, SIGKILL, over a non-blocking console fd, and the
panic/"BUG:" post-mortem path gets the same treatment. A spin-livelocked
guest becomes a fast, loud failure rather than an indefinite hang, which
matters for CI generally, not just for these tests.

swapfile_deadlock.ktest is the discriminator from the #646 thread: on a
build without reclaim armour it fails in about three minutes with the
workqueue-MAYDAY/six_lock signature, and on an armoured build it passes
three pressure rounds at 99% swap utilisation plus a swapoff-under-pressure
phase with a clean fsck. The pressure profile is calibrated and every
load-bearing choice (unkillable eater sizing, the sacrificial balloon, 2
vCPUs, swapfile sized to keep commit near 80% of RAM+swap) is documented in
the file, since getting any of them wrong either hides the deadlock or
false-positives correct kernels.

writeback_pressure.ktest and fsync_pressure.ktest are the no-swap siblings —
dirty page cache and journal reclaim respectively as reclaim's only outlet.
Both pass on current bcachefs master, which is the evidence that the hazard
family arrives with swap support rather than being pre-existing.
memory-pressure-libs.sh holds the shared eater/balloon/telemetry machinery
and documents its traps (the prelude's inherited ERR trap killing respawn
loops, overcommit settings, per-15s swap telemetry so a pass can't hide
unmaterialised pressure).

reflink_recovery_panic.ktest is a crash-recovery regression guard from a
separate investigation: it creates dangling reflink_p keys with
kill_btree_node, then drives copygc/evacuate over them through
emergency-read-only recovery and a real sysrq-b crash-reboot recovery, with
optional profiles layering on background dedup and swap-under-memory-
pressure. All profiles currently pass; it exists to catch regressions on the
recovery path raced by copygc.

swapfile_deadlock and the swap profile of reflink_recovery_panic need a
kernel with swap-on-bcachefs support (the #646 series or equivalent); the
other tests run on current master.
