### PR TITLE
tests/bcachefs: test journal flush SRCU liveness

### DIFF
--- a/tests/fs/bcachefs/journal_flush_srcu_liveness.ktest
+++ b/tests/fs/bcachefs/journal_flush_srcu_liveness.ktest
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+
+# shellcheck source=tests/fs/bcachefs/bcachefs-test-libs.sh
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/bcachefs-test-libs.sh"
+
+require-kernel-config BCACHEFS_FS=y
+
+config-mem 4G
+config-timeout 900
+config-scratch-devs 2G
+config-scratch-devs 2G
+config-scratch-devs 2G
+
+devs()
+{
+    join_by : "${ktest_scratch_dev[@]}"
+}
+
+journal_srcu_trace_events()
+{
+    local t=/sys/kernel/tracing/events
+    local events=(
+	bcachefs:data_update_write
+	bcachefs:data_update_fail
+	bcachefs:journal_flush
+	bcachefs:journal_write
+	bcachefs:journal_reclaim_start
+	bcachefs:journal_reclaim_finish
+	bcachefs:journal_res_get_blocked
+	block:block_bio_queue
+	block:block_bio_complete
+    )
+
+    for event in "${events[@]}"; do
+	local path="${event%%:*}/${event#*:}"
+	if [[ -e $t/$path/enable ]]; then
+	    echo "$event"
+	fi
+    done
+}
+
+dump_journal_srcu_debug()
+{
+    findmnt /mnt || true
+    fuser -vm /mnt || true
+    bcachefs fs usage -h --all /mnt || true
+    cat /sys/fs/bcachefs/*/reconcile_status || true
+    cat /sys/fs/bcachefs/*/internal/copy_gc_wait || true
+    cat /sys/fs/bcachefs/*/internal/moving_ctxts || true
+    cat /sys/fs/bcachefs/*/journal_reclaim || true
+    cat /sys/fs/bcachefs/*/time_stats/journal_flush_write || true
+    cat /sys/fs/bcachefs/*/time_stats/journal_flush_seq || true
+    cat /sys/fs/bcachefs/*/time_stats/blocked_journal_low_on_space || true
+    cat /sys/fs/bcachefs/*/time_stats/blocked_journal_low_on_pin || true
+    cat /sys/fs/bcachefs/*/time_stats/blocked_journal_max_in_flight || true
+    cat /sys/kernel/debug/bcachefs/*/write_points || true
+    tail -n 1200 /sys/kernel/tracing/trace || true
+    dmesg | tail -n 300 || true
+}
+
+format_journal_srcu_fs()
+{
+    run_quiet "" bcachefs format -f			\
+	--block_size=4k					\
+	--bucket_size=256k				\
+	--replicas=1					\
+	--foreground_target=src				\
+	--background_target=src				\
+	--metadata_target=dst				\
+	--rotational=1 --label=src "${ktest_scratch_dev[0]}" \
+	--rotational=1 --label=dst "${ktest_scratch_dev[1]}" \
+	--rotational=1 --label=dst "${ktest_scratch_dev[2]}"
+}
+
+stress_journal_flush_srcu_path()
+{
+    echo 1000 > /sys/fs/bcachefs/*/options/journal_flush_delay
+    echo 256k > /sys/fs/bcachefs/*/options/move_bytes_in_flight
+    echo 4 > /sys/fs/bcachefs/*/options/move_ios_in_flight
+}
+
+seed_source_data()
+{
+    local size=${1:-$((384 * 1024 * 1024))}
+
+    dd if=/dev/zero of=/mnt/src-only-data bs=4M	\
+	count=$((size / (4 * 1024 * 1024)))	\
+	oflag=direct status=none
+    sync
+}
+
+start_dst_pressure()
+{
+    local log=$1
+
+    mkdir -p /mnt/dst-pressure
+    bcachefs set-file-option --foreground_target=dst /mnt/dst-pressure
+    dd if=/dev/zero of=/mnt/dst-pressure/hotfile bs=4M count=64 \
+	oflag=direct status=none
+    sync
+
+    setsid fio --eta=always			\
+	--exitall_on_error=1			\
+	--ioengine=libaio			\
+	--iodepth=64				\
+	--iodepth_batch=16			\
+	--direct=1				\
+	--numjobs=1				\
+	--time_based				\
+	--runtime=420				\
+	--name=dst-pressure			\
+	--rw=randwrite				\
+	--fsync=1				\
+	--bs=256k				\
+	--filesize=256M				\
+	--filename=/mnt/dst-pressure/hotfile	\
+	>"$log" 2>&1 &
+    echo $!
+}
+
+stop_dst_pressure()
+{
+    local pid=${1:-}
+
+    [[ -n $pid ]] || return 0
+
+    kill -- "-$pid" 2>/dev/null || true
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+}
+
+assert_no_srcu_journal_warnings()
+{
+    if dmesg | grep -E 'btree trans held srcu lock|bch2_journal_flush_seq stuck\?'; then
+	echo "journal/move pressure emitted SRCU or journal flush liveness warning" >&2
+	dump_journal_srcu_debug >&2
+	return 1
+    fi
+}
+
+teardown_journal_srcu_fs()
+{
+    if ! timeout 90 mount -o remount,ro /mnt; then
+	echo "remount,ro did not complete after journal/SRCU pressure" >&2
+	dump_journal_srcu_debug >&2
+	return 1
+    fi
+
+    if ! timeout 90 umount /mnt; then
+	echo "umount did not complete after journal/SRCU pressure" >&2
+	dump_journal_srcu_debug >&2
+	return 1
+    fi
+
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+
+    # This test deliberately creates journal/move pressure, so the generic
+    # slowpath counter ratio check can trip on expected transaction restarts
+    # before the SRCU/journal liveness oracle fires. Keep the hard health
+    # checks, but leave broad slowpath-counter tuning to throughput tests.
+    check_bcachefs_leaks
+    check_bcachefs_errors "${ktest_scratch_dev[0]}"
+    check_bcachefs_device_errors "${ktest_scratch_dev[0]}"
+}
+
+test_journal_flush_srcu_liveness()
+{
+    set_watchdog 900
+
+    local fioout="$ktest_out/journal-srcu-dst-pressure-fio-out"
+    local evacuate_log="$ktest_out/journal-srcu-evacuate-out"
+    local fiopid
+    local events
+    local ret=0
+
+    format_journal_srcu_fs
+    mount -t bcachefs "$(devs)" /mnt
+    seed_source_data
+    stress_journal_flush_srcu_path
+
+    events=$(journal_srcu_trace_events | xargs)
+    if [[ -n $events ]]; then
+	setup_tracing "$events"
+    fi
+
+    dmesg -C || true
+    : > /sys/kernel/tracing/trace || true
+
+    fiopid=$(start_dst_pressure "$fioout")
+    sleep 3
+
+    if ! timeout 360 bcachefs device evacuate "${ktest_scratch_dev[0]}" \
+	>"$evacuate_log" 2>&1; then
+	cat "$evacuate_log" || true
+	cat "$fioout" || true
+	echo "device evacuate did not complete under journal/SRCU pressure" >&2
+	ret=1
+    fi
+
+    stop_dst_pressure "$fiopid"
+
+    if ((ret)); then
+	dump_journal_srcu_debug >&2
+	timeout 30 umount /mnt || true
+	return 1
+    fi
+
+    sync
+    if ! assert_no_srcu_journal_warnings; then
+	ret=1
+    fi
+
+    if ! teardown_journal_srcu_fs; then
+	ret=1
+    fi
+
+    return "$ret"
+}
+
+main "$@"

--- a/tests/fs/bcachefs/journal_flush_srcu_liveness.ktest
+++ b/tests/fs/bcachefs/journal_flush_srcu_liveness.ktest
@@ -27,6 +27,12 @@ journal_srcu_trace_events()
 	bcachefs:journal_reclaim_start
 	bcachefs:journal_reclaim_finish
 	bcachefs:journal_res_get_blocked
+	bcachefs:reconcile_scan_device
+	bcachefs:reconcile_clear_scan
+	bcachefs:reconcile_btree
+	bcachefs:reconcile_data
+	bcachefs:reconcile_phys
+	bcachefs:reconcile_set_pending
 	block:block_bio_queue
 	block:block_bio_complete
     )
@@ -39,23 +45,71 @@ journal_srcu_trace_events()
     done
 }
 
+reconcile_status()
+{
+    local status
+
+    for status in /sys/fs/bcachefs/*/reconcile_status; do
+	[[ -r $status ]] || continue
+	cat "$status"
+    done
+}
+
 dump_journal_srcu_debug()
 {
-    findmnt /mnt || true
-    fuser -vm /mnt || true
-    bcachefs fs usage -h --all /mnt || true
-    cat /sys/fs/bcachefs/*/reconcile_status || true
-    cat /sys/fs/bcachefs/*/internal/copy_gc_wait || true
-    cat /sys/fs/bcachefs/*/internal/moving_ctxts || true
-    cat /sys/fs/bcachefs/*/journal_reclaim || true
-    cat /sys/fs/bcachefs/*/time_stats/journal_flush_write || true
-    cat /sys/fs/bcachefs/*/time_stats/journal_flush_seq || true
-    cat /sys/fs/bcachefs/*/time_stats/blocked_journal_low_on_space || true
-    cat /sys/fs/bcachefs/*/time_stats/blocked_journal_low_on_pin || true
-    cat /sys/fs/bcachefs/*/time_stats/blocked_journal_max_in_flight || true
-    cat /sys/kernel/debug/bcachefs/*/write_points || true
-    tail -n 1200 /sys/kernel/tracing/trace || true
-    dmesg | tail -n 300 || true
+    local dir=${1:-}
+    local out=/dev/stdout
+
+    if [[ -n $dir ]]; then
+	mkdir -p "$dir"
+	out="$dir/status"
+	reconcile_status >"$dir/reconcile-status" 2>&1 || true
+	tail -n 1200 /sys/kernel/tracing/trace >"$dir/trace" 2>&1 || true
+	dmesg >"$dir/dmesg" 2>&1 || true
+    fi
+
+    {
+	findmnt /mnt || true
+	fuser -vm /mnt || true
+	cat /proc/mounts || true
+	for dev in "${ktest_scratch_dev[@]}"; do
+	    echo "===== $dev queue/rotational ====="
+	    cat "/sys/block/$(basename "$dev")/queue/rotational" 2>&1 || true
+	done
+	ps -eLo pid,ppid,stat,wchan:32,comm,args || true
+	for stack in /proc/[0-9]*/stack; do
+	    pid=${stack#/proc/}
+	    pid=${pid%/stack}
+	    echo "===== /proc/$pid/stack ($(cat "/proc/$pid/comm" 2>/dev/null || true)) ====="
+	    cat "$stack" 2>&1 || true
+	done
+	echo w > /proc/sysrq-trigger 2>/dev/null || true
+	bcachefs fs usage -h --all /mnt || true
+	if [[ -n $dir ]]; then
+	    cat "$dir/reconcile-status" || true
+	else
+	    reconcile_status || true
+	fi
+	cat /sys/fs/bcachefs/*/internal/copy_gc_wait || true
+	cat /sys/fs/bcachefs/*/internal/moving_ctxts || true
+	cat /sys/fs/bcachefs/*/journal_reclaim || true
+	cat /sys/fs/bcachefs/*/time_stats/journal_flush_write || true
+	cat /sys/fs/bcachefs/*/time_stats/journal_flush_seq || true
+	cat /sys/fs/bcachefs/*/time_stats/blocked_journal_low_on_space || true
+	cat /sys/fs/bcachefs/*/time_stats/blocked_journal_low_on_pin || true
+	cat /sys/fs/bcachefs/*/time_stats/blocked_journal_max_in_flight || true
+	cat /sys/kernel/debug/bcachefs/*/write_points || true
+	for keys in /sys/kernel/debug/bcachefs/*/btrees/{extents,reflink}/keys; do
+	    echo "===== $keys ====="
+	    sed -n '1,320p' "$keys" 2>&1 || true
+	done
+	for keys in /sys/kernel/debug/bcachefs/*/btrees/{backpointers,reconcile_scan,reconcile_hipri,reconcile_work,reconcile_pending,reconcile_hipri_phys,reconcile_work_phys}/keys; do
+	    echo "===== $keys ====="
+	    sed -n '1,240p' "$keys" 2>&1 || true
+	done
+	tail -n 1200 /sys/kernel/tracing/trace || true
+	dmesg | tail -n 300 || true
+    } >"$out" 2>&1
 }
 
 format_journal_srcu_fs()
@@ -65,7 +119,7 @@ format_journal_srcu_fs()
 	--bucket_size=256k				\
 	--replicas=1					\
 	--foreground_target=src				\
-	--background_target=src				\
+	--background_target=dst				\
 	--metadata_target=dst				\
 	--rotational=1 --label=src "${ktest_scratch_dev[0]}" \
 	--rotational=1 --label=dst "${ktest_scratch_dev[1]}" \
@@ -138,6 +192,35 @@ assert_no_srcu_journal_warnings()
     fi
 }
 
+assert_source_device_evacuated()
+{
+    local usage="$ktest_out/journal-srcu-post-evacuate-usage"
+    local has_data
+
+    sync
+    bcachefs fs usage -h --all /mnt >"$usage" 2>&1
+    has_data=$(cat /sys/fs/bcachefs/*/dev-0/has_data 2>/dev/null || true)
+
+    if [[ -n $has_data && $has_data != "0" && $has_data != "none" ]]; then
+	cat "$usage" >&2 || true
+	echo "source device still reports has_data after evacuate: $has_data" >&2
+	dump_journal_srcu_debug >&2
+	return 1
+    fi
+
+    if ! awk '
+	/src \(device 0\):/ { in_src = 1; next }
+	in_src && /^$/ { in_src = 0 }
+	in_src && /^[[:space:]]*user:/ { saw_user = 1; exit ($2 == "0" ? 0 : 1) }
+	END { if (!saw_user) exit 1 }
+    ' "$usage"; then
+	cat "$usage" >&2 || true
+	echo "source device still has user data after evacuate" >&2
+	dump_journal_srcu_debug >&2
+	return 1
+    fi
+}
+
 teardown_journal_srcu_fs()
 {
     if ! timeout 90 mount -o remount,ro /mnt; then
@@ -167,9 +250,10 @@ test_journal_flush_srcu_liveness()
 {
     set_watchdog 900
 
-    local fioout="$ktest_out/journal-srcu-dst-pressure-fio-out"
-    local evacuate_log="$ktest_out/journal-srcu-evacuate-out"
-    local fiopid
+	local fioout="$ktest_out/journal-srcu-dst-pressure-fio-out"
+	local evacuate_log="$ktest_out/journal-srcu-evacuate-out"
+	local evacuate_timeout=${ktest_journal_srcu_evac_timeout:-360}
+	local fiopid
     local events
     local ret=0
 
@@ -189,7 +273,7 @@ test_journal_flush_srcu_liveness()
     fiopid=$(start_dst_pressure "$fioout")
     sleep 3
 
-    if ! timeout 360 bcachefs device evacuate "${ktest_scratch_dev[0]}" \
+	if ! timeout "$evacuate_timeout" bcachefs device evacuate "${ktest_scratch_dev[0]}" \
 	>"$evacuate_log" 2>&1; then
 	cat "$evacuate_log" || true
 	cat "$fioout" || true
@@ -200,12 +284,18 @@ test_journal_flush_srcu_liveness()
     stop_dst_pressure "$fiopid"
 
     if ((ret)); then
-	dump_journal_srcu_debug >&2
-	timeout 30 umount /mnt || true
+	dump_journal_srcu_debug "$ktest_out/journal-srcu-debug-failure"
+	poweroff -f || true
 	return 1
     fi
 
     sync
+	reconcile_status >"$ktest_out/journal-srcu-reconcile-status" 2>&1 || true
+
+    if ! assert_source_device_evacuated; then
+	ret=1
+    fi
+
     if ! assert_no_srcu_journal_warnings; then
 	ret=1
     fi


### PR DESCRIPTION
## Summary

Adds `journal_flush_srcu_liveness.ktest` for the SRCU/journal-liveness shape in
https://github.com/koverstreet/bcachefs-tools/issues/783.

The test mounts a 3-device debug bcachefs filesystem, delays journal flushes,
constrains move writeback concurrency, runs foreground `fio` pressure, and
evacuates a source device. It fails if the stress window emits either:

- `btree trans held srcu lock`
- `bch2_journal_flush_seq stuck?`

After the stress window it remounts read-only, unmounts, runs
`bcachefs fsck -ny`, and checks for bcachefs leak/error/device-error reports.

## Current Source-PR Status

This was originally paired with
https://github.com/koverstreet/bcachefs-tools/pull/790, but that PR is now
closed after upstream review rejected the broad SRCU-unlock approach and split
the useful pieces out.

The surviving source-side journal-reclaim work is
https://github.com/koverstreet/bcachefs-tools/pull/792. This ktest should not be
read as a red-to-green reproducer for that PR: it is a regression/smoke oracle
for the journal-flush/SRCU liveness invariant from
https://github.com/koverstreet/bcachefs-tools/issues/783.

## Scope Update After Coverage Audit

This is not a failing reproducer for
https://github.com/koverstreet/bcachefs-tools/issues/783. It passes unpatched
`origin/testing` at `838ead8957377100c58b501fc1c50816cb7e7da2` as well as the
historical `koverstreet/bcachefs-tools#790` branch, so there is no red-to-green
transition.

I also tried a closer member-stall prototype that suspends a source member with
`dmsetup suspend` during `bcachefs device evacuate`. The initial oracle treated
any `bch2_journal_flush_seq stuck?` as failure, but that is too strict when the
test deliberately suspends a member for longer than the journal warning
threshold. With the oracle narrowed to post-resume non-recovery or
`btree trans held srcu lock`, the prototype passes current unpatched
`koverstreet/bcachefs-tools` `origin/testing`, while still showing the expected
journal-stuck diagnostics during the artificial suspend.

That prototype is therefore not included in this PR as a regression test.

## Testing

- `git diff --check origin/master..HEAD`
- `bash -n tests/fs/bcachefs/journal_flush_srcu_liveness.ktest`
- `tests/fs/bcachefs/journal_flush_srcu_liveness.ktest list-tests`
- `tests/fs/bcachefs/journal_flush_srcu_liveness.ktest deps`
- Full VM run against unpatched `koverstreet/bcachefs-tools` `origin/testing`
  at `838ead8957377100c58b501fc1c50816cb7e7da2`, confirming this is not a red
  reproducer:
  - bcachefs module loaded in guest: `version: v1.38.8-161-g838ead895737`
  - result: `========= PASSED journal_flush_srcu_liveness in 69s`
  - result: `TEST SUCCESS`
- Full VM run against the original paired source fix at
  `fd929bb4241a885b8ce62f0f5b2412f247b13699`:
  - bcachefs module loaded in guest: `version: v1.38.8-162-gfd929bb4241a`
  - result: `========= PASSED journal_flush_srcu_liveness in 24s`
  - result: `TEST SUCCESS`
  - log oracle found no `btree trans held srcu lock`
  - log oracle found no `bch2_journal_flush_seq stuck?`
- Full VM run against historical `koverstreet/bcachefs-tools#790` source head
  `58f07184dbe66dcfa01d8ef021d1326fa4027a2f`:
  - bcachefs module loaded in guest: `version: v1.38.8-182-g58f07184dbe6`
  - result: `========= PASSED journal_flush_srcu_liveness in 114s`
  - result: `TEST SUCCESS`
  - log oracle found no `btree trans held srcu lock`
  - log oracle found no `bch2_journal_flush_seq stuck?`

## VM proof

VM run against master bcachefs-tools (kernel 7.2.0-rc4): `journal_flush_srcu_liveness` PASSED in 32s -- delayed journal flushes plus constrained move-writeback concurrency and foreground fio pressure on a 3-device debug fs completed without an SRCU/journal-liveness warning, source evacuated.
