### PR TITLE
bcachefs: test EC evacuation after degraded IO

### DIFF
--- a/tests/fs/bcachefs/ec-evacuate.ktest
+++ b/tests/fs/bcachefs/ec-evacuate.ktest
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Reproduce an intermittent EC evacuation stall after degraded IO.
+# shellcheck disable=SC2154
+
+# shellcheck source=tests/fs/bcachefs/bcachefs-test-libs.sh
+. "$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")/bcachefs-test-libs.sh"
+
+require-kernel-config BCACHEFS_ERASURE_CODING
+
+config-scratch-devs 16G
+config-scratch-devs 16G
+config-scratch-devs 16G
+config-scratch-devs 16G
+config-scratch-devs 16G
+
+config-mem 4G
+
+test_ec_evacuate_after_degraded_io()
+{
+    set_watchdog 1200
+
+    run_quiet "" bcachefs format -f		\
+	--erasure_code				\
+	--replicas=3				\
+	"${ktest_scratch_dev[0]}"			\
+	"${ktest_scratch_dev[1]}"			\
+	"${ktest_scratch_dev[2]}"			\
+	"${ktest_scratch_dev[3]}"
+
+    mount -t bcachefs "$(join_by : "${ktest_scratch_dev[@]:0:4}")" /mnt
+    bcachefs subvolume create /mnt/data
+
+    fio --output-format=json			\
+	--output="$ktest_out/fio-seed.json"	\
+	--name=seed				\
+	--filename=/mnt/data/seed.dat		\
+	--rw=write				\
+	--bs=1M					\
+	--size=7G				\
+	--end_fsync=1
+
+    fio --output-format=json			\
+	--output="$ktest_out/fio-churn.json"	\
+	--name=churn				\
+	--filename=/mnt/data/seed.dat		\
+	--rw=randwrite				\
+	--bs=4k					\
+	--size=7G				\
+	--runtime=120				\
+	--time_based				\
+	--fdatasync=16
+
+    bcachefs fs usage -h /mnt
+    bcachefs device offline --force "${ktest_scratch_dev[1]}" ||
+	bcachefs device offline "${ktest_scratch_dev[1]}"
+
+    fio --output-format=json				\
+	--output="$ktest_out/fio-degraded-write.json"	\
+	--name=degraded-write				\
+	--directory=/mnt/data				\
+	--rw=randwrite					\
+	--bs=4k						\
+	--size=1G					\
+	--runtime=30					\
+	--time_based					\
+	--fdatasync=16
+
+    fio --output-format=json				\
+	--output="$ktest_out/fio-degraded-read.json"	\
+	--name=degraded-read				\
+	--filename=/mnt/data/seed.dat			\
+	--rw=randread					\
+	--bs=4k						\
+	--size=7G					\
+	--runtime=30					\
+	--time_based
+
+    bcachefs device online "${ktest_scratch_dev[1]}"
+    bcachefs device add -f /mnt "${ktest_scratch_dev[4]}"
+    bcachefs device evacuate "${ktest_scratch_dev[1]}"
+
+    bcachefs fs usage -h /mnt
+    bcachefs scrub /mnt
+    umount /mnt
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add a focused five-device bcachefs test for an intermittent EC evacuation stall. Unlike the existing EC evacuation coverage, this sequence:

- formats four devices with `--erasure_code --replicas=3`
- seeds and churns 7 GiB before device loss
- performs random writes and reads while one member is offline
- brings that member online, adds a fifth device, then evacuates the original member

The standalone workload stalled in 4 of 25 valid evacuation trials. The test can be repeated with ktest's `-L` option. Evidence and failure artifacts are linked from https://github.com/fenio/modern-fs-benchmark/blob/main/docs/bcachefs-ec-evacuation-reproducer.md.

## Validation

- `bash -n tests/fs/bcachefs/ec-evacuate.ktest`
- full pass in an ARM64 Ubuntu 26.04 VM on kernel 7.0.0-27-generic with bcachefs tools/module 1.38.8
- evacuation completed from 3.95 GiB to zero; scrub and offline fsck passed