### PR TITLE
ci dashboard: preserve user in filtered commit links

### DIFF
--- a/src/bin/cgi.rs
+++ b/src/bin/cgi.rs
@@ -323,8 +323,9 @@ fn ci_log(ci: &Ci) -> cgi::Response {
                 writeln!(&mut out, "<tr class={}>", t.1.status.table_class()).unwrap();
                 writeln!(
                     &mut out,
-                    "<td> <a href=\"{}?branch={}&commit={}\">{}</a> </td>",
+                    "<td> <a href=\"{}?user={}&branch={}&commit={}\">{}</a> </td>",
                     ci.script_name,
+                    ci.user.as_ref().unwrap(),
                     branch,
                     r.id,
                     &r.id.as_str()[..14]


### PR DESCRIPTION
## Summary

Preserve the selected user in commit links rendered by the single-test branch history view.

Without the user parameter, clicking a commit from a filtered result falls through to the dashboard homepage instead of opening the commit details. The multi-test view already includes this parameter.

## Testing

- `cargo test` (12 passed)
- `git diff --check`