### PR TITLE
Shut the VM down when the test finishes

### DIFF
--- a/lib/libktest.sh
+++ b/lib/libktest.sh
@@ -411,6 +411,7 @@ start_vm()
 
     rm -f "$ktest_out/core.*"
     rm -f "$ktest_out/vmcore"
+    rm -f "$ktest_out/status"
     rm -f "$ktest_out/vm"
     ln -s "$ktest_tmp" "$ktest_out/vm"
 
@@ -645,8 +646,34 @@ start_vm()
     done
 
     "${qemu_cmd[@]}"
+    local ret=$?
 
-    kill $virtiofsd_pid 2>/dev/null
+    # `|| true`: virtiofsd normally exits by itself when qemu drops the
+    # vhost-user connection, so by now it's usually already gone.
+    kill $virtiofsd_pid 2>/dev/null || true
+
+    # -I keeps the VM alive on purpose; the user ended the run themselves
+    # and there's no verdict to report. Otherwise the guest left one in
+    # $ktest_out/status on its way down (lib/testrunner) - report it as
+    # our exit status, so a caller can just test $? instead of grepping
+    # the console for TEST SUCCESS. Those markers are the CI supervisor's
+    # interface; everyone else deserves an exit code.
+    #
+    # No status file means the VM never got that far: a panic, an OOM
+    # kill, a hang someone interrupted. That's a failure.
+    if ! $ktest_interactive; then
+	if [[ ! -f $ktest_out/status ]]; then
+	    echo "VM exited without a test verdict (qemu exited $ret)"
+	    ret=1
+	elif [[ $(<"$ktest_out/status") != SUCCESS ]]; then
+	    ret=1
+	fi
+    fi
+
+    # exit, not return: a bare `return 1` would trip common.sh's ERR trap
+    # on the way out and print a spurious "Error 1 at ..." for an ordinary
+    # test failure. This is the end of the run either way.
+    exit $ret
 }
 
 map_clang_version() {

--- a/lib/testrunner
+++ b/lib/testrunner
@@ -40,6 +40,50 @@ ln -s $ktest_deps_dir/.cargo /root/.cargo
 
 ktest_no_cleanup_tmpdir=1
 
+# Take the VM down on the way out, however we get there.
+#
+# Nothing on the host reaps this VM. Since 0b3b971c ("Move logic for
+# retrying subtests to the CI") start_vm runs qemu directly; only the CI
+# wraps it in lib/supervisor, which watches the console for the TEST
+# SUCCESS/TEST FAILED markers and kills the VM when it sees one. A plain
+# `ktest run` / `build-test-kernel run` has no such watcher, so if the
+# guest doesn't take itself down the run never finishes: the test's
+# verdict scrolls past, the guest idles at a login prompt, and qemu (plus
+# the shell blocked in wait(2) on it) sits there until someone notices.
+#
+# An EXIT trap rather than a call at the end of the script: testrunner
+# has several early `exit`s (unexpected reboot, no tests, tainted
+# kernel), and every one of them used to strand a VM too.
+#
+# -I means "don't shut down the VM automatically", so honour it.
+vm_exit()
+{
+    pkill -P $$ >/dev/null || true
+
+    if ${ktest_interactive:-false}; then
+	return
+    fi
+
+    # Give the last console lines time to drain out of the virtio-console
+    # queue - they are the test's verdict, and the host only ever sees
+    # what qemu wrote before it exited.
+    sleep 2
+
+    # sysrq rather than `poweroff`, matching do_reboot(): a clean systemd
+    # shutdown can block on a wedged unit or a busy /host mount, which
+    # would strand the VM again - the exact failure this trap exists to
+    # prevent. Deliberately no sync(1) here either: these tests wedge
+    # filesystems on purpose, and $ktest_out is virtiofs, so the results
+    # are already on the host's fs by the time we get here.
+    #
+    # Enable sysrq here rather than relying on the block further down:
+    # the early exits above are reached before it runs.
+    echo 1 > /proc/sys/kernel/sysrq
+    echo o > /proc/sysrq-trigger
+}
+
+trap vm_exit EXIT
+
 log_verbose "Testrunner starting"
 
 mkdir -p /root/.ssh
@@ -218,7 +262,6 @@ if [[ $ktest_tests = "none" ]]; then
     exit 0
 fi
 
-trap 'pkill -P $$ >/dev/null' EXIT
 cd /root
 
 # ktest_tmp here is testrunner's /host/-rewritten *host* tmpdir; the
@@ -257,8 +300,14 @@ check_taint
 echo -n "Kernel version: "
 uname -r
 
+# $ktest_out/status is the same verdict in a file the host can read
+# without parsing the console; start_vm turns it into its exit status.
+# Absent means failure - every early exit above prints TEST FAILED and
+# never reaches here, and neither does a VM that died mid-run.
 if [[ $ret = 0 ]]; then
     echo "TEST SUCCESS"
+    echo "SUCCESS" > "$ktest_out/status"
 else
     echo "TEST FAILED"
+    echo "FAILED" > "$ktest_out/status"
 fi


### PR DESCRIPTION
Fixes #106.

`ktest run` and `build-test-kernel run` never return. The test prints its
verdict, and then the guest idles at a login prompt forever while qemu — and the
shell blocked in `wait(2)` on it — stay resident. Seven VMs accumulated on one
machine before anyone noticed.

Nothing asks the VM to stop. `lib/testrunner` ends by echoing `TEST SUCCESS` or
`TEST FAILED` and returning; there is no poweroff in that path. Host side,
`start_vm` runs qemu in the foreground with nothing watching its console.

It used to be watched: before `0b3b971c` ("Move logic for retrying subtests to
the CI") `start_vm` ran qemu under `lib/qemu-wrapper` — today's
`lib/supervisor` — which breaks on those console markers and SIGTERMs the VM.
That commit moved the wrapper up into the CI and deleted it from `start_vm`, so
the CI path still terminates correctly and the direct path has terminated
nothing since. Running interactively hides it: the verdict scrolls past and you
hit Ctrl-C.

This has the guest take itself down instead, from an `EXIT` trap rather than a
call at the end of the script — `testrunner` has several early exits (unexpected
reboot, no tests found, tainted kernel) and each of those stranded a VM too.
sysrq rather than `poweroff`, matching `do_reboot()`: a clean systemd shutdown
can block on a stuck unit or a busy `/host` mount, which would strand the VM
again. `-I` still means "leave it up".

While here, the run gets an exit status. The guest writes its verdict to
`$ktest_out/status` and `start_vm` reports it, so a caller can test `$?` instead
of grepping the console; a missing status file means the VM died before
finishing and counts as a failure. The console markers stay the supervisor's
interface, unchanged.

This does not disturb the CI: `ci-daemon` still wraps runs in the supervisor,
which breaks on the marker before the guest's timer expires and ignores the
inner exit status anyway.

A natural companion to #105, which is still open.
