### PR TITLE
bcachefs: test that going read-only aborts a running scrub

### DIFF
--- a/tests/fs/bcachefs/bcachefs-test-libs.sh
+++ b/tests/fs/bcachefs/bcachefs-test-libs.sh
@@ -577,6 +577,84 @@ bcachefs_test_end_checks()
     check_bcachefs_counters $@
 }
 
+# On-disk corruption injection: parse physical pointer locations out of
+# bkey listings (bcachefs list / list_journal), then overwrite them on
+# the raw device. Used by the scrub corruption tests.
+
+# bcachefs_ptr_sectors <bucket_size_sectors> <dev_idx>
+#
+# Print the raw device sector of every pointer on member device
+# <dev_idx>, parsed from a bkey listing on stdin. Pointers print as
+# "ptr: <devname> <dev>:<bucket>:<offset> gen <g>"; key positions are
+# also colon-separated numbers, so only accept tokens adjacent to a
+# "ptr:" marker.
+bcachefs_ptr_sectors()
+{
+    awk -v bsz="$1" -v dev="$2" '
+	{
+	    for (i = 1; i < NF; i++) {
+		if ($i != "ptr:")
+		    continue
+		for (j = i + 1; j <= i + 2 && j <= NF; j++)
+		    if ($j ~ /^[0-9]+:[0-9]+:[0-9]+$/) {
+			split($j, p, ":")
+			if (p[1] == dev)
+			    print p[2] * bsz + p[3]
+			break
+		    }
+	    }
+	}'
+}
+
+# bcachefs_first_stripe_blocks <bucket_size_sectors>
+#
+# For the first stripe in `bcachefs list -b stripes` output on stdin,
+# print "meta <nr_data> <nr_redundant>" followed by one
+# "block <idx> <dev> <sector>" line per stripe block, in block order
+# (data blocks first, then parity).
+bcachefs_first_stripe_blocks()
+{
+    awk -v bsz="$1" '
+	/blocks [0-9]+:[0-9]+/ {
+	    if (found)
+		exit
+	    found = 1
+	    match($0, /blocks [0-9]+:[0-9]+/)
+	    split(substr($0, RSTART + 7, RLENGTH - 7), b, ":")
+	    nr_data = b[1]
+	    nr_red = b[2]
+	    idx = 0
+	    print "meta", nr_data, nr_red
+	    next
+	}
+	found {
+	    for (i = 1; i <= NF; i++)
+		if ($i ~ /^[0-9]+:[0-9]+:[0-9]+$/) {
+		    split($i, p, ":")
+		    print "block", idx, p[1], p[2] * bsz + p[3]
+		    idx++
+		}
+	    if (idx >= nr_data + nr_red)
+		exit
+	}'
+}
+
+# bcachefs_corrupt_sectors <dev>
+#
+# Overwrite 4k with random data at each sector read from stdin; prints
+# the number of locations corrupted.
+bcachefs_corrupt_sectors()
+{
+    local dev=$1 nr=0 sector
+    while read -r sector; do
+	dd if=/dev/urandom of="$dev" bs=512 seek="$sector" count=8 \
+	    conv=notrunc status=none
+	nr=$((nr + 1))
+    done
+    echo "corrupted $nr x 4k at pointer locations on $dev" >&2
+    echo $nr
+}
+
 fill_device()
 {
     local filename=$1

--- a/tests/fs/bcachefs/scrub-cancel.ktest
+++ b/tests/fs/bcachefs/scrub-cancel.ktest
@@ -1,8 +1,71 @@
 #!/usr/bin/env bash
+#
+# Scrub cancellation tests.
+#
+# Cancelling a scrub job means closing its progress fd, which blocks in
+# kthread_stop() until that device's scrub thread notices and drains its
+# in-flight reads. The scrub command must issue those closes in parallel
+# on interrupt: serial closes cost the sum of per-device stop latencies.
+#
+# scrub_cancel is the basic single-device test; the parallel_* tests
+# use dm-delay to make per-device stop latency large and controlled,
+# then verify the parallelism property directly (timing, and
+# simultaneous kthread_stop stack samples).
 
 . $(dirname $(readlink -e ${BASH_SOURCE[0]}))/bcachefs-test-libs.sh
 
-config-scratch-devs 8G
+require-kernel-config DM_DELAY
+
+config-scratch-devs 4G
+config-scratch-devs 4G
+config-scratch-devs 4G
+config-scratch-devs 4G
+
+NR_DEVS=4
+delay_devs=()
+
+# dm-delay wrappers over the scratch devices. Created with no delay so
+# format/mount/writes run at full speed; set_read_delay swaps in a
+# read-side delay just before the scrub under test.
+setup_delay_devs()
+{
+    local i
+
+    # Self-clean in case an earlier failed subtest left state behind:
+    umount /mnt 2>/dev/null || true
+    for i in $(seq 0 $((NR_DEVS - 1))); do
+	dmsetup remove --retry scrubdelay$i 2>/dev/null || true
+    done
+
+    delay_devs=()
+    for i in $(seq 0 $((NR_DEVS - 1))); do
+	local dev=${ktest_scratch_dev[$i]}
+	dmsetup create scrubdelay$i --table \
+	    "0 $(blockdev --getsz $dev) delay $dev 0 0"
+	delay_devs+=(/dev/mapper/scrubdelay$i)
+    done
+}
+
+set_read_delay()
+{
+    local ms=$1 i
+    for i in $(seq 0 $((NR_DEVS - 1))); do
+	local dev=${ktest_scratch_dev[$i]}
+	dmsetup reload scrubdelay$i --table \
+	    "0 $(blockdev --getsz $dev) delay $dev 0 $ms $dev 0 0"
+	dmsetup suspend scrubdelay$i
+	dmsetup resume scrubdelay$i
+    done
+}
+
+teardown_delay_devs()
+{
+    local i
+    for i in $(seq 0 $((NR_DEVS - 1))); do
+	dmsetup remove --retry scrubdelay$i
+    done
+    delay_devs=()
+}
 
 test_scrub_cancel()
 {
@@ -85,6 +148,149 @@ test_scrub_cancel()
     umount /mnt
     bcachefs fsck -ny ${ktest_scratch_dev[0]}
     bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+# Start a scrub against the delay devices with the given read delay and
+# wait until all four device jobs have reads in flight; sets scrub_pid.
+# Callers take over from the SIGINT.
+#
+# The workload must be many small extents: scrub keeps up to
+# move_ios_in_flight (64) reads in flight per device, and anything that
+# fits in one submission burst completes after a single delay round no
+# matter how large the delay - a handful of big extents makes the whole
+# scrub finish in one round before we can interrupt it. 4k random
+# writes produce thousands of physically discontiguous (so unmergeable)
+# extents per device, sustaining delayed read rounds for minutes.
+start_delayed_scrub()
+{
+    local delay_ms=$1
+
+    setup_delay_devs
+    run_quiet "" bcachefs format -f "${delay_devs[@]}"
+    local devs="$(join_by : "${delay_devs[@]}")"
+    mount -t bcachefs $devs /mnt
+
+    run_fio_base				\
+	--name=frag				\
+	--rw=randwrite				\
+	--bs=4k					\
+	--filesize=32M
+    sync
+
+    set_read_delay $delay_ms
+
+    bcachefs scrub /mnt &
+    scrub_pid=$!
+    sleep 3
+
+    # A scrub that finished (needs a bigger workload or delay) and a
+    # scrub that died on startup (a broken CLI) both show up here as a
+    # dead pid but want opposite fixes; tell them apart by exit status.
+    if ! kill -0 $scrub_pid 2>/dev/null; then
+	if wait $scrub_pid; then
+	    echo "ERROR: scrub finished before it could be interrupted"
+	else
+	    echo "ERROR: scrub exited nonzero before it could be interrupted - it never started"
+	fi
+	return 1
+    fi
+}
+
+# Wait for the scrub command to exit; sets scrub_exit_s. If it is still
+# running after $1 seconds, dump its kernel stacks and the filesystem's
+# moving_ctxts - a wedged cancellation with no state dump is
+# undebuggable from a test log - then kill it so teardown can proceed.
+wait_scrub_exit()
+{
+    local timeout=$1
+    local start=$(date +%s)
+
+    while kill -0 $scrub_pid 2>/dev/null; do
+	if (($(date +%s) - start > timeout)); then
+	    echo "ERROR: scrub still running after ${timeout}s"
+	    echo "Thread state:"
+	    cat /proc/$scrub_pid/task/*/stack 2>/dev/null || true
+	    echo "Moving contexts:"
+	    cat /sys/fs/bcachefs/*/moving_ctxts 2>/dev/null || true
+	    kill -9 $scrub_pid 2>/dev/null || true
+	    wait $scrub_pid 2>/dev/null || true
+	    return 1
+	fi
+	sleep 0.1
+    done
+    wait $scrub_pid 2>/dev/null || true
+    scrub_exit_s=$(($(date +%s) - start))
+}
+
+finish_delayed_scrub()
+{
+    set_read_delay 0
+    umount /mnt
+    teardown_delay_devs
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+test_scrub_cancel_parallel_timing()
+{
+    set_watchdog 300
+
+    # Stopping one device's scrub job means draining its current batch
+    # of delayed reads, up to one full 8s round. The four jobs submit
+    # their bursts in lockstep (same start, same delay, same batch
+    # size), so batch boundaries stay aligned across devices: serial
+    # cancellation finishes one device's drain exactly when the others
+    # have just submitted fresh batches, cascading into further full
+    # rounds. Measured: parallel ~14s (signal poll + up to two rounds),
+    # serial ~47s; the 25s threshold sits between with >10s margin to
+    # each.
+    start_delayed_scrub 8000
+
+    local start_ms=$(date +%s%3N)
+    kill -INT $scrub_pid
+    if ! wait_scrub_exit 60; then
+	finish_delayed_scrub
+	return 1
+    fi
+    local elapsed_ms=$(($(date +%s%3N) - start_ms))
+    echo "cancellation took ${elapsed_ms}ms"
+
+    finish_delayed_scrub
+
+    if ((elapsed_ms > 25000)); then
+	echo "ERROR: cancellation took ${elapsed_ms}ms - serial kthread_stop?"
+	return 1
+    fi
+}
+
+test_scrub_cancel_parallel_stacks()
+{
+    set_watchdog 300
+
+    start_delayed_scrub 3000
+
+    kill -INT $scrub_pid
+
+    # Sample the scrub process's kernel stacks while it tears down: with
+    # parallel cancellation multiple threads block in kthread_stop() at
+    # once; the serial implementation can never show more than one.
+    local max_parallel=0 n
+    while kill -0 $scrub_pid 2>/dev/null; do
+	n=$(grep -l kthread_stop /proc/$scrub_pid/task/*/stack 2>/dev/null | wc -l || true)
+	if ((n > max_parallel)); then
+	    max_parallel=$n
+	fi
+	sleep 0.05
+    done
+    wait $scrub_pid || true
+    echo "max threads simultaneously in kthread_stop: $max_parallel"
+
+    finish_delayed_scrub
+
+    if ((max_parallel < 2)); then
+	echo "ERROR: never saw parallel kthread_stop - cancellation is serial"
+	return 1
+    fi
 }
 
 main "$@"

--- a/tests/fs/bcachefs/scrub-cancel.ktest
+++ b/tests/fs/bcachefs/scrub-cancel.ktest
@@ -263,6 +263,38 @@ test_scrub_cancel_parallel_timing()
     fi
 }
 
+# Going read-only must abort running data jobs: every job holds a
+# c->writes ref for its thread's lifetime, and the read-only transition
+# (asynchronous - the trigger returns immediately) blocks in the write
+# ref drain until the jobs are gone. With the abort, each job errors
+# out at its next loop iteration, drops its ref, and the scrub command
+# sees its jobs finish and exits within seconds. Without it, the jobs
+# run to completion - the dm-delay reads make that take minutes - and
+# the scrub outliving the trigger by 30s is the failure signature.
+test_scrub_emergency_ro()
+{
+    set_watchdog 300
+
+    start_delayed_scrub 3000
+
+    echo 1 > /sys/fs/bcachefs/*/internal/trigger_emergency_read_only
+
+    if ! wait_scrub_exit 30; then
+	return 1
+    fi
+    echo "scrub exited ${scrub_exit_s}s after emergency read-only"
+
+    set_read_delay 0
+    umount /mnt
+    teardown_delay_devs
+
+    # Journal replay from the unclean shutdown, then verify:
+    local devs="$(join_by : "${ktest_scratch_dev[@]}")"
+    mount -t bcachefs $devs /mnt
+    umount /mnt
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+}
+
 test_scrub_cancel_parallel_stacks()
 {
     set_watchdog 300

--- a/tests/fs/bcachefs/scrub-corrupt.ktest
+++ b/tests/fs/bcachefs/scrub-corrupt.ktest
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+#
+# Scrub detection and repair of real on-disk data corruption: locate
+# extent/stripe pointers from key listings (dev:bucket:offset, fixed
+# 512k buckets so the sector math is static), overwrite the data with
+# the filesystem unmounted, then verify scrub's exit code: bit 2 =
+# errors corrected, bit 4 = uncorrectable errors found.
+#
+# Four cases:
+#   single_replica - no redundancy: scrub must report uncorrectable
+#   replicated     - four replicas, random subsets of copies corrupt
+#                    (including one extent with three of four gone):
+#                    scrub must repair everything from the survivors
+#   ec_data        - EC stripe data block corrupt: scrub must repair
+#                    via stripe reconstruction
+#   ec_parity      - EC stripe parity block corrupt: scrub must repair
+#                    it (parity is reconstructible from the intact data
+#                    blocks).
+
+. $(dirname $(readlink -e ${BASH_SOURCE[0]}))/bcachefs-test-libs.sh
+
+require-kernel-config BCACHEFS_ERASURE_CODING
+
+config-scratch-devs 4G
+config-scratch-devs 4G
+config-scratch-devs 4G
+config-scratch-devs 4G
+
+BUCKET_SIZE_KB=512
+BUCKET_SIZE_SECTORS=$((BUCKET_SIZE_KB * 2))
+
+test_scrub_corrupt_single_replica()
+{
+    ktest_expect_device_errors=1
+    ktest_expect_sb_errors="data_read_(io|csum)_err(_recovered)?"
+    set_watchdog 120
+
+    local dev=${ktest_scratch_dev[0]}
+
+    run_quiet "" bcachefs format -f --bucket_size=${BUCKET_SIZE_KB}k "$dev"
+    mount -t bcachefs "$dev" /mnt
+    dd if=/dev/urandom of=/mnt/testfile bs=1M count=16 oflag=direct
+    sync
+    umount /mnt
+
+    local nr=$(bcachefs list -b extents "$dev" |
+	bcachefs_ptr_sectors $BUCKET_SIZE_SECTORS 0 | head -8 |
+	bcachefs_corrupt_sectors "$dev")
+    if ((nr == 0)); then
+	echo "ERROR: found no extent locations to corrupt"
+	return 1
+    fi
+
+    mount -t bcachefs "$dev" /mnt
+    local rc=0
+    bcachefs scrub "$dev" || rc=$?
+    echo "scrub exit code: $rc"
+    umount /mnt
+
+    if (((rc & 4) == 0)); then
+	echo "ERROR: scrub did not report uncorrectable errors"
+	return 1
+    fi
+
+    bcachefs fsck -ny "$dev"
+    bcachefs_test_end_checks "$dev"
+}
+
+# Print "extent# dev sector" for every replica pointer in a bkey
+# listing on stdin, grouping pointers by the extent they belong to.
+extent_replica_locations()
+{
+    awk -v bsz="$1" '
+	/ type extent / { ext++ }
+	ext {
+	    for (i = 1; i < NF; i++) {
+		if ($i != "ptr:")
+		    continue
+		for (j = i + 1; j <= i + 2 && j <= NF; j++)
+		    if ($j ~ /^[0-9]+:[0-9]+:[0-9]+$/) {
+			split($j, p, ":")
+			print ext, p[1], p[2] * bsz + p[3]
+			break
+		    }
+	    }
+	}'
+}
+
+test_scrub_corrupt_replicated()
+{
+    ktest_expect_device_errors=1
+    ktest_expect_sb_errors="data_read_(io|csum)_err(_recovered)?"
+    set_watchdog 180
+
+    run_quiet "" bcachefs format -f --replicas=4	\
+	--bucket_size=${BUCKET_SIZE_KB}k		\
+	"${ktest_scratch_dev[@]}"
+    local devs="$(join_by : "${ktest_scratch_dev[@]}")"
+    mount -t bcachefs $devs /mnt
+    dd if=/dev/urandom of=/mnt/testfile bs=1M count=16 oflag=direct
+    cp /mnt/testfile /root/scrub-orig
+    sync
+    umount /mnt
+
+    local locations=$(bcachefs list -b extents "${ktest_scratch_dev[@]}" |
+	extent_replica_locations $BUCKET_SIZE_SECTORS)
+    local nr_extents=$(echo "$locations" |
+	awk '{ if ($1 > m) m = $1 } END { print m + 0 }')
+    if ((nr_extents < 6)); then
+	echo "ERROR: only $nr_extents extents to corrupt"
+	return 1
+    fi
+
+    # Corrupt random replicas of six random extents. The first victim
+    # loses three of its four copies - repair must work from a single
+    # surviving replica - and the rest lose a random one to three.
+    local ext k dev sector nr=0 first=1
+    for ext in $(seq 1 $nr_extents | shuf -n6); do
+	if ((first)); then
+	    k=3
+	    first=0
+	else
+	    k=$((RANDOM % 3 + 1))
+	fi
+	while read -r _ dev sector; do
+	    echo "corrupting extent $ext replica: dev $dev sector $sector"
+	    echo "$sector" |
+		bcachefs_corrupt_sectors ${ktest_scratch_dev[$dev]} > /dev/null
+	    nr=$((nr + 1))
+	done < <(echo "$locations" | awk -v e=$ext '$1 == e' | shuf -n$k)
+    done
+    echo "corrupted $nr replicas across 6 extents"
+
+    mount -t bcachefs $devs /mnt
+
+    # Scrub each device in turn - sequentially, so concurrent
+    # per-device repairs of the same extent can't race. Combined they
+    # must find and repair everything, nothing uncorrectable.
+    local rc=0 drc d
+    for d in "${ktest_scratch_dev[@]}"; do
+	drc=0
+	bcachefs scrub "$d" || drc=$?
+	echo "scrub $d exit code: $drc"
+	rc=$((rc | drc))
+    done
+
+    if (((rc & 2) == 0)); then
+	echo "ERROR: scrub did not report corrected errors"
+	return 1
+    fi
+    if (((rc & 4) != 0)); then
+	echo "ERROR: scrub reported uncorrectable errors with a good replica present"
+	return 1
+    fi
+
+    # Repair must converge: a second full pass runs clean.
+    rc=0
+    for d in "${ktest_scratch_dev[@]}"; do
+	drc=0
+	bcachefs scrub "$d" || drc=$?
+	rc=$((rc | drc))
+    done
+    if ((rc != 0)); then
+	echo "ERROR: second scrub pass still found errors (exit code $rc)"
+	return 1
+    fi
+
+    cmp /mnt/testfile /root/scrub-orig
+    umount /mnt
+
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+# Format with erasure coding, write data, wait for background reconcile
+# to build at least one stripe, and leave the fs unmounted. Sets
+# stripe_meta and stripe_block_lines from the first stripe found.
+setup_ec_corrupt()
+{
+    run_quiet "" bcachefs format -f		\
+	--erasure_code				\
+	--replicas=2				\
+	--bucket_size=${BUCKET_SIZE_KB}k	\
+	"${ktest_scratch_dev[@]}"
+    local devs="$(join_by : "${ktest_scratch_dev[@]}")"
+    mount -t bcachefs $devs /mnt
+
+    dd if=/dev/urandom of=/mnt/testfile bs=1M count=128 oflag=direct
+    cp /mnt/testfile /root/scrub-orig
+    sync
+
+    # Stripe creation is a background reconcile operation; kick it and
+    # poll the stripe_create counter until a stripe exists.
+    local created=0 i
+    for i in $(seq 1 60); do
+	echo 1 > /sys/fs/bcachefs/*/internal/trigger_reconcile_wakeup
+	created=$(awk '/since mount/ {print $3}' \
+	    /sys/fs/bcachefs/*/counters/stripe_create)
+	if ((created > 0)); then
+	    break
+	fi
+	sleep 1
+    done
+    if ((created == 0)); then
+	echo "ERROR: no stripes created after 60s"
+	return 1
+    fi
+    umount /mnt
+
+    local blocks=$(bcachefs list -b stripes "${ktest_scratch_dev[@]}" |
+	bcachefs_first_stripe_blocks $BUCKET_SIZE_SECTORS)
+    echo "first stripe:"
+    echo "$blocks"
+
+    stripe_meta=$(echo "$blocks" | awk '$1 == "meta" {print $2, $3}')
+    stripe_block_lines=$(echo "$blocks" | awk '$1 == "block"')
+    if [[ -z $stripe_meta || -z $stripe_block_lines ]]; then
+	echo "ERROR: could not parse stripe blocks"
+	return 1
+    fi
+}
+
+# Print "<dev> <sector>" for stripe block index $1.
+stripe_block()
+{
+    echo "$stripe_block_lines" | awk -v want="$1" '$2 == want {print $3, $4}'
+}
+
+test_scrub_corrupt_ec_data()
+{
+    ktest_expect_device_errors=1
+    ktest_expect_sb_errors="data_read_(io|csum)_err(_recovered)?"
+    set_watchdog 300
+
+    setup_ec_corrupt
+
+    # Corrupt the first data block of the stripe.
+    local tdev tsector
+    read -r tdev tsector <<< "$(stripe_block 0)"
+    echo "corrupting stripe data block 0: dev $tdev sector $tsector"
+    echo "$tsector" | bcachefs_corrupt_sectors ${ktest_scratch_dev[$tdev]} > /dev/null
+
+    local devs="$(join_by : "${ktest_scratch_dev[@]}")"
+    mount -t bcachefs $devs /mnt
+
+    local rc=0
+    bcachefs scrub ${ktest_scratch_dev[$tdev]} || rc=$?
+    echo "scrub exit code: $rc"
+
+    if (((rc & 2) == 0)); then
+	echo "ERROR: scrub did not report corrected errors"
+	return 1
+    fi
+    if (((rc & 4) != 0)); then
+	echo "ERROR: scrub reported uncorrectable errors despite EC redundancy"
+	return 1
+    fi
+
+    cmp /mnt/testfile /root/scrub-orig
+    umount /mnt
+
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+test_scrub_corrupt_ec_parity()
+{
+    ktest_expect_device_errors=1
+    ktest_expect_sb_errors="data_read_(io|csum)_err(_recovered)?"
+    set_watchdog 300
+
+    setup_ec_corrupt
+
+    # Corrupt the first parity block (block index nr_data): three 4k
+    # spots spread across the block.
+    local nr_data nr_red
+    read -r nr_data nr_red <<< "$stripe_meta"
+
+    local tdev tsector
+    read -r tdev tsector <<< "$(stripe_block $nr_data)"
+    echo "corrupting stripe parity block $nr_data: dev $tdev sector $tsector"
+    printf '%s\n' $tsector $((tsector + 256)) $((tsector + 512)) |
+	bcachefs_corrupt_sectors ${ktest_scratch_dev[$tdev]} > /dev/null
+
+    local devs="$(join_by : "${ktest_scratch_dev[@]}")"
+    mount -t bcachefs $devs /mnt
+
+    local rc=0
+    bcachefs scrub ${ktest_scratch_dev[$tdev]} || rc=$?
+    echo "scrub exit code: $rc"
+    umount /mnt
+
+    if (((rc & 2) == 0)); then
+	echo "ERROR: scrub did not repair parity block corruption"
+	return 1
+    fi
+    if (((rc & 4) != 0)); then
+	echo "ERROR: scrub reported parity corruption as uncorrectable" \
+	     "despite intact data blocks"
+	return 1
+    fi
+
+    bcachefs fsck -ny "${ktest_scratch_dev[@]}"
+    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
+}
+
+main "$@"

--- a/tests/fs/bcachefs/scrub-journal.ktest
+++ b/tests/fs/bcachefs/scrub-journal.ktest
@@ -52,22 +52,8 @@ test_scrub_journal()
 	exit 1
     fi
 
-    # Parse raw sector offsets from extent lines
-    # Input: extent lines on stdin
-    # Output: one raw sector offset per line
     local extent_sectors=$(echo "$extents" |
-	awk -v bsz="$BUCKET_SIZE_SECTORS" '
-	/ptr:/ {
-	    for (i = 1; i <= NF; i++) {
-		if (match($i, /^[0-9]+:[0-9]+:[0-9]+$/)) {
-		    split($i, parts, ":")
-		    bucket = parts[2] + 0
-		    offset = parts[3] + 0
-		    print bucket * bsz + offset
-		}
-	    }
-	}'
-    )
+	bcachefs_ptr_sectors $BUCKET_SIZE_SECTORS 0)
 
     if [[ -z $extent_sectors ]]; then
 	echo "ERROR: No sector offsets parsed from extents"
@@ -77,13 +63,8 @@ test_scrub_journal()
     local nr_total=$(echo "$extent_sectors" | wc -l)
 
     # Corrupt a limited number of data blocks
-    local nr_corrupted=0
-    while read sector; do
-	dd if=/dev/urandom of="$dev" bs=512 seek="$sector" count=8 \
-	    conv=notrunc 2>/dev/null
-	nr_corrupted=$((nr_corrupted + 1))
-	[[ $nr_corrupted -ge 10 ]] && break
-    done <<< "$extent_sectors"
+    local nr_corrupted=$(echo "$extent_sectors" | head -10 |
+	bcachefs_corrupt_sectors "$dev")
 
     echo "Corrupted $nr_corrupted / $nr_total data extent locations"
 


### PR DESCRIPTION
This is a bit ugly right now; depends on #111, I'll rebase it if/when that gets in.

Intended to test https://github.com/koverstreet/bcachefs-tools/pull/838.