### PR TITLE
bcachefs: add lockdep test for buffered write snapshots

### DIFF
--- a/tests/fs/bcachefs/lockdep-buffered-write-snapshot.ktest
+++ b/tests/fs/bcachefs/lockdep-buffered-write-snapshot.ktest
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+. $(dirname $(readlink -e "${BASH_SOURCE[0]}"))/bcachefs-test-libs.sh
+
+config-mem 4G
+config-scratch-devs 4G
+config-timeout 120
+
+require-kernel-config PROVE_LOCKING
+require-kernel-config LOCKDEP_BITS=20
+require-kernel-config LOCKDEP_CHAINS_BITS=20
+require-kernel-config DEBUG_ATOMIC_SLEEP
+require-kernel-config PREEMPT
+require-kernel-config DEBUG_PREEMPT
+require-kernel-config DMABUF_HEAPS
+
+test_buffered_write_snapshot_lockdep()
+{
+    set_watchdog 120
+
+    run_quiet "" bcachefs format -f "${ktest_scratch_dev[0]}"
+    mount -t bcachefs "${ktest_scratch_dev[0]}" /mnt
+
+    cat > /tmp/repro.c <<'EOF'
+#define _GNU_SOURCE
+#include <err.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static atomic_int stop;
+
+enum {
+    FILE_SIZE = 4096 * 64,
+    SNAPSHOT_ITERATIONS = 128
+};
+
+static void *mmap_writer(void *arg)
+{
+    char *p = arg;
+    size_t off;
+
+    while (!atomic_load(&stop)) {
+        for (off = 0; off < FILE_SIZE; off += 4096)
+            p[off]++;
+        msync(p, FILE_SIZE, MS_ASYNC);
+    }
+
+    return NULL;
+}
+
+static void *snapshot_worker(void *arg)
+{
+    char *p = arg;
+    for (unsigned int i = 0; i < SNAPSHOT_ITERATIONS && !atomic_load(&stop); i++) {
+        char snap[64];
+        pid_t pid;
+        int status;
+
+        snprintf(snap, sizeof(snap), "/mnt/snap-%u", i);
+
+        pid = fork();
+        if (pid < 0)
+            err(1, "fork");
+        if (pid == 0) {
+            execlp("bcachefs", "bcachefs", "subvolume", "snapshot",
+                   p, snap, NULL);
+            _exit(127);
+        }
+
+        if (waitpid(pid, &status, 0) < 0)
+            err(1, "waitpid");
+        if (WIFSIGNALED(status) || WEXITSTATUS(status) != 0)
+            err(1, "snapshot %s failed", snap);
+
+        usleep(2500);
+    }
+
+    return NULL;
+}
+
+int main(void)
+{
+    int src = open("/mnt/src", O_CREAT|O_RDWR|O_TRUNC, 0600);
+    int dst = open("/mnt/dst", O_CREAT|O_RDWR|O_TRUNC, 0600);
+    int mapfd = open("/mnt/map", O_CREAT|O_RDWR|O_TRUNC, 0600);
+
+    if (src < 0 || dst < 0 || mapfd < 0)
+        err(1, "open");
+
+    if (ftruncate(src, FILE_SIZE) || ftruncate(mapfd, FILE_SIZE))
+        err(1, "ftruncate");
+
+    char *srcp = mmap(NULL, FILE_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED, src, 0);
+    char *mapp = mmap(NULL, FILE_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED, mapfd, 0);
+
+    if (srcp == MAP_FAILED || mapp == MAP_FAILED)
+        err(1, "mmap");
+
+    srcp[0] = 0x5a;
+
+    atomic_store(&stop, 0);
+    pthread_t t;
+    if (pthread_create(&t, NULL, mmap_writer, mapp))
+        err(1, "pthread_create");
+
+    pthread_t snap;
+    if (pthread_create(&snap, NULL, snapshot_worker, "/mnt") != 0)
+        err(1, "pthread_create");
+
+    for (unsigned i = 0; i < 2048; i++) {
+        if (pwrite(dst, srcp, FILE_SIZE, 0) < 0)
+            err(1, "pwrite");
+        if ((i & 7) == 7)
+            usleep(5000);
+    }
+
+    atomic_store(&stop, 1);
+    if (pthread_join(snap, NULL))
+        err(1, "pthread_join");
+    pthread_join(t, NULL);
+    return 0;
+}
+EOF
+
+    gcc -O2 -Wall -pthread /tmp/repro.c -o /tmp/repro
+
+    awk '/debug_locks:/ { print "before " $0 }' /proc/lockdep_stats
+
+    /tmp/repro
+    sync
+
+    awk '/debug_locks:/ { print "after " $0; if ($2 != 1) exit 1 }' /proc/lockdep_stats
+
+    ! dmesg | grep -Ei 'possible circular locking dependency|WARNING:|BUG:|Oops:'
+
+    umount /mnt
+    bcachefs_test_end_checks "${ktest_scratch_dev[0]}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add a targeted bcachefs lockdep test for the buffered write/snapshot lock
ordering issue fixed in koverstreet/bcachefs-tools#865.

The test mounts a scratch bcachefs filesystem, runs a bounded workload that
combines:

- buffered `pwrite()` from a shared mmap source
- concurrent mmap writes to exercise `page_mkwrite`
- repeated `bcachefs subvolume snapshot` calls from a separate snapshot worker

It then checks that lockdep stayed enabled and that dmesg did not report a
circular locking dependency, warning, BUG, or oops.

## Validation

- `git diff --check origin/master...HEAD`
- PR scope gate:

```text
tests/fs/bcachefs/lockdep-buffered-write-snapshot.ktest
```

- parser checks:

```text
tests/fs/bcachefs/lockdep-buffered-write-snapshot.ktest list-tests
tests/fs/bcachefs/lockdep-buffered-write-snapshot.ktest deps buffered_write_snapshot_lockdep
```

I did not run the full VM ktest in this pass.

The original companion patch was closed as koverstreet/bcachefs-tools#863; the
current fixed companion is koverstreet/bcachefs-tools#865.
